### PR TITLE
Add tricycle kinematics

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,7 +8,8 @@ Checks: >
   cppcoreguidelines-pro-type-static-cast-downcast,
   cppcoreguidelines-pro-type-union-access,
   cppcoreguidelines-slicing,
-  cppcoreguidelines-special-member-functions
-WarningsAsErrors: ''
-HeaderFilterRegex: '.*'
+  cppcoreguidelines-special-member-functions,
+  -bugprone-easily-swappable-parameters,
+WarningsAsErrors: ""
+HeaderFilterRegex: ".*"
 FormatStyle: file

--- a/mola_georeferencing/CMakeLists.txt
+++ b/mola_georeferencing/CMakeLists.txt
@@ -2,7 +2,7 @@
 #        A Modular Optimization framework for Localization and mApping
 #                              (MOLA)
 #
-# Copyright (C) 2018-2025, Jose Luis Blanco-Claraco
+# Copyright (C) 2018-2026, Jose Luis Blanco-Claraco
 # All rights reserved.
 # Released under GNU GPL v3. See LICENSE file
 # ------------------------------------------------------------------------------

--- a/mola_georeferencing/README.md
+++ b/mola_georeferencing/README.md
@@ -13,7 +13,7 @@ mola-sm-georeferencing -i INPUT_WITH_GPS.simplemap --write-into MAP.mm
 ```
 
 # License
-Copyright (C) 2018-2025 Jose Luis Blanco <jlblanco@ual.es>, University of Almeria
+Copyright (C) 2018-2026 Jose Luis Blanco <jlblanco@ual.es>, University of Almeria
 
 This package is released under the GNU GPL v3 license as open source, with the main 
 intention of being useful for research and evaluation purposes.

--- a/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
+++ b/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_georeferencing/apps/mola-trajectory-georef-cli.cpp
+++ b/mola_georeferencing/apps/mola-trajectory-georef-cli.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_georeferencing/apps/mola-trajectory-georef-cli.cpp
+++ b/mola_georeferencing/apps/mola-trajectory-georef-cli.cpp
@@ -139,7 +139,10 @@ int main(int argc, char** argv)
         Cli cli;
 
         // Parse arguments:
-        if (!cli.cmd.parse(argc, argv)) return 1;  // should exit.
+        if (!cli.cmd.parse(argc, argv))
+        {
+            return 1;  // should exit.
+        }
 
         run_traj_georef(cli);
     }

--- a/mola_georeferencing/include/mola_georeferencing/simplemap_georeference.h
+++ b/mola_georeferencing/include/mola_georeferencing/simplemap_georeference.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_georeferencing/src/simplemap_georeference.cpp
+++ b/mola_georeferencing/src/simplemap_georeference.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/CMakeLists.txt
+++ b/mola_gtsam_factors/CMakeLists.txt
@@ -48,6 +48,7 @@ mola_add_library(
     include/mola_gtsam_factors/FactorGnssEnu.h
     include/mola_gtsam_factors/FactorGnssMapEnu.h
     include/mola_gtsam_factors/FactorTrapezoidalIntegrator.h
+    include/mola_gtsam_factors/FactorTricycleKinematic.h
     include/mola_gtsam_factors/gtsam_detect_version.h
     include/mola_gtsam_factors/id.h
     include/mola_gtsam_factors/MeasuredGravityFactor.h
@@ -57,6 +58,7 @@ mola_add_library(
     src/FactorGnssEnu.cpp
     src/FactorGnssMapEnu.cpp
     src/FactorTrapezoidalIntegrator.cpp
+    src/FactorTricycleKinematic.cpp
     src/MeasuredGravityFactor.cpp
     src/Pose3RotationFactor.cpp
     src/register.cpp

--- a/mola_gtsam_factors/CMakeLists.txt
+++ b/mola_gtsam_factors/CMakeLists.txt
@@ -2,7 +2,7 @@
 #        A Modular Optimization framework for Localization and mApping
 #                              (MOLA)
 #
-# Copyright (C) 2018-2025, Jose Luis Blanco-Claraco
+# Copyright (C) 2018-2026, Jose Luis Blanco-Claraco
 # All rights reserved.
 # Released under GNU GPL v3. See LICENSE file
 # ------------------------------------------------------------------------------

--- a/mola_gtsam_factors/README.md
+++ b/mola_gtsam_factors/README.md
@@ -3,7 +3,7 @@
 C++ library with reusable GTSAM factors for georeferencing and state estimation in other MOLA packages.
 
 # License
-Copyright (C) 2018-2025 Jose Luis Blanco <jlblanco@ual.es>, University of Almeria
+Copyright (C) 2018-2026 Jose Luis Blanco <jlblanco@ual.es>, University of Almeria
 
 This package is released under the GNU GPL v3 license as open source, with the main 
 intention of being useful for research and evaluation purposes.

--- a/mola_gtsam_factors/include/mola_gtsam_factors/FactorAngularVelocityIntegration.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/FactorAngularVelocityIntegration.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/include/mola_gtsam_factors/FactorConstLocalVelocity.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/FactorConstLocalVelocity.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/include/mola_gtsam_factors/FactorGnssEnu.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/FactorGnssEnu.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/include/mola_gtsam_factors/FactorGnssMapEnu.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/FactorGnssMapEnu.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/include/mola_gtsam_factors/FactorTrapezoidalIntegrator.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/FactorTrapezoidalIntegrator.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/include/mola_gtsam_factors/FactorTricycleKinematic.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/FactorTricycleKinematic.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/include/mola_gtsam_factors/FactorTricycleKinematic.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/FactorTricycleKinematic.h
@@ -147,8 +147,8 @@ class FactorTricycleKinematic : public gtsam::NoiseModelFactor4<
         boost::optional<gtsam::Matrix&> H1, boost::optional<gtsam::Matrix&> H2,
         boost::optional<gtsam::Matrix&> H3, boost::optional<gtsam::Matrix&> H4
 #else
-        boost::optional<gtsam::Matrix&> H1, boost::optional<gtsam::Matrix&> H2,
-        boost::optional<gtsam::Matrix&> H3, boost::optional<gtsam::Matrix&> H4
+        gtsam::Matrix* H1 = nullptr, gtsam::Matrix* H2 = nullptr, gtsam::Matrix* H3 = nullptr,
+        gtsam::Matrix* H4 = nullptr
 #endif
     ) const override;
 

--- a/mola_gtsam_factors/include/mola_gtsam_factors/FactorTricycleKinematic.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/FactorTricycleKinematic.h
@@ -1,0 +1,194 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   FactorTricycleKinematic.h
+ * @brief  GTSAM factor for tricycle kinematic model
+ * @author Jose Luis Blanco Claraco
+ * @date   Jan 12, 2026
+ */
+
+#pragma once
+
+#include <gtsam/geometry/Point3.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
+#include <mola_gtsam_factors/gtsam_detect_version.h>
+
+#include <cmath>
+
+namespace mola::factors
+{
+
+/**
+ * Factor for tricycle kinematic model using Euler integration.
+ *
+ * Models motion as a circular arc based on linear velocity v and angular velocity w
+ * at the initial timestep (Euler integration).
+ *
+ * The kinematic model:
+ * - For w ≈ 0: straight line motion
+ * - For w ≠ 0: circular arc with radius R = v/w
+ *
+ * State variables:
+ * - Ti: SE(3) pose at time i
+ * - bVi: linear velocity vector in body frame [vx, vy, vz]
+ * - bWi: angular velocity vector in body frame [wx, wy, wz]
+ * - Tj: SE(3) pose at time j
+ *
+ * The factor constrains Tj to be the predicted pose after following
+ * the tricycle kinematic model from Ti for duration dt using velocities at time i.
+ */
+class FactorTricycleKinematic : public gtsam::NoiseModelFactor4<
+                                    gtsam::Pose3, gtsam::Point3, gtsam::Point3,  // Ti, bVi, bWi
+                                    gtsam::Pose3>  // Tj
+{
+   private:
+    using This = FactorTricycleKinematic;
+    using Base = gtsam::NoiseModelFactor4<
+        gtsam::Pose3, gtsam::Point3, gtsam::Point3,  // Ti, bVi, bWi
+        gtsam::Pose3>;  // Tj
+
+    double dt_                     = 0.0;
+    double w_threshold_            = 1e-4;  // Threshold for considering w ≈ 0
+    bool   approximateDerivatives_ = true;
+
+   public:
+    /// default constructor for serialization
+    FactorTricycleKinematic();
+
+    /**
+     * Constructor
+     * @param kTi Key for initial pose
+     * @param kVi Key for initial linear velocity (body frame)
+     * @param kWi Key for initial angular velocity (body frame)
+     * @param kTj Key for final pose
+     * @param dt Time interval
+     * @param model Noise model (should be 6D for Pose3)
+     * @param w_threshold Threshold below which angular velocity is considered zero
+     * @param approximateDerivatives If true, skip numerical derivative computation
+     */
+    FactorTricycleKinematic(
+        gtsam::Key kTi, gtsam::Key kVi, gtsam::Key kWi, gtsam::Key kTj, const double dt,
+        const gtsam::SharedNoiseModel& model, const double w_threshold = 1e-4,
+        const bool approximateDerivatives = true);
+
+    /// @return a deep copy of this factor
+    gtsam::NonlinearFactor::shared_ptr clone() const override
+    {
+#if GTSAM_USES_BOOST
+        return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+            gtsam::NonlinearFactor::shared_ptr(new This(*this)));
+#else
+        return std::static_pointer_cast<gtsam::NonlinearFactor>(std::make_shared<This>(*this));
+#endif
+    }
+
+    /**
+     * Compute predicted pose using tricycle kinematic model with Euler integration
+     */
+    static gtsam::Pose3 tricycleKinematicModel(
+        const gtsam::Pose3& Ti, const gtsam::Point3& bVi, const gtsam::Point3& bWi, double dt,
+        double w_threshold)
+    {
+        // Extract scalar values (assuming planar motion for tricycle)
+        const double v = bVi.x();  // Forward velocity
+        const double w = bWi.z();  // Yaw rate (angular velocity around z-axis)
+
+        gtsam::Pose3 delta_pose;
+
+        if (std::abs(w) < w_threshold)
+        {
+            // Straight line motion
+            const gtsam::Point3 translation(v * dt, 0.0, 0.0);
+            delta_pose = gtsam::Pose3(gtsam::Rot3::Identity(), translation);
+        }
+        else
+        {
+            // Circular arc motion
+            const double R     = v / w;  // Radius of curvature
+            const double theta = w * dt;  // Total rotation angle
+
+            // Position change in body frame
+            const double        dx = R * std::sin(theta);
+            const double        dy = R * (1.0 - std::cos(theta));
+            const gtsam::Point3 translation(dx, dy, 0.0);
+
+            // Rotation around z-axis
+            const gtsam::Rot3 rotation = gtsam::Rot3::Rz(theta);
+
+            delta_pose = gtsam::Pose3(rotation, translation);
+        }
+
+        // Apply delta in body frame: T_j_pred = T_i * delta_T
+        return Ti.compose(delta_pose);
+    }
+
+    /**
+     * Error function
+     * Computes the error as the relative pose between predicted and actual Tj
+     * Returns a 6D vector: [rotation_error (3D), translation_error (3D)]
+     */
+    gtsam::Vector evaluateError(
+        const gtsam::Pose3& Ti, const gtsam::Point3& bVi, const gtsam::Point3& bWi,
+        const gtsam::Pose3& Tj,
+#if GTSAM_USES_BOOST
+        boost::optional<gtsam::Matrix&> H1, boost::optional<gtsam::Matrix&> H2,
+        boost::optional<gtsam::Matrix&> H3, boost::optional<gtsam::Matrix&> H4
+#else
+        boost::optional<gtsam::Matrix&> H1, boost::optional<gtsam::Matrix&> H2,
+        boost::optional<gtsam::Matrix&> H3, boost::optional<gtsam::Matrix&> H4
+#endif
+    ) const override;
+
+    /** print */
+    void print(
+        const std::string&         s,
+        const gtsam::KeyFormatter& keyFormatter = gtsam::DefaultKeyFormatter) const override
+    {
+        std::cout << s << "FactorTricycleKinematic(" << keyFormatter(this->keys_[0]) << ","
+                  << keyFormatter(this->keys_[1]) << "," << keyFormatter(this->keys_[2]) << ","
+                  << keyFormatter(this->keys_[3]) << ")\n";
+        gtsam::traits<double>::Print(dt_, "  dt: ");
+        gtsam::traits<double>::Print(w_threshold_, "  w_threshold: ");
+        this->noiseModel_->print("  noise model: ");
+    }
+
+    /** equals */
+    bool equals(const gtsam::NonlinearFactor& expected, double tol = 1e-9) const override
+    {
+        const This* e = dynamic_cast<const This*>(&expected);
+        return e != nullptr && Base::equals(*e, tol) &&
+               gtsam::traits<double>::Equals(e->dt_, dt_, tol) &&
+               gtsam::traits<double>::Equals(e->w_threshold_, w_threshold_, tol) &&
+               e->approximateDerivatives_ == approximateDerivatives_;
+    }
+
+   private:
+#if GTSAM_USES_BOOST
+    /** Serialization function */
+    friend class boost::serialization::access;
+    template <class ARCHIVE>
+    void serialize(ARCHIVE& ar, const unsigned int /*version*/)
+    {
+        ar& boost::serialization::make_nvp(
+            "FactorTricycleKinematic", boost::serialization::base_object<Base>(*this));
+        ar& BOOST_SERIALIZATION_NVP(dt_);
+        ar& BOOST_SERIALIZATION_NVP(w_threshold_);
+        ar& BOOST_SERIALIZATION_NVP(approximateDerivatives_);
+    }
+#endif
+};
+
+}  // namespace mola::factors

--- a/mola_gtsam_factors/include/mola_gtsam_factors/FactorTricycleKinematic.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/FactorTricycleKinematic.h
@@ -60,9 +60,8 @@ class FactorTricycleKinematic : public gtsam::NoiseModelFactor4<
         gtsam::Pose3, gtsam::Point3, gtsam::Point3,  // Ti, bVi, bWi
         gtsam::Pose3>;  // Tj
 
-    double dt_                     = 0.0;
-    double w_threshold_            = 1e-4;  // Threshold for considering w ≈ 0
-    bool   approximateDerivatives_ = true;
+    double dt_          = 0.0;
+    double w_threshold_ = 1e-4;  // Threshold for considering w ≈ 0
 
    public:
     /// default constructor for serialization
@@ -77,12 +76,10 @@ class FactorTricycleKinematic : public gtsam::NoiseModelFactor4<
      * @param dt Time interval
      * @param model Noise model (should be 6D for Pose3)
      * @param w_threshold Threshold below which angular velocity is considered zero
-     * @param approximateDerivatives If true, skip numerical derivative computation
      */
     FactorTricycleKinematic(
         gtsam::Key kTi, gtsam::Key kVi, gtsam::Key kWi, gtsam::Key kTj, const double dt,
-        const gtsam::SharedNoiseModel& model, const double w_threshold = 1e-4,
-        const bool approximateDerivatives = true);
+        const gtsam::SharedNoiseModel& model, const double w_threshold = 1e-4);
 
     /// @return a deep copy of this factor
     gtsam::NonlinearFactor::shared_ptr clone() const override
@@ -171,8 +168,7 @@ class FactorTricycleKinematic : public gtsam::NoiseModelFactor4<
         const This* e = dynamic_cast<const This*>(&expected);
         return e != nullptr && Base::equals(*e, tol) &&
                gtsam::traits<double>::Equals(e->dt_, dt_, tol) &&
-               gtsam::traits<double>::Equals(e->w_threshold_, w_threshold_, tol) &&
-               e->approximateDerivatives_ == approximateDerivatives_;
+               gtsam::traits<double>::Equals(e->w_threshold_, w_threshold_, tol);
     }
 
    private:
@@ -186,7 +182,6 @@ class FactorTricycleKinematic : public gtsam::NoiseModelFactor4<
             "FactorTricycleKinematic", boost::serialization::base_object<Base>(*this));
         ar& BOOST_SERIALIZATION_NVP(dt_);
         ar& BOOST_SERIALIZATION_NVP(w_threshold_);
-        ar& BOOST_SERIALIZATION_NVP(approximateDerivatives_);
     }
 #endif
 };

--- a/mola_gtsam_factors/include/mola_gtsam_factors/FactorTricycleKinematic.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/FactorTricycleKinematic.h
@@ -97,40 +97,7 @@ class FactorTricycleKinematic : public gtsam::NoiseModelFactor4<
      */
     static gtsam::Pose3 tricycleKinematicModel(
         const gtsam::Pose3& Ti, const gtsam::Point3& bVi, const gtsam::Point3& bWi, double dt,
-        double w_threshold)
-    {
-        // Extract scalar values (assuming planar motion for tricycle)
-        const double v = bVi.x();  // Forward velocity
-        const double w = bWi.z();  // Yaw rate (angular velocity around z-axis)
-
-        gtsam::Pose3 delta_pose;
-
-        if (std::abs(w) < w_threshold)
-        {
-            // Straight line motion
-            const gtsam::Point3 translation(v * dt, 0.0, 0.0);
-            delta_pose = gtsam::Pose3(gtsam::Rot3::Identity(), translation);
-        }
-        else
-        {
-            // Circular arc motion
-            const double R     = v / w;  // Radius of curvature
-            const double theta = w * dt;  // Total rotation angle
-
-            // Position change in body frame
-            const double        dx = R * std::sin(theta);
-            const double        dy = R * (1.0 - std::cos(theta));
-            const gtsam::Point3 translation(dx, dy, 0.0);
-
-            // Rotation around z-axis
-            const gtsam::Rot3 rotation = gtsam::Rot3::Rz(theta);
-
-            delta_pose = gtsam::Pose3(rotation, translation);
-        }
-
-        // Apply delta in body frame: T_j_pred = T_i * delta_T
-        return Ti.compose(delta_pose);
-    }
+        double w_threshold);
 
     /**
      * Error function

--- a/mola_gtsam_factors/include/mola_gtsam_factors/MeasuredGravityFactor.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/MeasuredGravityFactor.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/include/mola_gtsam_factors/Pose3RotationFactor.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/Pose3RotationFactor.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/include/mola_gtsam_factors/gtsam_detect_version.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/gtsam_detect_version.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/include/mola_gtsam_factors/id.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/id.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/src/FactorAngularVelocityIntegration.cpp
+++ b/mola_gtsam_factors/src/FactorAngularVelocityIntegration.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/src/FactorConstLocalVelocity.cpp
+++ b/mola_gtsam_factors/src/FactorConstLocalVelocity.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/src/FactorGnssEnu.cpp
+++ b/mola_gtsam_factors/src/FactorGnssEnu.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/src/FactorGnssMapEnu.cpp
+++ b/mola_gtsam_factors/src/FactorGnssMapEnu.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/src/FactorTrapezoidalIntegrator.cpp
+++ b/mola_gtsam_factors/src/FactorTrapezoidalIntegrator.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/src/FactorTricycleKinematic.cpp
+++ b/mola_gtsam_factors/src/FactorTricycleKinematic.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/src/FactorTricycleKinematic.cpp
+++ b/mola_gtsam_factors/src/FactorTricycleKinematic.cpp
@@ -36,6 +36,43 @@ FactorTricycleKinematic::FactorTricycleKinematic(
 {
 }
 
+gtsam::Pose3 FactorTricycleKinematic::tricycleKinematicModel(
+    const gtsam::Pose3& Ti, const gtsam::Point3& bVi, const gtsam::Point3& bWi, double dt,
+    double w_threshold)
+{
+    // Extract scalar values (assuming planar motion for tricycle)
+    const double v = bVi.x();  // Forward velocity
+    const double w = bWi.z();  // Yaw rate (angular velocity around z-axis)
+
+    gtsam::Pose3 delta_pose;
+
+    if (std::abs(w) < w_threshold)
+    {
+        // Straight line motion
+        const gtsam::Point3 translation(v * dt, 0.0, 0.0);
+        delta_pose = gtsam::Pose3(gtsam::Rot3::Identity(), translation);
+    }
+    else
+    {
+        // Circular arc motion
+        const double R     = v / w;  // Radius of curvature
+        const double theta = w * dt;  // Total rotation angle
+
+        // Position change in body frame
+        const double        dx = R * std::sin(theta);
+        const double        dy = R * (1.0 - std::cos(theta));
+        const gtsam::Point3 translation(dx, dy, 0.0);
+
+        // Rotation around z-axis
+        const gtsam::Rot3 rotation = gtsam::Rot3::Rz(theta);
+
+        delta_pose = gtsam::Pose3(rotation, translation);
+    }
+
+    // Apply delta in body frame: T_j_pred = T_i * delta_T
+    return Ti.compose(delta_pose);
+}
+
 gtsam::Vector FactorTricycleKinematic::evaluateError(
     const gtsam::Pose3& Ti, const gtsam::Point3& bVi, const gtsam::Point3& bWi,
     const gtsam::Pose3& Tj,
@@ -76,11 +113,9 @@ gtsam::Vector FactorTricycleKinematic::evaluateError(
         delta_pose      = gtsam::Pose3(gtsam::Rot3::Rz(theta), gtsam::Point3(dx, dy, 0.0));
 
         // Analytical derivatives in delta_pose's local tangent space
-        // J_v = [0, 0, 0, sin(theta)/w, (cos(theta)-1)/w, 0]^T
-        J_v << 0, 0, 0, s / w, (c - 1.0) / w, 0;
+        J_v << 0, 0, 0, s / w, (1.0 - c) / w, 0;
 
-        // J_w = [0, 0, dt, v*(theta - sin(theta))/w^2, 0, 0]^T
-        J_w << 0, 0, dt_, v * (theta - s) / (w * w), 0, 0;
+        J_w << 0, 0, dt_, v * (theta * c - s) / (w * w), v * (theta * s + c - 1) / (w * w), 0;
     }
 
     // 1. Prediction: T_pred = Ti * delta_pose

--- a/mola_gtsam_factors/src/FactorTricycleKinematic.cpp
+++ b/mola_gtsam_factors/src/FactorTricycleKinematic.cpp
@@ -1,0 +1,132 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   FactorTricycleKinematic.cpp
+ * @brief  GTSAM factor for tricycle kinematic model
+ * @author Jose Luis Blanco Claraco
+ * @date   Jan 12, 2026
+ */
+
+#include <mola_gtsam_factors/FactorTricycleKinematic.h>
+
+namespace mola::factors
+{
+
+FactorTricycleKinematic::FactorTricycleKinematic()
+    : Base(gtsam::noiseModel::Isotropic::Sigma(6, 1.0), 0, 0, 0, 0)
+{
+}
+
+FactorTricycleKinematic::FactorTricycleKinematic(
+    gtsam::Key kTi, gtsam::Key kVi, gtsam::Key kWi, gtsam::Key kTj, const double dt,
+    const gtsam::SharedNoiseModel& model, const double w_threshold,
+    const bool approximateDerivatives)
+    : Base(model, kTi, kVi, kWi, kTj),
+      dt_(dt),
+      w_threshold_(w_threshold),
+      approximateDerivatives_(approximateDerivatives)
+{
+}
+
+gtsam::Vector FactorTricycleKinematic::evaluateError(
+    const gtsam::Pose3& Ti, const gtsam::Point3& bVi, const gtsam::Point3& bWi,
+    const gtsam::Pose3& Tj,
+#if GTSAM_USES_BOOST
+    boost::optional<gtsam::Matrix&> H1, boost::optional<gtsam::Matrix&> H2,
+    boost::optional<gtsam::Matrix&> H3, boost::optional<gtsam::Matrix&> H4
+#else
+    boost::optional<gtsam::Matrix&> H1, boost::optional<gtsam::Matrix&> H2,
+    boost::optional<gtsam::Matrix&> H3, boost::optional<gtsam::Matrix&> H4
+#endif
+) const
+{
+    const double v     = bVi.x();  // linear velocity
+    const double w     = bWi.z();  // angular velocity
+    const double theta = w * dt_;
+
+    gtsam::Pose3 delta_pose;
+    // Local Jacobians for delta_pose w.r.t v and w
+    gtsam::Vector6 J_v = gtsam::Vector6::Zero();
+    gtsam::Vector6 J_w = gtsam::Vector6::Zero();
+
+    if (std::abs(w) < w_threshold_)
+    {
+        // Straight line motion
+        delta_pose = gtsam::Pose3(gtsam::Rot3::Identity(), gtsam::Point3(v * dt_, 0, 0));
+
+        // Derivatives for small w (Taylor expansions)
+        J_v << 0, 0, 0, dt_, 0, 0;
+        J_w << 0, 0, dt_, 0, 0.5 * v * dt_ * dt_, 0;
+    }
+    else
+    {
+        // Circular arc motion
+        const double R  = v / w;
+        const double s  = std::sin(theta);
+        const double c  = std::cos(theta);
+        const double dx = R * s;
+        const double dy = R * (1.0 - c);
+        delta_pose      = gtsam::Pose3(gtsam::Rot3::Rz(theta), gtsam::Point3(dx, dy, 0.0));
+
+        // Analytical derivatives in delta_pose's local tangent space
+        // J_v = [0, 0, 0, sin(theta)/w, (cos(theta)-1)/w, 0]^T
+        J_v << 0, 0, 0, s / w, (c - 1.0) / w, 0;
+
+        // J_w = [0, 0, dt, v*(theta - sin(theta))/w^2, 0, 0]^T
+        J_w << 0, 0, dt_, v * (theta - s) / (w * w), 0, 0;
+    }
+
+    // 1. Prediction: T_pred = Ti * delta_pose
+    gtsam::Matrix66    H_comp_Ti, H_comp_delta;
+    const gtsam::Pose3 Tj_pred = Ti.compose(delta_pose, H_comp_Ti, H_comp_delta);
+
+    // 2. Error: Tj_pred.between(Tj)
+    gtsam::Matrix66      H_btw_pred, H_btw_actual;
+    const gtsam::Pose3   error_pose = Tj_pred.between(Tj, H_btw_pred, H_btw_actual);
+    const gtsam::Vector6 error      = gtsam::Pose3::Logmap(error_pose);
+
+    // 3. Chain Rule for Jacobians
+    if (H1 || H2 || H3 || H4)
+    {
+        // Logmap Jacobian (De_Log)
+        gtsam::Matrix66 De_Log = gtsam::Pose3::LogmapDerivative(error_pose);
+
+        if (H1)
+        {  // Jacobian w.r.t Ti
+            *H1 = De_Log * H_btw_pred * H_comp_Ti;
+        }
+
+        if (H2)  // Jacobian w.r.t bVi (Point3)
+        {
+            *H2        = gtsam::Matrix::Zero(6, 3);
+            H2->col(0) = De_Log * H_btw_pred * H_comp_delta * J_v;
+        }
+
+        if (H3)  // Jacobian w.r.t bWi (Point3)
+        {
+            *H3        = gtsam::Matrix::Zero(6, 3);
+            H3->col(2) = De_Log * H_btw_pred * H_comp_delta * J_w;
+        }
+
+        if (H4)
+        {  // Jacobian w.r.t Tj
+            *H4 = De_Log * H_btw_actual;
+        }
+    }
+
+    return error;
+}
+
+}  // namespace mola::factors

--- a/mola_gtsam_factors/src/FactorTricycleKinematic.cpp
+++ b/mola_gtsam_factors/src/FactorTricycleKinematic.cpp
@@ -47,8 +47,7 @@ gtsam::Vector FactorTricycleKinematic::evaluateError(
     boost::optional<gtsam::Matrix&> H1, boost::optional<gtsam::Matrix&> H2,
     boost::optional<gtsam::Matrix&> H3, boost::optional<gtsam::Matrix&> H4
 #else
-    boost::optional<gtsam::Matrix&> H1, boost::optional<gtsam::Matrix&> H2,
-    boost::optional<gtsam::Matrix&> H3, boost::optional<gtsam::Matrix&> H4
+    gtsam::Matrix* H1, gtsam::Matrix* H2, gtsam::Matrix* H3, gtsam::Matrix* H4
 #endif
 ) const
 {

--- a/mola_gtsam_factors/src/FactorTricycleKinematic.cpp
+++ b/mola_gtsam_factors/src/FactorTricycleKinematic.cpp
@@ -31,12 +31,8 @@ FactorTricycleKinematic::FactorTricycleKinematic()
 
 FactorTricycleKinematic::FactorTricycleKinematic(
     gtsam::Key kTi, gtsam::Key kVi, gtsam::Key kWi, gtsam::Key kTj, const double dt,
-    const gtsam::SharedNoiseModel& model, const double w_threshold,
-    const bool approximateDerivatives)
-    : Base(model, kTi, kVi, kWi, kTj),
-      dt_(dt),
-      w_threshold_(w_threshold),
-      approximateDerivatives_(approximateDerivatives)
+    const gtsam::SharedNoiseModel& model, const double w_threshold)
+    : Base(model, kTi, kVi, kWi, kTj), dt_(dt), w_threshold_(w_threshold)
 {
 }
 

--- a/mola_gtsam_factors/src/MeasuredGravityFactor.cpp
+++ b/mola_gtsam_factors/src/MeasuredGravityFactor.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/src/Pose3RotationFactor.cpp
+++ b/mola_gtsam_factors/src/Pose3RotationFactor.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_gtsam_factors/src/register.cpp
+++ b/mola_gtsam_factors/src/register.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_simple/CMakeLists.txt
+++ b/mola_state_estimation_simple/CMakeLists.txt
@@ -2,7 +2,7 @@
 #        A Modular Optimization framework for Localization and mApping
 #                               (MOLA)
 #
-# Copyright (C) 2018-2025, Jose Luis Blanco-Claraco, contributors (AUTHORS.md)
+# Copyright (C) 2018-2026, Jose Luis Blanco-Claraco, contributors (AUTHORS.md)
 # All rights reserved.
 # Released under GNU GPL v3. See LICENSE file
 # ------------------------------------------------------------------------------

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/Parameters.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/Parameters.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_simple/src/Parameters.cpp
+++ b/mola_state_estimation_simple/src/Parameters.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_simple/src/Parameters.cpp
+++ b/mola_state_estimation_simple/src/Parameters.cpp
@@ -61,7 +61,10 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
 
         auto&      tw  = initial_twist;
         const auto seq = cfg["initial_twist"].asSequenceRange();
-        for (size_t i = 0; i < 6; i++) tw[i] = seq.at(i).as<double>();
+        for (size_t i = 0; i < 6; i++)
+        {
+            tw[i] = seq.at(i).as<double>();
+        }
     }
 }
 

--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_simple/src/register.cpp
+++ b/mola_state_estimation_simple/src/register.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
+++ b/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_smoother/CMakeLists.txt
+++ b/mola_state_estimation_smoother/CMakeLists.txt
@@ -2,7 +2,7 @@
 #        A Modular Optimization framework for Localization and mApping
 #                               (MOLA)
 #
-# Copyright (C) 2018-2025, Jose Luis Blanco-Claraco, contributors (AUTHORS.md)
+# Copyright (C) 2018-2026, Jose Luis Blanco-Claraco, contributors (AUTHORS.md)
 # All rights reserved.
 # Released under GNU GPL v3. See LICENSE file
 # ------------------------------------------------------------------------------

--- a/mola_state_estimation_smoother/CMakeLists.txt
+++ b/mola_state_estimation_smoother/CMakeLists.txt
@@ -10,6 +10,10 @@
 # Minimum CMake vesion: limited by CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
 cmake_minimum_required(VERSION 3.5)
 
+if("$ENV{ROS_VERSION}" STREQUAL "2")
+    set(DETECTED_ROS2 TRUE)
+endif()
+
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(default_build_type "Release")
   message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
@@ -87,7 +91,25 @@ mola_add_executable(
     ${PROJECT_NAME}
 )
 
-# -----------------------
-# define tests:
-enable_testing()
-add_subdirectory(tests)
+if(DETECTED_ROS2)
+  # -----------------------------------------------------------------------------
+  #  ROS2
+  # -----------------------------------------------------------------------------
+  # find dependencies
+  find_package(ament_cmake REQUIRED)
+
+  if(BUILD_TESTING)
+    find_package(ament_lint_auto REQUIRED)
+    find_package(ament_cmake_gtest REQUIRED)
+    ament_lint_auto_find_test_dependencies()
+
+    add_subdirectory(tests)
+  endif()
+
+  ament_package()
+else()
+  # define tests (w/o ROS)
+  enable_testing()
+  add_subdirectory(tests)
+endif()
+

--- a/mola_state_estimation_smoother/CMakeLists.txt
+++ b/mola_state_estimation_smoother/CMakeLists.txt
@@ -68,6 +68,16 @@ mola_add_library(
 )
 target_include_directories(${PROJECT_NAME} PRIVATE ".")
 
+# Install files:
+install(
+  DIRECTORY
+    mola-cli-launchs
+    ros2-launchs
+    params
+  DESTINATION
+    share/${PROJECT_NAME}
+)
+
 # -----------------------
 # define cli apps:
 mola_add_executable(

--- a/mola_state_estimation_smoother/apps/mola-navstate-cli.cpp
+++ b/mola_state_estimation_smoother/apps/mola-navstate-cli.cpp
@@ -1,6 +1,6 @@
 /* -------------------------------------------------------------------------
  *   A Modular Optimization framework for Localization and mApping  (MOLA)
- * Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria
+ * Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria
  * See LICENSE for license information.
  * ------------------------------------------------------------------------- */
 

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
@@ -195,6 +195,15 @@ class Parameters
     std::regex do_process_gnss_labels_re{".*"};
 
     /** @} */
+
+    struct Visualization
+    {
+        bool show_console_messages = true;
+
+        // this is automatically called by parent's loadFrom()
+        void loadFrom(const mrpt::containers::yaml& cfg);
+    };
+    Visualization visualization;
 };
 
 }  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -25,6 +25,7 @@
 #include <mola_kernel/interfaces/LocalizationSourceBase.h>
 #include <mola_kernel/interfaces/NavStateFilter.h>
 #include <mola_kernel/interfaces/RawDataSourceBase.h>
+#include <mola_kernel/interfaces/VizInterface.h>
 #include <mola_kernel/version.h>
 #include <mola_state_estimation_smoother/Parameters.h>
 
@@ -353,6 +354,8 @@ class StateEstimationSmoother : public mola::NavStateFilter, public mola::Locali
         /** Elapsed time between "from_kf" and "to_kf" [seconds] */
         double deltaTime = .0;
     };
+
+    VizInterface::Ptr visualizer_;
 };
 
 }  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -108,8 +108,8 @@ class StateEstimationSmoother : public mola::NavStateFilter, public mola::Locali
 {
     DEFINE_MRPT_OBJECT(StateEstimationSmoother, mola::state_estimation_smoother)
    private:
-    class FactorConstVelKinematics;  // Forward decls.
-    class FactorTricycleKinematics;
+    class AbsFactorConstVelKinematics;  // Forward decls.
+    class AbsFactorTricycleKinematics;
 
    public:
     StateEstimationSmoother();
@@ -284,8 +284,8 @@ class StateEstimationSmoother : public mola::NavStateFilter, public mola::Locali
     void process_pending_gtsam_updates();
 
     /// Implementation of Eqs (1),(4) in the MOLA RSS2019 paper.
-    void addFactor(const FactorConstVelKinematics& f);
-    void addFactor(const FactorTricycleKinematics& f);
+    void addFactor(const AbsFactorConstVelKinematics& f);
+    void addFactor(const AbsFactorTricycleKinematics& f);
 
     /// Delete out-of-window entries in stamp2frame_index and last_estimated_state
     void delete_too_old_entries();
@@ -318,13 +318,13 @@ class StateEstimationSmoother : public mola::NavStateFilter, public mola::Locali
     /** Abstract representation of a constant-velocity kinematic motion model factor
      * between two key frames.
      */
-    class FactorConstVelKinematics
+    class AbsFactorConstVelKinematics
     {
        public:
-        FactorConstVelKinematics() = default;
+        AbsFactorConstVelKinematics() = default;
 
         /** Creates relative pose constraint of KF `to` as seem from `from`. */
-        FactorConstVelKinematics(id_t kf_from, id_t kf_to, double delta_time)  // NOLINT
+        AbsFactorConstVelKinematics(id_t kf_from, id_t kf_to, double delta_time)  // NOLINT
             : from_kf(kf_from), to_kf(kf_to), deltaTime(delta_time)
         {
         }
@@ -338,13 +338,13 @@ class StateEstimationSmoother : public mola::NavStateFilter, public mola::Locali
     /** Abstract representation of a constant-velocity tricycle kinematic motion
      * model factor between two key frames.
      */
-    class FactorTricycleKinematics
+    class AbsFactorTricycleKinematics
     {
        public:
-        FactorTricycleKinematics() = default;
+        AbsFactorTricycleKinematics() = default;
 
         /** Creates relative pose constraint of KF `to` as seem from `from`. */
-        FactorTricycleKinematics(id_t kf_from, id_t kf_to, double delta_time)  // NOLINT
+        AbsFactorTricycleKinematics(id_t kf_from, id_t kf_to, double delta_time)  // NOLINT
             : from_kf(kf_from), to_kf(kf_to), deltaTime(delta_time)
         {
         }

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/pose_pdf_to_string_with_sigmas.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/pose_pdf_to_string_with_sigmas.h
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_smoother/mola-cli-launchs/state_estimator_ros2.yaml
+++ b/mola_state_estimation_smoother/mola-cli-launchs/state_estimator_ros2.yaml
@@ -1,0 +1,147 @@
+# -----------------------------------------------------------------------------
+#                        SLAM system definition for MOLA
+#
+# This file defines: Input and output with ROS 2, the MOLA Visualizer.
+# This can be launched with the ROS2 launch file "ros2-state-estimator.launch.py"
+# -----------------------------------------------------------------------------
+
+modules:
+  # =====================
+  # MolaViz
+  # =====================
+  - name: viz
+    type: mola::MolaViz
+    enabled: ${MOLA_WITH_GUI|true}
+    verbosity_level: "${MOLA_VERBOSITY_MOLA_VIZ|INFO}"
+    params: ~ # none
+
+  # =====================
+  # State Estimation
+  # =====================
+  - name: state_estimation
+    type: mola::mola_state_estimation_smoother::StateEstimationSmoother
+    verbosity_level: "${MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR|INFO}"
+    raw_data_source: "ros2_bridge"
+
+    # When using StateEstimationSmoother, this execution rate (Hz) determines the
+    # rate of publishing filtered pose estimations.
+    execution_rate: ${MOLA_STATE_ESTIMATOR_PUBLISH_RATE|10} # Hz
+
+    # This includes here a whole block "params: (...)":
+    params: "${MOLA_STATE_ESTIMATOR_YAML|../params/state-estimation-smoother.yaml}"
+
+  # =====================
+  # ROS2 <-> MOLA
+  # =====================
+  - type: mola::BridgeROS2
+    name: ros2_bridge
+    verbosity_level: "${MOLA_VERBOSITY_BRIDGE_ROS2|INFO}"
+    export_to_rawlog: ${MOLA_BRIDGE_ROS2_EXPORT_TO_RAWLOG_FILE|''}
+
+    # In BridgeROS2, this execution rate (Hz) determines the
+    # rate of publishing odometry observations, if enabled.
+    # All other subscribed sensors are forwarded to the MOLA
+    # system without delay as they are received from ROS.
+    execution_rate: 20 # Hz
+
+    gui_preview_sensors:
+      - raw_sensor_label: ${MOLA_LIDAR_NAME|lidar}
+        decimation: 1
+        enabled: ${MOLA_WITH_GUI|true}
+        win_pos: 5 5 400 400
+
+    params:
+      # tf frame name with respect to sensor poses are measured, and also used for publishing
+      # SLAM/localization results (read below).
+      base_link_frame: "${MOLA_TF_BASE_LINK|base_link}"
+
+      # If not empty, the node will broadcast a static /tf from base_footprint to
+      # base_link with the TF base_footprint_to_base_link_tf at start up.
+      base_footprint_frame: "${MOLA_TF_FOOTPRINT_LINK|base_footprint}"
+      base_footprint_to_base_link_tf: "${MOLA_TF_FOOTPRINT_TO_BASE_LINK|[0, 0, 0, 0, 0, 0]}" # [x, y, z, yaw_deg, pitch_deg, roll_deg]
+
+      # Used for:
+      # (a) importing odometry to MOLA if ``forward_ros_tf_as_mola_odometry_observations=true``
+      # (b) querying ``${odom_frame} => ${base_link_frame}`` when
+      #     ``publish_localization_following_rep105=true``.
+      odom_frame: "${MOLA_TF_ESTIMATED_ODOMETRY|odom}"
+
+      # tf frame used for:
+      # (a) See ``publish_tf_from_robot_pose_observations``
+      # (b) To follow REP105 (``publish_localization_following_rep105``), this must match
+      #     the frame used as reference in the LocalizationSource (e.g. mola_lidar_odometry)
+      reference_frame: "${MOLA_TF_MAP|map}"
+
+      # How to publish localization to /tf:
+      # - ``false``(direct mode): reference_frame ("map") -> base_link ("base_link")
+      #   Note that reference_frame in this case comes from the localization source module
+      #   (e.g. mola_lidar_odometry), it is not configured here.
+      #
+      #  - ``true`` (indirect mode), following ROS [REP
+      #  105](https://ros.org/reps/rep-0105.html):
+      #   ``map -> odom``  (such as "map -> odom -> base_link" = "map -> base_link")
+      publish_localization_following_rep105: false # For state estimation smoother, this is better false. See online docs.
+
+      # If enabled, during spinOnce(), the tf ``${odom_frame} => ${base_link_frame}`` will
+      # be queried and forwarded as an `CObservationOdometry` reading to the MOLA subsystem:
+      forward_ros_tf_as_mola_odometry_observations: ${MOLA_FORWARD_ROS_TF_ODOM_TO_MOLA|false}
+
+      # If enabled, SLAM/Localization results will be published as nav_msgs/Odometry messages.
+      publish_odometry_msgs_from_slam: ${MOLA_LOCALIZATION_PUBLISH_ODOM_MSGS|true}
+
+      # If the flag above is true, this allows fine tuning which localization source will be actually forwarded (MOLA module name). Empty=any.
+      publish_odometry_msgs_from_slam_source: ${MOLA_LOCALIZATION_PUBLISH_ODOM_MSGS_SOURCE|""} # alternative: 'state_estimation_smoother'
+
+      # If enabled, SLAM/Localization results will be published as tf messages, for frames
+      # according to explained above for `publish_localization_following_rep105`.
+      publish_tf_from_slam: ${MOLA_LOCALIZATION_PUBLISH_TF|true}
+
+      # If the flag above is true, this allows fine tuning which localization source will be actually forwarded (MOLA module name). Empty=any.
+      publish_tf_from_slam_source: ${MOLA_LOCALIZATION_PUBLISH_TF_SOURCE|""} # alternative: 'state_estimation_smoother'
+
+      # If enabled, robot pose observations (typically, ground truth from datasets), will be
+      # forwarded to ROS as /tf messages: ``${reference_frame} => ${base_link}``
+      publish_tf_from_robot_pose_observations: false
+
+      # If not empty, this defines a topic name (type: geometry_msgs/PoseWithCovarianceStamped)
+      # to subscribe to. Each received message will map to requests to re-localize to MOLA modules
+      # in the system implementing `mola::Relocalization`:
+      relocalize_from_topic: "/initialpose"
+
+      # Everything published to ROS2 will have timestamps from:
+      #  - true: the original dataset timestamps.
+      #  - false: the wall-clock time.
+      publish_in_sim_time: ${MOLA_ROS2_PUBLISH_IN_SIM_TIME|true}
+
+      # Period [s] to publish new localization estimates to ROS2 from the MOLA SLAM solution:
+      # Note that no repeated localization are published. This is just the period for checking if new
+      # estimates are available and waiting to be published.
+      period_publish_new_localization: ${MOLA_ROS2_PUBLISH_LOCALIZATION_PERIOD|0.050} # [s]
+
+      # Period [s] to publish the updated map to ROS2 from the MOLA SLAM solution:
+      # Note that no repeated maps are published. This is just the period for checking the need to republish.
+      period_publish_new_map: ${MOLA_ROS2_PUBLISH_MAPS_PERIOD|1.0} # [s]
+
+      # A placeholder for optional flags from "ros2 launch", captured
+      # as all cli arguments after "--ros-args":
+      ros_args: '${ROS_ARGS|"[]"}'
+
+      # ROS2 topics to be forwarded to the MOLA system:
+      subscribe:
+        - topic: ${MOLA_GNSS_TOPIC|/gps}
+          msg_type: NavSatFix
+          output_sensor_label: "gps"
+          # If present, this will override whatever /tf tells about the sensor pose:
+          fixed_sensor_pose: "${GNSS_POSE_X|0} ${GNSS_POSE_Y|0} ${GNSS_POSE_Z|0} ${GNSS_POSE_YAW|0} ${GNSS_POSE_PITCH|0} ${GNSS_POSE_ROLL|0}" # 'x y z yaw_deg pitch_deg roll_deg''
+          use_fixed_sensor_pose: ${MOLA_USE_FIXED_GNSS_POSE|false}
+
+        - topic: ${MOLA_IMU_TOPIC|/imu}
+          msg_type: Imu
+          output_sensor_label: "imu"
+          # If present, this will override whatever /tf tells about the sensor pose:
+          fixed_sensor_pose: "${IMU_POSE_X|0} ${IMU_POSE_Y|0} ${IMU_POSE_Z|0} ${IMU_POSE_YAW|0} ${IMU_POSE_PITCH|0} ${IMU_POSE_ROLL|0}" # 'x y z yaw_deg pitch_deg roll_deg''
+          use_fixed_sensor_pose: ${MOLA_USE_FIXED_IMU_POSE|false}
+
+        #- topic: /odom
+        #  msg_type: Odometry
+        #  output_sensor_label: odom

--- a/mola_state_estimation_smoother/package.xml
+++ b/mola_state_estimation_smoother/package.xml
@@ -13,6 +13,15 @@
 
   <url type="website">https://github.com/MOLAorg/mola_state_estimation</url>
 
+  <!-- Entries to make ROS 2 to discover this as a proper package -->
+  <build_depend>ros_environment</build_depend>
+
+  <build_depend>ament_cmake_xmllint</build_depend>
+
+  <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_gtest</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
   <depend>mola_common</depend>
   <depend>mola_kernel</depend>
   <depend>mola_imu_preintegration</depend>
@@ -34,13 +43,13 @@
   <build_depend>libboost-chrono-dev</build_depend>
   <build_depend>libboost-regex-dev</build_depend>
 
+  <!-- Needed by the mola-cli launch files -->
+  <exec_depend>mola_launcher</exec_depend>
+
   <doc_depend>doxygen</doc_depend>
 
-  <!-- Minimum entries to release non-catkin pkgs: -->
-  <buildtool_depend>cmake</buildtool_depend>
   <export>
-    <build_type>cmake</build_type>
-  </export>
-  <!-- End -->
+    <build_type>ament_cmake</build_type>
+  </export>  
 
 </package>

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -1,0 +1,44 @@
+# This file holds parameters for mola::state_estimation_smoother::StateEstimationSmoother
+#
+# Refer to:
+# https://docs.mola-slam.org/latest/mola_state_estimators.html
+
+params:
+  # Maximum time since last observation to consider the validity of the velocity model:
+  # (KITTI360 test_3 has some blackouts >=1.0 seconds while angular acceleration is high, so
+  #  this threshold must be < 1.0 s for that dataset)
+  max_time_to_use_velocity_model: ${MOLA_MAX_TIME_TO_USE_VELOCITY_MODEL|0.75} # [s]
+
+  # Time to keep past observations in the filter
+  sliding_window_length: 2.5 # [s]
+
+  # Used to publish timely pose updates:
+  vehicle_frame_name: "${MOLA_TF_BASE_LINK|base_link}"
+
+  # Used to publish timely pose updates. Typically, 'map' or 'odom', etc.
+  # See docs: https://docs.mola-slam.org/latest/mola_state_estimators.html
+  reference_frame_name: "${MOLA_TF_MAP|map}"
+
+  # If the time between two keyframes is larger than this, a warning will be
+  # emitted; but the algorithm will keep trying its best.
+  time_between_frames_to_warning: 3.0 # [s]
+
+  sigma_random_walk_acceleration_linear: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC|1.0} # [m/s²]
+  sigma_random_walk_acceleration_angular: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_ANGACC|10.0} # [rad/s²]
+
+  sigma_integrator_position: 0.1 # [m]
+  sigma_integrator_orientation: 1.0 # [rad]
+
+  sigma_twist_from_consecutive_poses_linear: 1.0 # [m]
+  sigma_twist_from_consecutive_poses_angular: 1.0 # [rad/s]
+
+  # Optional initial guess for the twist (vx vy vz: m/s, wx wy wz: rad/s):
+  initial_twist: ["${MOLA_INITIAL_VX|0.0}", 0.0, 0.0, 0.0, 0.0, 0.0]
+  initial_twist_sigma_lin: 20.0 # [m/s]
+  initial_twist_sigma_ang: 3.0 # [rad/s]
+
+  robust_param: 3.0 # 0=no robust disabled
+  max_rmse: 2 # max inconsistencies to discard solution
+
+  # If enabled, the estimator will enforce z, pitch, and roll to be always 0:
+  enforce_planar_motion: ${MOLA_NAVSTATE_ENFORCE_PLANAR_MOTION|false}

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -158,15 +158,6 @@ params:
   additional_isam2_update_steps: 3
 
   # --------------------------------------------------------------------------
-  # Legacy Parameters (kept for backward compatibility)
-  # --------------------------------------------------------------------------
-
-  # NOTE: These parameters are deprecated but kept for compatibility
-  robust_param: 3.0 # 0=no robust disabled
-  max_rmse: 2 # max inconsistencies to discard solution
-
-
-  # --------------------------------------------------------------------------
   # Sensor Input Filtering (Regex Patterns)
   # --------------------------------------------------------------------------
 

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -1,44 +1,186 @@
-# This file holds parameters for mola::state_estimation_smoother::StateEstimationSmoother
+# ============================================================================
+# Configuration for mola::state_estimation_smoother::StateEstimationSmoother
+# ============================================================================
+# This file holds parameters for MOLA State Estimation Smoother that fuses
+# multiple sensor inputs (IMU, odometry, GNSS) for robust pose and velocity
+# estimation.
 #
 # Refer to:
 # https://docs.mola-slam.org/latest/mola_state_estimators.html
+# https://github.com/MOLAorg/mola
+# ============================================================================
 
 params:
-  # Maximum time since last observation to consider the validity of the velocity model:
-  # (KITTI360 test_3 has some blackouts >=1.0 seconds while angular acceleration is high, so
-  #  this threshold must be < 1.0 s for that dataset)
-  max_time_to_use_velocity_model: ${MOLA_MAX_TIME_TO_USE_VELOCITY_MODEL|0.75} # [s]
+  # --------------------------------------------------------------------------
+  # Reference Frame IDs
+  # --------------------------------------------------------------------------
 
-  # Time to keep past observations in the filter
-  sliding_window_length: 2.5 # [s]
-
+  # Frame name for the vehicle/robot base
   # Used to publish timely pose updates:
   vehicle_frame_name: "${MOLA_TF_BASE_LINK|base_link}"
 
-  # Used to publish timely pose updates. Typically, 'map' or 'odom', etc.
+  # Reference frame for pose publication (typically 'map' or 'odom')
+  # Used to publish timely pose updates.
   # See docs: https://docs.mola-slam.org/latest/mola_state_estimators.html
   reference_frame_name: "${MOLA_TF_MAP|map}"
 
+  # The ENU geo-reference frame
+  enu_frame_name: "enu"
+
+  # --------------------------------------------------------------------------
+  # Kinematic Model & Motion Factors
+  # --------------------------------------------------------------------------
+
+  # Kinematic model for internal motion model factors
+  # Options: KinematicModel::ConstantVelocity, KinematicModel::Tricycle
+  kinematic_model: "${MOLA_NAVSTATE_KINEMATIC_MODEL|KinematicModel::ConstantVelocity}"
+
+  # Time window to keep past observations in the filter [seconds]
+  sliding_window_length: ${MOLA_NAVSTATE_SLIDING_WINDOW_SEC|2.5}
+
+  # Minimum time difference between frames to create a new frame [seconds]
+  min_time_difference_to_create_new_frame: 0.01
+
+  # Maximum time to extrapolate velocity model since last observation [seconds]
+  # Valid estimations will be extrapolated only up to this time since the
+  # last incorporated observation. If a request is done farther away, an
+  # empty estimation will be returned.
+  # Beyond this time, empty estimations will be returned.
+  # (KITTI360 test_3 has some blackouts >=1.0 seconds while angular acceleration is high, so
+  #  this threshold must be < 1.0 s for that dataset)
+  max_time_to_use_velocity_model: ${MOLA_MAX_TIME_TO_USE_VELOCITY_MODEL|0.75}
+
+  # Warning threshold: emit warning if time between keyframes exceeds this [seconds]
   # If the time between two keyframes is larger than this, a warning will be
   # emitted; but the algorithm will keep trying its best.
-  time_between_frames_to_warning: 3.0 # [s]
+  time_between_frames_to_warning: 3.0
 
-  sigma_random_walk_acceleration_linear: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC|1.0} # [m/s²]
-  sigma_random_walk_acceleration_angular: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_ANGACC|10.0} # [rad/s²]
+  # When adding GNSS observations, specially with consumer grade receivers with errors larger
+  # than a few centimeters, we may be more permissive in the temporal distance between the GNSS
+  # datum and the associated existing keyframe. This parameter is the extended, alternative value
+  # to use instead of "min_time_difference_to_create_new_frame". [seconds]
+  gnss_nearby_keyframe_stamp_tolerance: 1.0
 
-  sigma_integrator_position: 0.1 # [m]
-  sigma_integrator_orientation: 1.0 # [rad]
+  # When adding IMU observations, this is the temporal distance between the IMU reading
+  # and the associated existing keyframe. This applies to gravity-oriented (IMU attitude) and
+  # gravity-estimation (accelerometer) only factors, not to high-frequency IMU preintegration.
+  # This parameter is the extended, alternative value
+  # to use instead of "min_time_difference_to_create_new_frame". [seconds]
+  imu_nearby_keyframe_stamp_tolerance: 0.10
 
-  sigma_twist_from_consecutive_poses_linear: 1.0 # [m]
-  sigma_twist_from_consecutive_poses_angular: 1.0 # [rad/s]
+  # Random walk model for linear acceleration uncertainty [m/s²]
+  sigma_random_walk_acceleration_linear: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC|1.0}
 
-  # Optional initial guess for the twist (vx vy vz: m/s, wx wy wz: rad/s):
-  initial_twist: ["${MOLA_INITIAL_VX|0.0}", 0.0, 0.0, 0.0, 0.0, 0.0]
-  initial_twist_sigma_lin: 20.0 # [m/s]
-  initial_twist_sigma_ang: 3.0 # [rad/s]
+  # Random walk model for angular acceleration uncertainty [rad/s²]
+  sigma_random_walk_acceleration_angular: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_ANGACC|10.0}
 
-  robust_param: 3.0 # 0=no robust disabled
-  max_rmse: 2 # max inconsistencies to discard solution
+  # Integrator uncertainty for position [m]
+  sigma_integrator_position: 0.1
+
+  # Integrator uncertainty for orientation [rad]
+  sigma_integrator_orientation: 1.0
+
+  # Uncertainty for linear velocity estimated from consecutive poses [m/s]
+  sigma_twist_from_consecutive_poses_linear: 1.0
+
+  # Uncertainty for angular velocity estimated from consecutive poses [rad/s]
+  sigma_twist_from_consecutive_poses_angular: 1.0
 
   # If enabled, the estimator will enforce z, pitch, and roll to be always 0:
   enforce_planar_motion: ${MOLA_NAVSTATE_ENFORCE_PLANAR_MOTION|false}
+
+  # If set, the first ever frame will also have an SE(3) edge favoring it to be the identity in
+  # the "reference_frame", with a sigma given by this value. Use a small number, like 1e-6, for
+  # initialing the first odometry pose near the map origin. Do not set when using geo-referenced
+  # maps.
+  # link_first_pose_to_reference_origin_sigma: 1e-6
+
+  # --------------------------------------------------------------------------
+  # Initial State Estimation
+  # --------------------------------------------------------------------------
+
+  # Optional initial guess for the twist (vx vy vz: m/s, wx wy wz: rad/s):
+  # Initial velocity twist (linear: vx, vy, vz; angular: wx, wy, wz)
+  initial_twist: ["${MOLA_INITIAL_VX|0.0}", 0.0, 0.0, 0.0, 0.0, 0.0]
+
+  # Defaults: somewhat confident that the vehicle is near rest.
+  # Change these if needed to start with the vehicle at high speed.
+  # Initial linear velocity uncertainty [m/s]
+  initial_twist_sigma_lin: ${MOLA_INITIAL_TWIST_SIGMA_LIN|20.0}
+
+  # Initial angular velocity uncertainty [rad/s]
+  initial_twist_sigma_ang: ${MOLA_INITIAL_TWIST_SIGMA_ANG|3.0}
+
+  # --------------------------------------------------------------------------
+  # IMU Related
+  # --------------------------------------------------------------------------
+
+  # When an IMU provides global attitude measurements (azimuth and gravity aligned), this is the
+  # uncertainty or noise sigma [degrees].
+  imu_attitude_sigma_deg: "${MOLA_IMU_ATTITUDE_SIGMA|2.0}"
+
+  # When an IMU provides global attitude measurements (azimuth and gravity aligned), this must
+  # define the angle (in degrees) to add to IMU yaw orientation to obtain azimuth so 0 deg is
+  # North. Note that ENU axes are such vehicle yaw is 0 when pointing East instead.
+  # Example cases:
+  # - IMU absolute yaw=0 points True North ==> offset=0
+  # - IMU absolute yaw=0 points East ==> offset=-90
+  imu_attitude_azimuth_offset_deg: "${MOLA_IMU_ATTITUDE_AZIMUTH_OFFSET|0.0}"
+
+  # When using an IMU with acceleration, use this sigma to estimate the up-vector, hence
+  # gravity-align the map.
+  # Set to 0 to disable.
+  imu_normalized_gravity_alignment_sigma: "${MOLA_IMU_GRAVITY_ALIGNMENT_SIGMA|0.4}"
+
+  # --------------------------------------------------------------------------
+  # Geo-referencing
+  # --------------------------------------------------------------------------
+
+  # If true, this estimator will try to estimate the best geo-referencing for {enu} ->
+  # {map} from incoming GNSS readings and other sensors. If false, geo-referencing is
+  # assumed to be given from either these initial parameters or, if not set, from an external
+  # source (e.g. a geo-referenced .mm map loaded in mola_lidar_odometry).
+  estimate_geo_reference: "${MOLA_ESTIMATE_GEO_REF|false}"
+
+  # If estimate_geo_reference is false and this is set, the geo-referencing will be taken
+  # from this value and never attempted to be optimized or changed.
+  # Other geo-reference information coming from external sources may override this fixed initial
+  # value, though.
+  # Fixed geo-reference to use when estimate_geo_reference is false
+  # fixed_geo_reference: { latitude_deg: 0.0, longitude_deg: 0.0, altitude: 0.0 }
+
+  # --------------------------------------------------------------------------
+  # Nonlinear Optimization
+  # --------------------------------------------------------------------------
+
+  # Each new sensor will become a call to isam2.update(), plus this number of additional
+  # refining steps. In theory, more steps lead to more accurate results.
+  additional_isam2_update_steps: 3
+
+  # --------------------------------------------------------------------------
+  # Legacy Parameters (kept for backward compatibility)
+  # --------------------------------------------------------------------------
+
+  # NOTE: These parameters are deprecated but kept for compatibility
+  robust_param: 3.0 # 0=no robust disabled
+  max_rmse: 2 # max inconsistencies to discard solution
+
+
+  # --------------------------------------------------------------------------
+  # Sensor Input Filtering (Regex Patterns)
+  # --------------------------------------------------------------------------
+
+  # Regular expression to filter IMU sensor labels/topics for processing
+  # Default accepts all: ".*"
+  # do_process_imu_labels_re: ".*"
+
+  # Regular expression to filter odometry input labels/topics for processing
+  # Default accepts all: ".*"
+  # do_process_odometry_labels_re: ".*"
+
+  # Regular expression to filter GNSS (GPS) labels/topics for processing
+  # Default accepts all: ".*"
+  # do_process_gnss_labels_re: ".*"
+# ============================================================================
+# End of Configuration
+# ============================================================================

--- a/mola_state_estimation_smoother/ros2-launchs/ros2-state-estimator.launch.py
+++ b/mola_state_estimation_smoother/ros2-launchs/ros2-state-estimator.launch.py
@@ -1,0 +1,294 @@
+
+# ROS 2 launch file
+
+from launch import LaunchDescription
+from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch.conditions import IfCondition
+from launch_ros.actions import Node
+from launch_ros.actions import PushRosNamespace
+from launch.actions import DeclareLaunchArgument
+from launch.actions import SetEnvironmentVariable
+from launch.actions import GroupAction
+from launch.actions import Shutdown
+from ament_index_python import get_package_share_directory
+import os
+
+
+def generate_launch_description():
+    myDir = get_package_share_directory("mola_lidar_odometry")
+
+    # -------------------
+    #     Arguments
+    # -------------------
+    # Mandatory
+    lidar_topic_name_arg = DeclareLaunchArgument(
+        "lidar_topic_name", description="Topic name to listen for PointCloud2 input from the LiDAR (for example '/ouster/points')")
+    lidar_topic_env_var = SetEnvironmentVariable(
+        name='MOLA_LIDAR_TOPIC', value=LaunchConfiguration('lidar_topic_name'))
+    # ~~~~~~~~~~~~
+    ignore_lidar_pose_from_tf_arg = DeclareLaunchArgument(
+        "ignore_lidar_pose_from_tf", default_value="false", description="If true, the LiDAR pose will be assumed to be at the origin (base_link). Set to false (default) if you want to read the actual sensor pose from /tf")
+    ignore_lidar_pose_from_tf_env_var = SetEnvironmentVariable(
+        name='MOLA_USE_FIXED_LIDAR_POSE', value=LaunchConfiguration('ignore_lidar_pose_from_tf'))
+    # ~~~~~~~~~~~~
+    ignore_imu_pose_from_tf_arg = DeclareLaunchArgument(
+        "ignore_imu_pose_from_tf", default_value="false", description="If true, the IMU pose will be assumed to be at the origin (base_link). Set to false (default) if you want to read the actual sensor pose from /tf")
+    ignore_imu_pose_from_tf_env_var = SetEnvironmentVariable(
+        name='MOLA_USE_FIXED_IMU_POSE', value=LaunchConfiguration('ignore_imu_pose_from_tf'))
+    # ~~~~~~~~~~~~
+    gnss_topic_name_arg = DeclareLaunchArgument(
+        "gnss_topic_name", default_value="gps", description="Topic name to listen for NavSatFix input from a GNSS (for example '/gps')")
+    gps_topic_env_var = SetEnvironmentVariable(
+        name='MOLA_GNSS_TOPIC', value=LaunchConfiguration('gnss_topic_name'))
+    # ~~~~~~~~~~~~
+    imu_topic_name_arg = DeclareLaunchArgument(
+        "imu_topic_name", default_value="imu", description="Topic name to listen for Imu input (for example '/imu')")
+    imu_topic_name_env_var = SetEnvironmentVariable(
+        name='MOLA_IMU_TOPIC', value=LaunchConfiguration('imu_topic_name'))
+    # ~~~~~~~~~~~~
+    use_rviz = LaunchConfiguration('use_rviz')
+    use_rviz_arg = DeclareLaunchArgument(
+        "use_rviz", default_value="True", description="Whether to launch RViz2 with default lidar-odometry.rviz configuration")
+    # ~~~~~~~~~~~~
+    use_mola_gui_arg = DeclareLaunchArgument(
+        "use_mola_gui", default_value="True", description="Whether to open MolaViz GUI interface for watching live mapping and control UI")
+    use_mola_gui_env_var = SetEnvironmentVariable(
+        name='MOLA_WITH_GUI', value=LaunchConfiguration('use_mola_gui'))
+    # ~~~~~~~~~~~~
+    publish_localization_following_rep105_arg = DeclareLaunchArgument(
+        "publish_localization_following_rep105", default_value="True", description="Whether to publish localization TFs in between map->odom (true) or directly map->base_link (false)")
+    publish_localization_following_rep105_env_var = SetEnvironmentVariable(
+        name='MOLA_LOCALIZ_USE_REP105', value=LaunchConfiguration('publish_localization_following_rep105'))
+    # ~~~~~~~~~~~~
+    start_mapping_enabled_arg = DeclareLaunchArgument(
+        "start_mapping_enabled", default_value="True", description="Whether MOLA-LO should start with map update enabled (true), or in localization-only mode (false)")
+    start_mapping_enabled_env_var = SetEnvironmentVariable(
+        name='MOLA_MAPPING_ENABLED', value=LaunchConfiguration('start_mapping_enabled'))
+    # ~~~~~~~~~~~~
+    start_active_arg = DeclareLaunchArgument(
+        "start_active", default_value="True", description="Whether MOLA-LO should start active, that is, processing incoming sensor data (true), or ignoring them (false)")
+    start_active_env_var = SetEnvironmentVariable(
+        name='MOLA_START_ACTIVE', value=LaunchConfiguration('start_active'))
+    # ~~~~~~~~~~~~
+    mola_lo_reference_frame_arg = DeclareLaunchArgument(
+        "mola_lo_reference_frame", default_value="map", description="The /tf frame name to be used for MOLA-LO localization updates")
+    mola_lo_reference_frame_env_var = SetEnvironmentVariable(
+        name='MOLA_LO_PUBLISH_REF_FRAME', value=LaunchConfiguration('mola_lo_reference_frame'))
+    # ~~~~~~~~~~~~
+    mola_se_reference_frame_arg = DeclareLaunchArgument(
+        "mola_state_estimator_reference_frame", default_value="map", description="The /tf frame name to be used as reference for MOLA State Estimators to publish pose updates")
+    mola_tf_map_env_var = SetEnvironmentVariable(
+        name='MOLA_TF_MAP', value=LaunchConfiguration('mola_state_estimator_reference_frame'))
+    # ~~~~~~~~~~~~
+    mola_lo_pipeline_arg = DeclareLaunchArgument(
+        "mola_lo_pipeline", default_value="../pipelines/lidar3d-default.yaml", description="The LiDAR-Odometry pipeline configuration YAML file defining the LO system. Absolute path, or relative to 'mola-cli-launchs/lidar_odometry_ros2.yaml'. Default is the 'lidar3d-default.yaml' system described in the IJRR 2025 paper.")
+    mola_lo_pipeline_env_var = SetEnvironmentVariable(
+        name='MOLA_ODOMETRY_PIPELINE_YAML', value=LaunchConfiguration('mola_lo_pipeline'))
+    # ~~~~~~~~~~~~
+    generate_simplemap_arg = DeclareLaunchArgument(
+        "generate_simplemap", default_value="False", description="Whether to create a '.simplemap', useful for map post-processing. Refer to online tutorials.")
+    generate_simplemap_env_var = SetEnvironmentVariable(
+        name='MOLA_GENERATE_SIMPLEMAP', value=LaunchConfiguration('generate_simplemap'))
+    # ~~~~~~~~~~~~
+    mola_initial_map_mm_file_arg = DeclareLaunchArgument(
+        "mola_initial_map_mm_file", default_value="\"\"", description="Can be used to provide a metric map '.mm' file to be loaded as initial map. Refer to online tutorials.")
+    mola_initial_map_mm_file_env_var = SetEnvironmentVariable(
+        name='MOLA_LOAD_MM', value=LaunchConfiguration('mola_initial_map_mm_file'))
+    # ~~~~~~~~~~~~
+    mola_initial_map_sm_file_arg = DeclareLaunchArgument(
+        "mola_initial_map_sm_file", default_value="\"\"", description="Can be used to provide a keyframes map '.simplemap' file to be loaded as initial map. Refer to online tutorials.")
+    mola_initial_map_sm_file_env_var = SetEnvironmentVariable(
+        name='MOLA_LOAD_SM', value=LaunchConfiguration('mola_initial_map_sm_file'))
+    # ~~~~~~~~~~~~
+    mola_footprint_to_base_link_tf_arg = DeclareLaunchArgument(
+        "mola_footprint_to_base_link_tf", default_value="[0, 0, 0, 0, 0, 0]", description="Can be used to define a custom transformation between base_footprint and base_link. The coordinates are [x, y, z, yaw_deg, pitch_deg, roll_deg].")
+    mola_footprint_to_base_link_tf_env_var = SetEnvironmentVariable(
+        name='MOLA_TF_FOOTPRINT_TO_BASE_LINK', value=LaunchConfiguration('mola_footprint_to_base_link_tf'))
+    # ~~~~~~~~~~~~
+    enforce_planar_motion_arg = DeclareLaunchArgument(
+        "enforce_planar_motion", default_value="False", description="Whether to enforce z, pitch, and roll to be zero.")
+    enforce_planar_motion_env_var = SetEnvironmentVariable(
+        name='MOLA_NAVSTATE_ENFORCE_PLANAR_MOTION', value=LaunchConfiguration('enforce_planar_motion'))
+    # ~~~~~~~~~~~~
+    forward_ros_tf_odom_to_mola_arg = DeclareLaunchArgument(
+        "forward_ros_tf_odom_to_mola", default_value="False", description="Whether to import an existing /tf 'odom'->'base_link' odometry into the MOLA subsystem.")
+    forward_ros_tf_odom_to_mola_env_var = SetEnvironmentVariable(
+        name='MOLA_FORWARD_ROS_TF_ODOM_TO_MOLA', value=LaunchConfiguration('forward_ros_tf_odom_to_mola'))
+    # ~~~~~~~~~~~~
+    initial_localization_method_arg = DeclareLaunchArgument(
+        "initial_localization_method", default_value="InitLocalization::FixedPose", description="What method to use for initialization. See https://docs.mola-slam.org/latest/ros2api.html#initial-localization")
+    initial_localization_method_env_var = SetEnvironmentVariable(
+        name='MOLA_LO_INITIAL_LOCALIZATION_METHOD', value=LaunchConfiguration('initial_localization_method'))
+    # ~~~~~~~~~~~~
+    use_state_estimator_arg = DeclareLaunchArgument(
+        "use_state_estimator",
+        default_value="False",
+        description="If false, the basic state estimator 'mola::state_estimation_simple::StateEstimationSimple' will be used. If true, 'mola::state_estimation_smoother::StateEstimationSmoother' is used instead."
+    )
+    use_state_estimator_env_var = SetEnvironmentVariable(
+        name='MOLA_STATE_ESTIMATOR', value=PythonExpression(
+            ["'mola::state_estimation_smoother::StateEstimationSmoother' if ",
+             LaunchConfiguration(
+                 'use_state_estimator'),
+             " else 'mola::state_estimation_simple::StateEstimationSimple'"
+             ]))
+    localization_publish_tf_source_env_var = SetEnvironmentVariable(
+        name='MOLA_LOCALIZATION_PUBLISH_TF_SOURCE',
+        value=PythonExpression([
+            "'state_estimator' if ", LaunchConfiguration(
+                'use_state_estimator'), " else 'lidar_odometry'"
+        ])
+    )
+    localization_publish_odom_source_env_var = SetEnvironmentVariable(
+        name='MOLA_LOCALIZATION_PUBLISH_ODOM_MSGS_SOURCE',
+        value=PythonExpression([
+            "'state_estimator' if ", LaunchConfiguration(
+                'use_state_estimator'), " else 'lidar_odometry'"
+        ])
+    )
+    state_estimator_config_yaml_arg = DeclareLaunchArgument(
+        "state_estimator_config_yaml", default_value=PythonExpression(
+            ["'../state-estimator-params/state-estimation-smoother.yaml' if ",
+             LaunchConfiguration(
+                 'use_state_estimator'),
+             " else '../state-estimator-params/state-estimation-simple.yaml'"
+             ]),
+        description="A YAML file with settings for the state estimator. Absolute path or relative to 'mola-cli-launchs/lidar_odometry_ros2.yaml'")
+    state_estimator_config_yaml_env_var = SetEnvironmentVariable(
+        name='MOLA_STATE_ESTIMATOR_YAML', value=LaunchConfiguration('state_estimator_config_yaml'))
+    # ~~~~~~~~~~~~
+    lidar_scan_validity_minimum_point_count_arg = DeclareLaunchArgument(
+        "lidar_scan_validity_minimum_point_count", default_value="100", description="Minimum number of points in each LiDAR raw scan for it to be considered valid; otherwise, it is ignored.")
+    lidar_scan_validity_minimum_point_env_var = SetEnvironmentVariable(
+        name='MOLA_OBS_VALIDITY_MIN_POINTS', value=LaunchConfiguration('lidar_scan_validity_minimum_point_count'))
+    lidar_scan_validity_enable_env_var = SetEnvironmentVariable(
+        name='MOLA_ENABLE_OBS_VALIDITY_FILTER', value='True')
+    # ~~~~~~~~~~~~
+    mola_deskew_method_arg = DeclareLaunchArgument(
+        "mola_deskew_method", default_value="MotionCompensationMethod::Linear", description="Which motion-compensation method to use to align LiDAR scans more precisely")
+    mola_deskew_method_env_var = SetEnvironmentVariable(
+        name='MOLA_DESKEW_METHOD', value=LaunchConfiguration('mola_deskew_method'))
+    # ~~~~~~~~~~~~
+    mola_tf_base_link_arg = DeclareLaunchArgument(
+        "mola_tf_base_link", default_value="base_link", description="The /tf frame name for the robot base link.")
+    mola_tf_base_link_env_var = SetEnvironmentVariable(
+        name='MOLA_TF_BASE_LINK', value=LaunchConfiguration('mola_tf_base_link'))
+
+    # Namespace (Based on Nav2's bring-up launch file!)
+    # ---------------------------------------------------
+    namespace = LaunchConfiguration('namespace')
+    use_namespace = LaunchConfiguration('use_namespace')
+
+    declare_namespace_cmd = DeclareLaunchArgument(
+        'namespace',
+        default_value='',
+        description='Top-level namespace')
+
+    declare_use_namespace_cmd = DeclareLaunchArgument(
+        'use_namespace',
+        default_value='false',
+        description='Whether to apply a namespace to the navigation stack')
+
+    # Map fully qualified names to relative ones so the node's namespace can be prepended.
+    # In case of the transforms (tf), currently, there doesn't seem to be a better alternative
+    # https://github.com/ros/geometry2/issues/32
+    # https://github.com/ros/robot_state_publisher/pull/30
+    #
+    # (JLBC further explanation) The problem is the "tf2" library. It's hardcoded to subscribe
+    # to "/tf". This remapping allows "/robot/tf" to be seen as "/tf" so tf2_ros (and RViz) can see it.
+    #
+    tf_remaps = [('/tf', 'tf'),
+                 ('/tf_static', 'tf_static')]
+
+    # MOLA subsystem configuration YAML file
+    # ------------------------------------------
+    mola_system_yaml_file = os.path.join(
+        myDir, 'mola-cli-launchs', 'lidar_odometry_ros2.yaml')
+
+    # -------------------
+    #        Node
+    # -------------------
+    node_group = GroupAction([
+        PushRosNamespace(
+            condition=IfCondition(use_namespace),
+            namespace=namespace),
+
+        Node(
+            package='mola_launcher',
+            executable='mola-cli',
+            output='screen',
+            remappings=tf_remaps,
+            arguments=[mola_system_yaml_file],
+            on_exit=Shutdown()
+        ),
+
+        Node(
+            condition=IfCondition(use_rviz),
+            package='rviz2',
+            executable='rviz2',
+            name='rviz2',
+            remappings=tf_remaps,
+            arguments=[
+                '-d', [os.path.join(myDir, 'rviz2', 'lidar-odometry.rviz')]]
+        )
+    ])
+
+    return LaunchDescription([
+        declare_namespace_cmd,
+        declare_use_namespace_cmd,
+        enforce_planar_motion_arg,
+        enforce_planar_motion_env_var,
+        forward_ros_tf_odom_to_mola_arg,
+        forward_ros_tf_odom_to_mola_env_var,
+        generate_simplemap_arg,
+        generate_simplemap_env_var,
+        gnss_topic_name_arg,
+        gps_topic_env_var,
+        ignore_imu_pose_from_tf_arg,
+        ignore_imu_pose_from_tf_env_var,
+        ignore_lidar_pose_from_tf_arg,
+        ignore_lidar_pose_from_tf_env_var,
+        imu_topic_name_arg,
+        imu_topic_name_env_var,
+        initial_localization_method_arg,
+        initial_localization_method_env_var,
+        lidar_scan_validity_enable_env_var,
+        lidar_scan_validity_minimum_point_count_arg,
+        lidar_scan_validity_minimum_point_env_var,
+        lidar_topic_env_var,
+        lidar_topic_name_arg,
+        mola_deskew_method_arg,
+        mola_deskew_method_env_var,
+        mola_footprint_to_base_link_tf_arg,
+        mola_footprint_to_base_link_tf_env_var,
+        mola_initial_map_mm_file_arg,
+        mola_initial_map_mm_file_env_var,
+        mola_initial_map_sm_file_arg,
+        mola_initial_map_sm_file_env_var,
+        mola_lo_pipeline_arg,
+        mola_lo_pipeline_env_var,
+        mola_lo_reference_frame_arg,
+        mola_lo_reference_frame_env_var,
+        mola_se_reference_frame_arg,
+        mola_tf_base_link_arg,
+        mola_tf_base_link_env_var,
+        mola_tf_map_env_var,
+        publish_localization_following_rep105_arg,
+        publish_localization_following_rep105_env_var,
+        start_active_arg,
+        start_active_env_var,
+        start_mapping_enabled_arg,
+        start_mapping_enabled_env_var,
+        use_mola_gui_arg,
+        use_mola_gui_env_var,
+        use_rviz_arg,
+        use_state_estimator_arg,
+        use_state_estimator_env_var,
+        # Must come later:
+        state_estimator_config_yaml_arg,
+        state_estimator_config_yaml_env_var,
+        localization_publish_tf_source_env_var,
+        localization_publish_odom_source_env_var,
+        # group
+        node_group
+    ])

--- a/mola_state_estimation_smoother/ros2-launchs/ros2-state-estimator.launch.py
+++ b/mola_state_estimation_smoother/ros2-launchs/ros2-state-estimator.launch.py
@@ -147,13 +147,8 @@ def generate_launch_description():
         ])
     )
     state_estimator_config_yaml_arg = DeclareLaunchArgument(
-        "state_estimator_config_yaml", default_value=PythonExpression(
-            ["'../state-estimator-params/state-estimation-smoother.yaml' if ",
-             LaunchConfiguration(
-                 'use_state_estimator'),
-             " else '../state-estimator-params/state-estimation-simple.yaml'"
-             ]),
-        description="A YAML file with settings for the state estimator. Absolute path or relative to 'mola-cli-launchs/lidar_odometry_ros2.yaml'")
+        "state_estimator_config_yaml", default_value='../params/state-estimation-smoother.yaml',
+        description="A YAML file with settings for the state estimator. Absolute path or relative to this launch file")
     state_estimator_config_yaml_env_var = SetEnvironmentVariable(
         name='MOLA_STATE_ESTIMATOR_YAML', value=LaunchConfiguration('state_estimator_config_yaml'))
     # ~~~~~~~~~~~~

--- a/mola_state_estimation_smoother/src/Parameters.cpp
+++ b/mola_state_estimation_smoother/src/Parameters.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_smoother/src/Parameters.cpp
+++ b/mola_state_estimation_smoother/src/Parameters.cpp
@@ -131,6 +131,16 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
             tw[i] = seq.at(i).as<double>();
         }
     }
+
+    if (cfg.has("visualization"))
+    {
+        visualization.loadFrom(cfg["visualization"]);
+    }
+}
+
+void Parameters::Visualization::loadFrom(const mrpt::containers::yaml& cfg)
+{
+    MCP_LOAD_OPT(cfg, show_console_messages);
 }
 
 }  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -532,52 +532,56 @@ void StateEstimationSmoother::fuse_twist(
 {
     auto lck = mrpt::lockHelper(stateMutex_);
 
-#if 0
-    const auto&          pd   = d.twist.value();
-    const gtsam::Vector3 v    = {pd.twist.vx, pd.twist.vy, pd.twist.vz};
-    const gtsam::Vector3 w    = {pd.twist.wx, pd.twist.wy, pd.twist.wz};
-    gtsam::Matrix3       vCov = pd.twistCov.asEigen().block<3, 3>(0, 0);
-    gtsam::Matrix3       wCov = pd.twistCov.asEigen().block<3, 3>(3, 3);
+    const gtsam::Vector3 v    = {twist.vx, twist.vy, twist.vz};
+    const gtsam::Vector3 w    = {twist.wx, twist.wy, twist.wz};
+    gtsam::Matrix3       vCov = twistCov.asEigen().block<3, 3>(0, 0);
+    gtsam::Matrix3       wCov = twistCov.asEigen().block<3, 3>(3, 3);
+
+    // Create a new KF id (or reuse a very close match):
+    const auto this_kf_id = create_or_get_keyframe_by_timestamp(timestamp);
 
     {
         auto                                noiseV = gtsam::noiseModel::Gaussian::Covariance(vCov);
         gtsam::noiseModel::Base::shared_ptr robNoiseV;
+#if 0
         if (params_.robust_param > 0)
         {
             robNoiseV = gtsam::noiseModel::Robust::Create(
                 gtsam::noiseModel::mEstimator::GemanMcClure::Create(params_.robust_param), noiseV);
         }
         else
+#endif
         {
             robNoiseV = noiseV;
         }
 
-        fg.addPrior(V(kfId), v, robNoiseV);
+        state_.gtsam->newFactors.addPrior(V(this_kf_id), v, robNoiseV);
     }
     {
         auto                                noiseW = gtsam::noiseModel::Gaussian::Covariance(wCov);
         gtsam::noiseModel::Base::shared_ptr robNoiseW;
+#if 0
         if (params_.robust_param > 0)
         {
             robNoiseW = gtsam::noiseModel::Robust::Create(
                 gtsam::noiseModel::mEstimator::GemanMcClure::Create(params_.robust_param), noiseW);
         }
         else
+#endif
         {
             robNoiseW = noiseW;
         }
 
-        fg.addPrior(W(kfId), w, robNoiseW);
+        state_.gtsam->newFactors.addPrior(W(this_kf_id), w, robNoiseW);
     }
 
     MRPT_LOG_DEBUG_FMT(
-        "[fuse_twist]: t=%f twist=%s sigmas=%.02e %.02e %.02e (m) %.02e %.02e "
+        "[fuse_twist]: t=%f this_kf_id=%zu twist=%s sigmas=%.02e %.02e %.02e (m) %.02e %.02e "
         "%.02e (deg)",
-        mrpt::Clock::toDouble(timestamp), twist.asString().c_str(), std::sqrt(twistCov(0, 0)),
-        std::sqrt(twistCov(1, 1)), std::sqrt(twistCov(2, 2)),
-        mrpt::RAD2DEG(std::sqrt(twistCov(3, 3))), mrpt::RAD2DEG(std::sqrt(twistCov(4, 4))),
-        mrpt::RAD2DEG(std::sqrt(twistCov(5, 5))));
-#endif
+        mrpt::Clock::toDouble(timestamp), static_cast<std::size_t>(this_kf_id),
+        twist.asString().c_str(), std::sqrt(twistCov(0, 0)), std::sqrt(twistCov(1, 1)),
+        std::sqrt(twistCov(2, 2)), mrpt::RAD2DEG(std::sqrt(twistCov(3, 3))),
+        mrpt::RAD2DEG(std::sqrt(twistCov(4, 4))), mrpt::RAD2DEG(std::sqrt(twistCov(5, 5))));
 }
 
 std::optional<NavState> StateEstimationSmoother::estimated_navstate(

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -147,6 +147,40 @@ void StateEstimationSmoother::initialize(const mrpt::containers::yaml& cfg)
     // Load params:
     params_.loadFrom(cfg["params"]);
 
+    if (auto vizMods = ExecutableBase::findService<mola::VizInterface>(); !vizMods.empty())
+    {
+        visualizer_ = std::dynamic_pointer_cast<mola::VizInterface>(*vizMods.begin());
+        if (visualizer_)
+        {
+            MRPT_LOG_DEBUG_STREAM("Connected to visualizer module");
+        }
+    }
+
+    if (visualizer_)
+    {
+        this->mrpt::system::COutputLogger::logRegisterCallback(
+            [&](std::string_view msg, const mrpt::system::VerbosityLevel level,
+                std::string_view loggerName, const mrpt::Clock::time_point timestamp)
+            {
+                using namespace std::string_literals;
+
+                if (!params_.visualization.show_console_messages)
+                {
+                    return;
+                }
+
+                if (level < this->getMinLoggingLevel())
+                {
+                    return;
+                }
+
+                visualizer_->output_console_message(
+                    "["s + mrpt::system::timeLocalToString(timestamp) + "|"s +
+                    mrpt::typemeta::enum2str(level) + " |"s + std::string(loggerName) + "]"s +
+                    std::string(msg));
+            });
+    }
+
     // Forward parameters to GTSAM smoother & iSAM2:
     gtsam::ISAM2Params isam2Params;
     isam2Params.findUnusedFactorSlots = true;  // Important, must be set for fixed-lag smoother

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -863,7 +863,7 @@ void StateEstimationSmoother::addFactor(const AbsFactorTricycleKinematics& f)
     }
     // In the tricycle model, body w_x,w_y must be zero:
     {
-        const Eigen::Vector3d sigmas = {std_lin_vel * dt, std_lin_vel * dt, TRICYCLE_LARGE_SIGMAS};
+        const Eigen::Vector3d sigmas = {std_ang_vel * dt, std_ang_vel * dt, TRICYCLE_LARGE_SIGMAS};
 
         state_.gtsam->newFactors.emplace_shared<gtsam::PriorFactor<gtsam::Point3>>(
             kbWj, gtsam::Point3::Zero(), gtsam::noiseModel::Diagonal::Sigmas(sigmas));
@@ -874,7 +874,7 @@ void StateEstimationSmoother::addFactor(const AbsFactorTricycleKinematics& f)
     gtsam::Vector6 sigmas;
     const auto     sigmaPos   = params_.sigma_integrator_position;
     const auto     sigmaAngle = params_.sigma_integrator_orientation;
-    sigmas << sigmaPos, sigmaPos, sigmaPos, sigmaAngle, sigmaAngle, sigmaAngle;
+    sigmas << sigmaAngle, sigmaAngle, sigmaAngle, sigmaPos, sigmaPos, sigmaPos;
 
     auto noise_kinematics = gtsam::noiseModel::Diagonal::Sigmas(sigmas);
 

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -49,6 +49,7 @@
 #include <mola_gtsam_factors/FactorConstLocalVelocity.h>
 #include <mola_gtsam_factors/FactorGnssMapEnu.h>
 #include <mola_gtsam_factors/FactorTrapezoidalIntegrator.h>
+#include <mola_gtsam_factors/FactorTricycleKinematic.h>
 #include <mola_gtsam_factors/MeasuredGravityFactor.h>
 #include <mola_gtsam_factors/Pose3RotationFactor.h>
 
@@ -63,6 +64,7 @@ constexpr double INIT_ODOM_FRAME_POSE_SIGMA  = 1e3;
 constexpr double FIRST_POSE_WEAK_PRIOR_SIGMA = 1e6;
 constexpr double PLANAR_XY_SIGMA             = 1e10;
 constexpr double PLANAR_Z_SIGMA              = 1e-4;
+constexpr double TRICYCLE_LARGE_SIGMAS       = 1e6;
 
 void enforce_planar_pose(mrpt::poses::CPose3D& p)
 {
@@ -742,7 +744,7 @@ void StateEstimationSmoother::onNewObservation(const CObservation::Ptr& o)
 }
 
 /// Implementation of Eqs (1),(4) in the MOLA RSS2019 paper.
-void StateEstimationSmoother::addFactor(const FactorConstVelKinematics& f)
+void StateEstimationSmoother::addFactor(const AbsFactorConstVelKinematics& f)
 {
     MRPT_LOG_DEBUG_STREAM(
         "[addFactor] FactorConstVelKinematics: " << f.from_kf << " ==> " << f.to_kf
@@ -805,10 +807,80 @@ void StateEstimationSmoother::addFactor(const FactorConstVelKinematics& f)
         kTi, kbWi, kTj, dt, noise_kinematicsOrientation);
 }
 
-void StateEstimationSmoother::addFactor(const FactorTricycleKinematics& f)
+void StateEstimationSmoother::addFactor(const AbsFactorTricycleKinematics& f)
 {
-    THROW_EXCEPTION("Write me!");
-    (void)f;
+    MRPT_LOG_DEBUG_STREAM(
+        "[addFactor] FactorTricycleKinematics: " << f.from_kf << " ==> " << f.to_kf
+                                                 << " dt=" << f.deltaTime);
+
+    // Add const-vel factor to gtsam itself:
+    double dt = f.deltaTime;
+
+    // trick to easily handle queries on exactly an existing keyframe:
+    if (dt == 0)
+    {
+        dt = 1e-5;
+    }
+
+    ASSERT_GT_(dt, 0.);
+
+    // errors in constant vel:
+    const double std_lin_vel = params_.sigma_random_walk_acceleration_linear;
+    const double std_ang_vel = params_.sigma_random_walk_acceleration_angular;
+
+    if (dt > params_.time_between_frames_to_warning)
+    {
+        MRPT_LOG_WARN_FMT("Tricycle kinematics factor added for large dT=%.03f s.", dt);
+    }
+
+    // 1) Add GTSAM factors for constant velocity model
+    // -------------------------------------------------
+    const auto kTi  = T(f.from_kf);
+    const auto kTj  = T(f.to_kf);
+    const auto kbVi = V(f.from_kf);
+    const auto kbVj = V(f.to_kf);
+    const auto kbWi = W(f.from_kf);
+    const auto kbWj = W(f.to_kf);
+
+    // See line 3 of eq (4) in the MOLA RSS2019 paper
+    // Modify to use velocity in local frame: reuse FactorConstLocalVelocity
+    // here too:
+    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
+        kTi, kbVi, kTj, kbVj, gtsam::noiseModel::Isotropic::Sigma(3, std_lin_vel * dt));
+
+    // \omega is in the body frame, we need a special factor to rotate it:
+    // See line 4 of eq (4) in the MOLA RSS2019 paper.
+    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
+        kTi, kbWi, kTj, kbWj, gtsam::noiseModel::Isotropic::Sigma(3, std_ang_vel * dt));
+
+    // In the tricycle model, body v_y must be zero:
+    {
+        const Eigen::Vector3d sigmas = {
+            TRICYCLE_LARGE_SIGMAS, std_lin_vel * dt, TRICYCLE_LARGE_SIGMAS};
+
+        state_.gtsam->newFactors.emplace_shared<gtsam::PriorFactor<gtsam::Point3>>(
+            kbVj, gtsam::Point3::Zero(), gtsam::noiseModel::Diagonal::Sigmas(sigmas));
+    }
+    // In the tricycle model, body w_x,w_y must be zero:
+    {
+        const Eigen::Vector3d sigmas = {std_lin_vel * dt, std_lin_vel * dt, TRICYCLE_LARGE_SIGMAS};
+
+        state_.gtsam->newFactors.emplace_shared<gtsam::PriorFactor<gtsam::Point3>>(
+            kbWj, gtsam::Point3::Zero(), gtsam::noiseModel::Diagonal::Sigmas(sigmas));
+    }
+
+    // 2) Add kinematics / numerical integration factor
+    // ---------------------------------------------------
+    gtsam::Vector6 sigmas;
+    const auto     sigmaPos   = params_.sigma_integrator_position;
+    const auto     sigmaAngle = params_.sigma_integrator_orientation;
+    sigmas << sigmaPos, sigmaPos, sigmaPos, sigmaAngle, sigmaAngle, sigmaAngle;
+
+    auto noise_kinematics = gtsam::noiseModel::Diagonal::Sigmas(sigmas);
+
+    // (To be written in a report/paper!)
+    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorTricycleKinematic>(
+        kTi, kbVi, kbWi, kTj, dt, noise_kinematics);
 }
 
 void StateEstimationSmoother::delete_too_old_entries()
@@ -1303,7 +1375,7 @@ void StateEstimationSmoother::add_kinematic_factor_between(
     {
         case KinematicModel::ConstantVelocity:
         {
-            FactorConstVelKinematics f;
+            AbsFactorConstVelKinematics f;
             f.from_kf   = from;
             f.to_kf     = to;
             f.deltaTime = dt;
@@ -1313,7 +1385,7 @@ void StateEstimationSmoother::add_kinematic_factor_between(
 
         case KinematicModel::Tricycle:
         {
-            FactorTricycleKinematics f;
+            AbsFactorTricycleKinematics f;
             f.from_kf   = from;
             f.to_kf     = to;
             f.deltaTime = dt;

--- a/mola_state_estimation_smoother/src/pose_pdf_to_string_with_sigmas.cpp
+++ b/mola_state_estimation_smoother/src/pose_pdf_to_string_with_sigmas.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_smoother/src/register.cpp
+++ b/mola_state_estimation_smoother/src/register.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_smoother/tests/CMakeLists.txt
+++ b/mola_state_estimation_smoother/tests/CMakeLists.txt
@@ -33,3 +33,11 @@ mola_add_test(
   LINK_LIBRARIES
     mola::mola_state_estimation_smoother
 )
+
+mola_add_test(
+  TARGET  test-twist-fusion
+  SOURCES test-twist-fusion.cpp
+  LINK_LIBRARIES
+    mola::mola_state_estimation_smoother
+)
+

--- a/mola_state_estimation_smoother/tests/test-lidar-imu-leveling.cpp
+++ b/mola_state_estimation_smoother/tests/test-lidar-imu-leveling.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_smoother/tests/test-lidar-imu-leveling.cpp
+++ b/mola_state_estimation_smoother/tests/test-lidar-imu-leveling.cpp
@@ -77,7 +77,7 @@ void run_test()
         mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, 0.0_deg, initBadPitch, initBadRoll);
 
     // Accumulated Odometry (Simulate typical LiDAR drift)
-    mrpt::poses::CPose3D currentOdom = mrpt::poses::CPose3D::Identity();
+    mrpt::poses::CPose3D currentOdom = initialBadPose;
 
     for (size_t i = 1; i <= numSteps; i++)
     {

--- a/mola_state_estimation_smoother/tests/test-lidar-imu-leveling.cpp
+++ b/mola_state_estimation_smoother/tests/test-lidar-imu-leveling.cpp
@@ -33,7 +33,6 @@ using namespace mrpt::literals;
 
 namespace
 {
-const bool   VERBOSE  = mrpt::get_env<bool>("VERBOSE", false);
 const size_t numSteps = 100;
 const double T        = 0.05;  // 20 Hz
 

--- a/mola_state_estimation_smoother/tests/test-navstate-basic.cpp
+++ b/mola_state_estimation_smoother/tests/test-navstate-basic.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_smoother/tests/test-navstate-odom-gnss-fusion.cpp
+++ b/mola_state_estimation_smoother/tests/test-navstate-odom-gnss-fusion.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_smoother/tests/test-navstate-odom-gnss-fusion.cpp
+++ b/mola_state_estimation_smoother/tests/test-navstate-odom-gnss-fusion.cpp
@@ -340,8 +340,6 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     constexpr int RANDOM_REPETITIONS = 5;
 
-    rng.randomize(1234);
-
     // shortcuts:
     for (const auto& kinModel : {Kinematic::ConstantVelocity, Kinematic::Tricycle})
     {
@@ -359,6 +357,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
         {
             for (int rep = 0; rep < RANDOM_REPETITIONS; rep++)
             {
+                rng.randomize(1234 + rep);  // for comparable results against diff kin models
+
                 std::cout
                     << "\n"
                        "========================================================================\n"

--- a/mola_state_estimation_smoother/tests/test-navstate-odom-gnss-fusion.cpp
+++ b/mola_state_estimation_smoother/tests/test-navstate-odom-gnss-fusion.cpp
@@ -335,70 +335,75 @@ void run_test(const TestCase& testCase)
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 {
-    int           numErrors          = 0;
+    int numErrors  = 0;
+    int numSuccess = 0;
+
     constexpr int RANDOM_REPETITIONS = 5;
 
     rng.randomize(1234);
 
     // shortcuts:
-    const auto modelCV = Kinematic::ConstantVelocity;
-
-    std::vector<TestCase> tests = {
-        {false, Pose::Identity(), modelCV},
-        {false, Pose::FromTranslation(3.0, 2.0, 1.0), modelCV},
-        {false, Pose::FromXYZYawPitchRoll(1.0, 3.0, 0.5, 30.0_deg, 0.0_deg, 0.0_deg), modelCV},
-        {true, Pose::Identity(), modelCV},
-        {true, Pose::FromTranslation(3.0, 2.0, 1.0), modelCV},
-        {true, Pose::FromXYZYawPitchRoll(1.0, 3.0, 0.5, 30.0_deg, 0.0_deg, 0.0_deg), modelCV},
-    };
-
-    for (const auto& t : tests)
+    for (const auto& kinModel : {Kinematic::ConstantVelocity, Kinematic::Tricycle})
     {
-        for (int rep = 0; rep < RANDOM_REPETITIONS; rep++)
+        std::vector<TestCase> tests = {
+            {false, Pose::Identity(), kinModel},
+            {false, Pose::FromTranslation(3.0, 2.0, 1.0), kinModel},
+            {false, Pose::FromXYZYawPitchRoll(1.0, 3.0, 0.5, 30.0_deg, 0.0_deg, 0.0_deg), kinModel},
+            {true, Pose::Identity(), kinModel},
+            {true, Pose::FromTranslation(3.0, 2.0, 1.0), kinModel},
+            {true, Pose::FromXYZYawPitchRoll(1.0, 3.0, 0.5, 30.0_deg, 0.0_deg, 0.0_deg), kinModel},
+            {true, Pose::FromXYZYawPitchRoll(1.0, 3.0, 0.5, 30.0_deg, 0.0_deg, 0.0_deg), kinModel},
+        };
+
+        for (const auto& t : tests)
         {
-            std::cout
-                << "\n"
-                   "========================================================================\n"
-                   "=== Running "
-                << rep << "/" << RANDOM_REPETITIONS << " test for initial pose: " << t.pose
-                << " Kinematic: " << mrpt::typemeta::enum2str(t.model)
-                << " has_gnss: " << t.has_gnss
-                << "\n"
-                   "========================================================================\n";
+            for (int rep = 0; rep < RANDOM_REPETITIONS; rep++)
+            {
+                std::cout
+                    << "\n"
+                       "========================================================================\n"
+                       "=== Running "
+                    << rep << "/" << RANDOM_REPETITIONS << " test for initial pose: " << t.pose
+                    << " Kinematic: " << mrpt::typemeta::enum2str(t.model)
+                    << " has_gnss: " << t.has_gnss
+                    << "\n"
+                       "========================================================================\n";
 
-            bool failed = true;
-            try
-            {
-                run_test(t);
+                bool failed = true;
+                try
+                {
+                    run_test(t);
 
-                failed = false;
-            }
-            catch (const std::exception& e)
-            {
-                mrpt::system::consoleColorAndStyle(mrpt::system::ConsoleForegroundColor::RED);
-                std::cerr << " ERROR:\n" << e.what() << std::endl;
-                mrpt::system::consoleColorAndStyle(mrpt::system::ConsoleForegroundColor::DEFAULT);
-            }
+                    failed = false;
+                }
+                catch (const std::exception& e)
+                {
+                    mrpt::system::consoleColorAndStyle(mrpt::system::ConsoleForegroundColor::RED);
+                    std::cerr << " ERROR:\n" << e.what() << std::endl;
+                    mrpt::system::consoleColorAndStyle(
+                        mrpt::system::ConsoleForegroundColor::DEFAULT);
+                }
 
-            std::cout
-                << "\n"
-                   "========================================================================\n";
-            if (failed)
-            {
-                numErrors++;
-                std::cout << "❌ FAILED\n";
+                std::cout
+                    << "\n"
+                       "========================================================================\n";
+                if (failed)
+                {
+                    numErrors++;
+                    std::cout << "❌ FAILED\n";
+                }
+                else
+                {
+                    numSuccess++;
+                    std::cout << "✅ SUCCESS\n";
+                }
+                std::cout << "====================================================================="
+                             "===\n\n";
             }
-            else
-            {
-                std::cout << "✅ SUCCESS\n";
-            }
-            std::cout
-                << "========================================================================\n\n";
         }
     }
 
-    std::cout << "\n\n RESULT: ✅ " << (tests.size() * RANDOM_REPETITIONS - numErrors)
-              << " SUCCESS, ❌ " << numErrors << " FAILURES.\n";
+    std::cout << "\n\n RESULT: ✅ " << numSuccess << " SUCCESS, ❌ " << numErrors << " FAILURES.\n";
 
     return numErrors == 0 ? 0 : 1;
 }

--- a/mola_state_estimation_smoother/tests/test-static-gnss-imu-orientation.cpp
+++ b/mola_state_estimation_smoother/tests/test-static-gnss-imu-orientation.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_smoother/tests/test-twist-fusion.cpp
+++ b/mola_state_estimation_smoother/tests/test-twist-fusion.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.

--- a/mola_state_estimation_smoother/tests/test-twist-fusion.cpp
+++ b/mola_state_estimation_smoother/tests/test-twist-fusion.cpp
@@ -37,8 +37,8 @@ namespace
 constexpr double TWIST_NOISE_LINEAR  = 0.05;  // m/s
 constexpr double TWIST_NOISE_ANGULAR = 0.02;  // rad/s
 
-constexpr double MAXIMUM_POSITION_ERROR = 0.80;  // meters
-constexpr double MAXIMUM_VELOCITY_ERROR = 0.30;  // m/s
+constexpr double MAXIMUM_POSITION_ERROR = 0.30;  // meters
+constexpr double MAXIMUM_VELOCITY_ERROR = 0.20;  // m/s
 
 constexpr const char* ODOMETRY_NAME = "odom";
 
@@ -148,6 +148,20 @@ void run_test(const TestCase& testCase)
                   << " wz=" << gtTwist.wz << "\n\n";
     }
 
+    // Apply rotation (exponential map for angular velocity)
+    const auto deltaPose = [&]()
+    {
+        mrpt::math::CVectorFixedDouble<6> delta;
+        delta[0] = gtTwist.vx * T;
+        delta[1] = gtTwist.vy * T;
+        delta[2] = gtTwist.vz * T;
+        delta[3] = gtTwist.wx * T;
+        delta[4] = gtTwist.wy * T;
+        delta[5] = gtTwist.wz * T;
+
+        return mrpt::poses::Lie::SE<3>::exp(delta);
+    }();
+
     for (size_t i = 0; i <= numSteps; i++)
     {
         const double t = T * static_cast<double>(i);
@@ -156,15 +170,8 @@ void run_test(const TestCase& testCase)
         if (i > 0)
         {
             // Simple Euler integration: pose = pose + twist * dt
-            // This is approximate but sufficient for testing
-            const auto deltaPose = mrpt::poses::CPose3D::FromTranslation(
-                gtTwist.vx * T, gtTwist.vy * T, gtTwist.vz * T);
 
-            // Apply rotation (exponential map for angular velocity)
-            const auto deltaRot =
-                mrpt::poses::CPose3D(0, 0, 0, gtTwist.wz * T, gtTwist.wy * T, gtTwist.wx * T);
-
-            currentGtPose = currentGtPose + deltaPose + deltaRot;
+            currentGtPose = currentGtPose + deltaPose;
         }
 
         // 2. Simulate noisy twist observation
@@ -197,21 +204,17 @@ void run_test(const TestCase& testCase)
         // (twist alone doesn't provide absolute position)
         if (i % 5 == 0)
         {
-            mrpt::obs::CObservationOdometry obsOdo;
-            obsOdo.timestamp   = mrpt::Clock::fromDouble(t);
-            obsOdo.sensorLabel = ODOMETRY_NAME;
-
             // Add noise to odometry
             auto noisyPose = currentGtPose;
             noisyPose.x_incr(rng.drawGaussian1D(0, 0.05));
             noisyPose.y_incr(rng.drawGaussian1D(0, 0.05));
             noisyPose.z_incr(rng.drawGaussian1D(0, 0.05));
 
-            obsOdo.odometry        = mrpt::poses::CPose2D(noisyPose);
-            obsOdo.hasEncodersInfo = false;
-            obsOdo.hasVelocities   = false;
+            mrpt::poses::CPose3DPDFGaussian odoPose;
+            odoPose.mean = noisyPose;
+            odoPose.cov.setDiagonal(mrpt::square(0.05));
 
-            stateEst.fuse_odometry(obsOdo, ODOMETRY_NAME);
+            stateEst.fuse_pose(mrpt::Clock::fromDouble(t), odoPose, ODOMETRY_NAME);
         }
 
         // Check estimation periodically
@@ -228,12 +231,14 @@ void run_test(const TestCase& testCase)
                 std::cout << "\n--- Estimation at t=" << t << " ---\n";
                 std::cout << "Estimated pose: " << estimatedPose << "\n";
                 std::cout << "Ground truth pose: " << currentGtPose << "\n";
+                std::cout << "Relative GT pose: " << currentGtPose - gtInitialPose << "\n";
                 std::cout << "Estimated twist: vx=" << estimatedTwist.vx
                           << " vy=" << estimatedTwist.vy << " wz=" << estimatedTwist.wz << "\n";
                 std::cout << "Ground truth twist: vx=" << gtTwist.vx << " vy=" << gtTwist.vy
                           << " wz=" << gtTwist.wz << "\n";
 
-                const auto posError = (estimatedPose.asTPose() - currentGtPose.asTPose()).norm();
+                const auto posError =
+                    (estimatedPose.asTPose() - (currentGtPose - gtInitialPose).asTPose()).norm();
                 const auto velError = std::sqrt(
                     mrpt::square(estimatedTwist.vx - gtTwist.vx) +
                     mrpt::square(estimatedTwist.vy - gtTwist.vy) +
@@ -243,6 +248,15 @@ void run_test(const TestCase& testCase)
                 std::cout << "Velocity error: " << velError << " m/s\n\n";
             }
         }
+    }
+
+    for (const auto& odom_frame : stateEst.known_odometry_frame_ids())
+    {
+        auto T_map_to_odom = stateEst.estimated_T_map_to_odometry_frame(odom_frame);
+        ASSERT_(T_map_to_odom.has_value());
+        std::cout << "T_map_to_odom[" << odom_frame << "]:\n"
+                  << mola::state_estimation_smoother::pose_pdf_to_string_with_sigmas(*T_map_to_odom)
+                  << "\n";
     }
 
     // Final verification
@@ -259,11 +273,13 @@ void run_test(const TestCase& testCase)
         std::cout << "\n=== FINAL RESULTS ===\n";
         std::cout << "Estimated pose: " << estimatedPose << "\n";
         std::cout << "Ground truth pose: " << currentGtPose << "\n";
+        std::cout << "Relative GT pose: " << currentGtPose - gtInitialPose << "\n";
         std::cout << mola::state_estimation_smoother::pose_pdf_to_string_with_sigmas(stateOpt->pose)
                   << "\n";
 
         // Check position error
-        const auto positionError = (estimatedPose.asTPose() - currentGtPose.asTPose()).norm();
+        const auto positionError =
+            (estimatedPose.asTPose() - (currentGtPose - gtInitialPose).asTPose()).norm();
         std::cout << "Position error: " << positionError << " m\n";
         ASSERT_LT_(positionError, MAXIMUM_POSITION_ERROR);
 
@@ -281,6 +297,7 @@ void run_test(const TestCase& testCase)
             mrpt::square(estimatedTwist.wy - gtTwist.wy) +
             mrpt::square(estimatedTwist.wz - gtTwist.wz));
         std::cout << "Angular velocity error: " << angVelError << " rad/s\n";
+        ASSERT_LT_(angVelError, MAXIMUM_VELOCITY_ERROR);
 
         std::cout << "Estimated twist: vx=" << estimatedTwist.vx << " vy=" << estimatedTwist.vy
                   << " vz=" << estimatedTwist.vz << " wx=" << estimatedTwist.wx
@@ -356,6 +373,10 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
         {Pose::FromXYZYawPitchRoll(2.0, 2.0, 3.0, 0.0, 10.0_deg, 5.0_deg),
          Twist(0.5, 0.0, 0.0, 0.2, 0.1, 0.0),  // Forward with pitch/roll rotation
          "3D rotation with forward motion (wx=0.2, wy=0.1)"},
+
+        // Test 14: Vertical motion
+        {Pose::FromXYZYawPitchRoll(0.0, 0.0, 0.0, 0.0, 0.0_deg, .0_deg),
+         Twist(0, 0.0, 0.1, 0.0, 0.0, 0.0), "Pure vertical motion"},
     };
 
     for (size_t testIdx = 0; testIdx < tests.size(); testIdx++)

--- a/mola_state_estimation_smoother/tests/test-twist-fusion.cpp
+++ b/mola_state_estimation_smoother/tests/test-twist-fusion.cpp
@@ -1,0 +1,414 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   test-twist-fusion.cpp
+ * @brief  Unit tests for StateEstimationSmoother twist fusion
+ * @author Jose Luis Blanco Claraco
+ * @date   Dec 10, 2025
+ */
+
+#include <mola_state_estimation_smoother/StateEstimationSmoother.h>
+#include <mola_state_estimation_smoother/pose_pdf_to_string_with_sigmas.h>
+#include <mrpt/core/get_env.h>
+#include <mrpt/math/TTwist3D.h>
+#include <mrpt/poses/CPose3D.h>
+#include <mrpt/random/RandomGenerators.h>
+
+#include <iostream>
+
+using namespace std::string_literals;
+using namespace mrpt::literals;
+
+namespace
+{
+
+constexpr double TWIST_NOISE_LINEAR  = 0.05;  // m/s
+constexpr double TWIST_NOISE_ANGULAR = 0.02;  // rad/s
+
+constexpr double MAXIMUM_POSITION_ERROR = 0.80;  // meters
+constexpr double MAXIMUM_VELOCITY_ERROR = 0.30;  // m/s
+
+constexpr const char* ODOMETRY_NAME = "odom";
+
+const bool VERBOSE = mrpt::get_env<bool>("VERBOSE", false);
+
+const size_t numSteps = 50;
+const double T        = 0.1;  // time step (10 Hz)
+
+auto& rng = mrpt::random::getRandomGenerator();
+
+const char* navStateParams =
+    R"###(# Config for Parameters
+params:
+    # Frame name for the vehicle/robot base
+    vehicle_frame_name: "base_link"
+
+    # Reference frame for pose publication (typically 'map' or 'odom')
+    reference_frame_name: "map"
+
+    max_time_to_use_velocity_model: 2.0
+
+    # ----------------------------------------------------------------------------
+    # Kinematic Model & Motion Factors
+    # ----------------------------------------------------------------------------
+
+    # Kinematic model for internal motion model factors
+    kinematic_model: KinematicModel::ConstantVelocity
+
+    # Time window to keep past observations in the filter [seconds]
+    sliding_window_length: 3.0
+    
+    # Minimum time difference between frames to create a new frame [seconds]
+    min_time_difference_to_create_new_frame: 0.05
+
+    # Random walk model for linear acceleration uncertainty [m/s²]
+    sigma_random_walk_acceleration_linear: 1.0
+
+    # Random walk model for angular acceleration uncertainty [rad/s²]
+    sigma_random_walk_acceleration_angular: 1.0
+
+    # Integrator uncertainty for position [m]
+    sigma_integrator_position: 0.10
+
+    # Integrator uncertainty for orientation [rad]
+    sigma_integrator_orientation: 0.10
+
+    # Twist from consecutive poses uncertainty
+    sigma_twist_from_consecutive_poses_linear: 1.0
+    sigma_twist_from_consecutive_poses_angular: 1.0
+
+    estimate_geo_reference: false
+)###";
+
+using Pose   = mrpt::poses::CPose3D;
+using Twist  = mrpt::math::TTwist3D;
+using Twist2 = mrpt::math::TTwist2D;
+
+struct TestCase
+{
+    Pose        initial_pose;
+    Twist       constant_twist;  // Ground truth constant twist
+    std::string description;
+};
+
+// Test: Simulate a vehicle moving with constant twist (linear and angular velocities).
+// Fuse twist observations and verify the estimator can recover the trajectory.
+//
+void run_test(const TestCase& testCase)
+{
+    mola::state_estimation_smoother::StateEstimationSmoother stateEst;
+
+    if (VERBOSE)
+    {
+        stateEst.setMinLoggingLevel(mrpt::system::LVL_DEBUG);
+    }
+    stateEst.profiler_.enable();
+
+    {
+        auto cfgYaml = mrpt::containers::yaml::FromText(navStateParams);
+        stateEst.initialize(cfgYaml);
+    }
+
+    const auto gtInitialPose = testCase.initial_pose;
+    const auto gtTwist       = testCase.constant_twist;
+
+    // Current ground truth pose
+    mrpt::poses::CPose3D currentGtPose = gtInitialPose;
+
+    // Link the "map" frame with "odom" for this example
+    {
+        auto map2odom_cov = mrpt::math::CMatrixDouble66::Identity();
+        map2odom_cov *= 1e-6;
+
+        stateEst.fuse_pose(
+            mrpt::Clock::fromDouble(0),
+            mrpt::poses::CPose3DPDFGaussian(mrpt::poses::CPose3D::Identity(), map2odom_cov),
+            stateEst.parameters().reference_frame_name);
+    }
+
+    if (VERBOSE)
+    {
+        std::cout << "\n=== Test Configuration ===\n";
+        std::cout << "Description: " << testCase.description << "\n";
+        std::cout << "Initial pose: " << gtInitialPose << "\n";
+        std::cout << "Constant twist: vx=" << gtTwist.vx << " vy=" << gtTwist.vy
+                  << " vz=" << gtTwist.vz << " wx=" << gtTwist.wx << " wy=" << gtTwist.wy
+                  << " wz=" << gtTwist.wz << "\n\n";
+    }
+
+    for (size_t i = 0; i <= numSteps; i++)
+    {
+        const double t = T * static_cast<double>(i);
+
+        // 1. Update ground truth pose by integrating twist
+        if (i > 0)
+        {
+            // Simple Euler integration: pose = pose + twist * dt
+            // This is approximate but sufficient for testing
+            const auto deltaPose = mrpt::poses::CPose3D::FromTranslation(
+                gtTwist.vx * T, gtTwist.vy * T, gtTwist.vz * T);
+
+            // Apply rotation (exponential map for angular velocity)
+            const auto deltaRot =
+                mrpt::poses::CPose3D(0, 0, 0, gtTwist.wz * T, gtTwist.wy * T, gtTwist.wx * T);
+
+            currentGtPose = currentGtPose + deltaPose + deltaRot;
+        }
+
+        // 2. Simulate noisy twist observation
+        {
+            mrpt::math::TTwist3D noisyTwist;
+            noisyTwist.vx = gtTwist.vx + rng.drawGaussian1D(0, TWIST_NOISE_LINEAR);
+            noisyTwist.vy = gtTwist.vy + rng.drawGaussian1D(0, TWIST_NOISE_LINEAR);
+            noisyTwist.vz = gtTwist.vz + rng.drawGaussian1D(0, TWIST_NOISE_LINEAR);
+            noisyTwist.wx = gtTwist.wx + rng.drawGaussian1D(0, TWIST_NOISE_ANGULAR);
+            noisyTwist.wy = gtTwist.wy + rng.drawGaussian1D(0, TWIST_NOISE_ANGULAR);
+            noisyTwist.wz = gtTwist.wz + rng.drawGaussian1D(0, TWIST_NOISE_ANGULAR);
+
+            // Twist covariance matrix (6x6)
+            mrpt::math::CMatrixDouble66 twistCov;
+            twistCov.setIdentity();
+            twistCov(0, 0) = twistCov(1, 1) = twistCov(2, 2) = mrpt::square(TWIST_NOISE_LINEAR);
+            twistCov(3, 3) = twistCov(4, 4) = twistCov(5, 5) = mrpt::square(TWIST_NOISE_ANGULAR);
+
+            // Fuse twist observation
+            stateEst.fuse_twist(mrpt::Clock::fromDouble(t), noisyTwist, twistCov);
+
+            if (VERBOSE && i % 10 == 0)
+            {
+                std::cout << "t=" << t << " Twist: vx=" << noisyTwist.vx << " vy=" << noisyTwist.vy
+                          << " wz=" << noisyTwist.wz << "\n";
+            }
+        }
+
+        // 3. Optionally add some odometry to help with pose estimation
+        // (twist alone doesn't provide absolute position)
+        if (i % 5 == 0)
+        {
+            mrpt::obs::CObservationOdometry obsOdo;
+            obsOdo.timestamp   = mrpt::Clock::fromDouble(t);
+            obsOdo.sensorLabel = ODOMETRY_NAME;
+
+            // Add noise to odometry
+            auto noisyPose = currentGtPose;
+            noisyPose.x_incr(rng.drawGaussian1D(0, 0.05));
+            noisyPose.y_incr(rng.drawGaussian1D(0, 0.05));
+            noisyPose.z_incr(rng.drawGaussian1D(0, 0.05));
+
+            obsOdo.odometry        = mrpt::poses::CPose2D(noisyPose);
+            obsOdo.hasEncodersInfo = false;
+            obsOdo.hasVelocities   = false;
+
+            stateEst.fuse_odometry(obsOdo, ODOMETRY_NAME);
+        }
+
+        // Check estimation periodically
+        if (i > 0 && i % 10 == 0)
+        {
+            const auto stateOpt = stateEst.estimated_navstate(
+                mrpt::Clock::fromDouble(t), stateEst.parameters().reference_frame_name);
+
+            if (stateOpt && VERBOSE)
+            {
+                const auto estimatedPose  = stateOpt->pose.mean;
+                const auto estimatedTwist = stateOpt->twist;
+
+                std::cout << "\n--- Estimation at t=" << t << " ---\n";
+                std::cout << "Estimated pose: " << estimatedPose << "\n";
+                std::cout << "Ground truth pose: " << currentGtPose << "\n";
+                std::cout << "Estimated twist: vx=" << estimatedTwist.vx
+                          << " vy=" << estimatedTwist.vy << " wz=" << estimatedTwist.wz << "\n";
+                std::cout << "Ground truth twist: vx=" << gtTwist.vx << " vy=" << gtTwist.vy
+                          << " wz=" << gtTwist.wz << "\n";
+
+                const auto posError = (estimatedPose.asTPose() - currentGtPose.asTPose()).norm();
+                const auto velError = std::sqrt(
+                    mrpt::square(estimatedTwist.vx - gtTwist.vx) +
+                    mrpt::square(estimatedTwist.vy - gtTwist.vy) +
+                    mrpt::square(estimatedTwist.vz - gtTwist.vz));
+
+                std::cout << "Position error: " << posError << " m\n";
+                std::cout << "Velocity error: " << velError << " m/s\n\n";
+            }
+        }
+    }
+
+    // Final verification
+    const double last_t = T * static_cast<double>(numSteps);
+    {
+        const auto stateOpt = stateEst.estimated_navstate(
+            mrpt::Clock::fromDouble(last_t), stateEst.parameters().reference_frame_name);
+
+        ASSERT_(stateOpt.has_value());
+
+        const auto estimatedPose  = stateOpt->pose.mean;
+        const auto estimatedTwist = stateOpt->twist;
+
+        std::cout << "\n=== FINAL RESULTS ===\n";
+        std::cout << "Estimated pose: " << estimatedPose << "\n";
+        std::cout << "Ground truth pose: " << currentGtPose << "\n";
+        std::cout << mola::state_estimation_smoother::pose_pdf_to_string_with_sigmas(stateOpt->pose)
+                  << "\n";
+
+        // Check position error
+        const auto positionError = (estimatedPose.asTPose() - currentGtPose.asTPose()).norm();
+        std::cout << "Position error: " << positionError << " m\n";
+        ASSERT_LT_(positionError, MAXIMUM_POSITION_ERROR);
+
+        // Check velocity error
+        const auto velocityError = std::sqrt(
+            mrpt::square(estimatedTwist.vx - gtTwist.vx) +
+            mrpt::square(estimatedTwist.vy - gtTwist.vy) +
+            mrpt::square(estimatedTwist.vz - gtTwist.vz));
+        std::cout << "Linear velocity error: " << velocityError << " m/s\n";
+        ASSERT_LT_(velocityError, MAXIMUM_VELOCITY_ERROR);
+
+        // Check angular velocity error
+        const auto angVelError = std::sqrt(
+            mrpt::square(estimatedTwist.wx - gtTwist.wx) +
+            mrpt::square(estimatedTwist.wy - gtTwist.wy) +
+            mrpt::square(estimatedTwist.wz - gtTwist.wz));
+        std::cout << "Angular velocity error: " << angVelError << " rad/s\n";
+
+        std::cout << "Estimated twist: vx=" << estimatedTwist.vx << " vy=" << estimatedTwist.vy
+                  << " vz=" << estimatedTwist.vz << " wx=" << estimatedTwist.wx
+                  << " wy=" << estimatedTwist.wy << " wz=" << estimatedTwist.wz << "\n";
+        std::cout << "Ground truth twist: vx=" << gtTwist.vx << " vy=" << gtTwist.vy
+                  << " vz=" << gtTwist.vz << " wx=" << gtTwist.wx << " wy=" << gtTwist.wy
+                  << " wz=" << gtTwist.wz << "\n";
+    }
+}
+
+}  // namespace
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+    int           numErrors          = 0;
+    constexpr int RANDOM_REPETITIONS = 3;
+
+    rng.randomize(9876);
+
+    // Define test cases with different motion patterns
+    std::vector<TestCase> tests = {
+        // Test 1: Pure forward motion (no rotation)
+        {Pose::Identity(), Twist(1.0, 0.0, 0.0, 0.0, 0.0, 0.0),  // 1 m/s forward
+         "Pure forward motion (1 m/s)"},
+
+        // Test 2: Forward motion with yaw rotation (circular motion)
+        {Pose::Identity(), Twist(1.5, 0.0, 0.0, 0.0, 0.0, 0.5),  // 1.5 m/s forward, 0.5 rad/s yaw
+         "Circular motion (1.5 m/s forward, 0.5 rad/s yaw)"},
+
+        // Test 3: Lateral motion (sideways)
+        {Pose::FromXYZYawPitchRoll(2.0, 3.0, 0.0, 45.0_deg, 0.0, 0.0),
+         Twist(0.0, 0.8, 0.0, 0.0, 0.0, 0.0),  // 0.8 m/s lateral
+         "Lateral motion (0.8 m/s sideways)"},
+
+        // Test 4: Combined forward and lateral motion
+        {Pose::Identity(), Twist(1.0, 0.5, 0.0, 0.0, 0.0, 0.0),  // 1 m/s forward, 0.5 m/s lateral
+         "Combined forward+lateral motion"},
+
+        // Test 5: Forward motion with vertical component
+        {Pose::FromTranslation(1.0, 2.0, 5.0),
+         Twist(1.2, 0.0, 0.3, 0.0, 0.0, 0.0),  // 1.2 m/s forward, 0.3 m/s up
+         "Forward motion with climb (vz=0.3)"},
+
+        // Test 6: Rotation in place (pure yaw)
+        {Pose::FromXYZYawPitchRoll(5.0, 5.0, 0.0, 30.0_deg, 0.0, 0.0),
+         Twist(0.0, 0.0, 0.0, 0.0, 0.0, 0.8),  // 0.8 rad/s yaw only
+         "Rotation in place (pure yaw, 0.8 rad/s)"},
+
+        // Test 7: Complex 3D motion
+        {Pose::FromXYZYawPitchRoll(3.0, 4.0, 2.0, 60.0_deg, 5.0_deg, 0.0),
+         Twist(1.0, 0.3, 0.2, 0.1, 0.05, 0.3),  // All components
+         "Complex 3D motion (all velocity components)"},
+
+        // Test 8: Slow motion
+        {Pose::Identity(), Twist(0.2, 0.0, 0.0, 0.0, 0.0, 0.1),  // Slow: 0.2 m/s, 0.1 rad/s
+         "Slow motion (0.2 m/s forward, 0.1 rad/s yaw)"},
+
+        // Test 9: Fast motion with tight turn
+        {Pose::FromXYZYawPitchRoll(10.0, 5.0, 1.0, -30.0_deg, 0.0, 0.0),
+         Twist(2.5, 0.0, 0.0, 0.0, 0.0, 1.2),  // 2.5 m/s forward, 1.2 rad/s yaw
+         "Fast motion with tight turn (2.5 m/s, 1.2 rad/s)"},
+
+        // Test 10: Backward motion
+        {Pose::FromTranslation(8.0, 6.0, 0.5),
+         Twist(-0.8, 0.0, 0.0, 0.0, 0.0, 0.0),  // -0.8 m/s (backward)
+         "Backward motion (-0.8 m/s)"},
+
+        // Test 11: Crabbing motion (diagonal)
+        {Pose::Identity(), Twist(0.7, 0.7, 0.0, 0.0, 0.0, 0.0),  // Diagonal motion
+         "Crabbing/diagonal motion (vx=vy=0.7)"},
+
+        // Test 12: 3D rotation (pitch and roll)
+        {Pose::FromXYZYawPitchRoll(2.0, 2.0, 3.0, 0.0, 10.0_deg, 5.0_deg),
+         Twist(0.5, 0.0, 0.0, 0.2, 0.1, 0.0),  // Forward with pitch/roll rotation
+         "3D rotation with forward motion (wx=0.2, wy=0.1)"},
+    };
+
+    for (size_t testIdx = 0; testIdx < tests.size(); testIdx++)
+    {
+        const auto& t = tests[testIdx];
+
+        for (int rep = 0; rep < RANDOM_REPETITIONS; rep++)
+        {
+            std::cout
+                << "\n"
+                   "========================================================================\n"
+                   "=== Running test "
+                << (testIdx + 1) << "/" << tests.size() << " rep " << rep << "/"
+                << RANDOM_REPETITIONS << "\n"
+                << "=== " << t.description << "\n"
+                << "=== Initial pose: " << t.initial_pose << "\n"
+                << "=== Constant twist: vx=" << t.constant_twist.vx << " vy=" << t.constant_twist.vy
+                << " vz=" << t.constant_twist.vz << " wx=" << t.constant_twist.wx
+                << " wy=" << t.constant_twist.wy << " wz=" << t.constant_twist.wz << "\n"
+                << "========================================================================\n";
+
+            bool failed = true;
+            try
+            {
+                run_test(t);
+                failed = false;
+            }
+            catch (const std::exception& e)
+            {
+                mrpt::system::consoleColorAndStyle(mrpt::system::ConsoleForegroundColor::RED);
+                std::cerr << " ERROR:\n" << e.what() << std::endl;
+                mrpt::system::consoleColorAndStyle(mrpt::system::ConsoleForegroundColor::DEFAULT);
+            }
+
+            std::cout
+                << "\n"
+                   "========================================================================\n";
+            if (failed)
+            {
+                numErrors++;
+                std::cout << "❌ FAILED\n";
+            }
+            else
+            {
+                std::cout << "✅ SUCCESS\n";
+            }
+            std::cout
+                << "========================================================================\n\n";
+        }
+    }
+
+    std::cout << "\n\n RESULT: ✅ " << (tests.size() * RANDOM_REPETITIONS - numErrors)
+              << " SUCCESS, ❌ " << numErrors << " FAILURES.\n";
+
+    return numErrors == 0 ? 0 : 1;
+}

--- a/mola_state_estimation_smoother/tests/test-twist-fusion.cpp
+++ b/mola_state_estimation_smoother/tests/test-twist-fusion.cpp
@@ -374,7 +374,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
          Twist(0.5, 0.0, 0.0, 0.2, 0.1, 0.0),  // Forward with pitch/roll rotation
          "3D rotation with forward motion (wx=0.2, wy=0.1)"},
 
-        // Test 14: Vertical motion
+        // Test 13: Vertical motion
         {Pose::FromXYZYawPitchRoll(0.0, 0.0, 0.0, 0.0, 0.0_deg, .0_deg),
          Twist(0, 0.0, 0.1, 0.0, 0.0, 0.0), "Pure vertical motion"},
     };

--- a/mola_state_estimation_smoother/tests/test-two-odometries.cpp
+++ b/mola_state_estimation_smoother/tests/test-two-odometries.cpp
@@ -4,7 +4,7 @@
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
 |_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
 
- Copyright (C) 2018-2025 Jose Luis Blanco, University of Almeria,
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
                          and individual contributors.
  SPDX-License-Identifier: GPL-3.0
  See LICENSE for full license information.


### PR DESCRIPTION
- [x] Finish the implementation of the alternative tricycle motion model factors.
- [x] Add unit tests.
- [x] Update docs to explain how to select the kinematic model. 
- [x] Update mola_lidar_odometry package's files to allow users selecting this, by env var and by ros2 launch arg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tricycle-kinematics factor and API support, ROS2-ready launch/config and a smoother YAML, plus optional runtime visualization.

* **Tests**
  * Added comprehensive twist‑fusion test and test target; expanded kinematic-model tests with repeated runs and improved reporting.

* **Chores**
  * Updated copyright years, ROS2 packaging/build metadata, resource installation, and added new configs/launch files.

* **Style**
  * Minor lint/config formatting and clang‑tidy cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->