### PR TITLE
Publish geo-ref on convergence

### DIFF
--- a/docs/mola_state_estimators.rst
+++ b/docs/mola_state_estimators.rst
@@ -28,6 +28,30 @@ What? Why? How?
 
 2. Selecting the S.E. method in launch files
 ------------------------------------------------
+
+2.1. Launching the state estimator standalone
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Next we show different possible use cases.
+
+.. dropdown:: Merging GNSS + IMU
+   :icon: code-review
+
+
+    .. code-block:: bash
+
+      #MOLA_VERBOSITY_BRIDGE_ROS2=DEBUG \
+      #MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR=DEBUG \
+
+      ros2 launch mola_state_estimation_smoother ros2-state-estimator.launch.py \
+        imu_topic_name:=imu \
+        gnss_topic_name:=gps1
+
+
+|
+
+2.2. Launching the state estimator + LO/LIO
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In the context of launching LiDAR odometry (LO) mapping or localization
 as explained :ref:`here <launching_mola_lo>`, note that default configurations
 include ``StateEstimationSimple`` as the method of choice, but it can be 

--- a/docs/mola_state_estimators.rst
+++ b/docs/mola_state_estimators.rst
@@ -40,10 +40,11 @@ Next we show different possible use cases.
 
     .. code-block:: bash
 
-      #MOLA_VERBOSITY_BRIDGE_ROS2=DEBUG \
-      #MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR=DEBUG \
+      # MOLA_VERBOSITY_BRIDGE_ROS2=DEBUG \
+      # MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR=DEBUG \
 
       ros2 launch mola_state_estimation_smoother ros2-state-estimator.launch.py \
+        estimate_geo_reference:=True \
         imu_topic_name:=imu \
         gnss_topic_name:=gps1
 

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/Parameters.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/Parameters.h
@@ -25,8 +25,6 @@
 #include <mrpt/math/TPoint3D.h>
 #include <mrpt/math/TTwist3D.h>
 
-#include <regex>
-
 namespace mola::state_estimation_simple
 {
 /** Parameters needed by StateEstimationSimple.
@@ -57,14 +55,14 @@ class Parameters
 
     bool enforce_planar_motion = false;
 
-    //!< regex for IMU sensor labels (ROS topics) to accept as IMU readings.
-    std::regex do_process_imu_labels_re{".*"};
+    /// regex for IMU sensor labels (ROS topics) to accept as IMU readings.
+    std::string do_process_imu_labels_re = ".*";
 
-    //!< regex for odometry inputs labels (ROS topics) to be accepted as inputs
-    std::regex do_process_odometry_labels_re{".*"};
+    /// regex for odometry inputs labels (ROS topics) to be accepted as inputs
+    std::string do_process_odometry_labels_re = ".*";
 
-    //!< regex for GNSS (GPS) labels (ROS topics) to be accepted as inputs
-    std::regex do_process_gnss_labels_re{".*"};
+    /// regex for GNSS (GPS) labels (ROS topics) to be accepted as inputs
+    std::string do_process_gnss_labels_re = ".*";
 };
 
 }  // namespace mola::state_estimation_simple

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/RegexCache.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/RegexCache.h
@@ -1,0 +1,53 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+// TODO: Remove from this package once  mola_kernel 2.5.0 is out.
+
+/**
+ * @file   RegexCache.h
+ * @brief  Cached regular expression
+ * @author Jose Luis Blanco Claraco
+ * @date   Jan 29, 2026
+ */
+#pragma once
+
+#include <optional>
+#include <regex>
+#include <string>
+
+namespace mola
+{
+
+/** Holds a reference to a cached regex. Recompiles only if the expression changed.
+ */
+class RegexCache
+{
+   public:
+    // Returns a reference to a cached regex. Recompiles only if the expression changed.
+    const std::regex& get_regex(const std::string& regExpression)
+    {
+        if (!cachedRegex_ || regExpression != cachedExpression_)
+        {
+            cachedExpression_ = regExpression;
+            cachedRegex_.emplace(cachedExpression_, std::regex::ECMAScript);
+        }
+        return *cachedRegex_;
+    }
+
+   private:
+    std::string               cachedExpression_;
+    std::optional<std::regex> cachedRegex_;
+};
+
+}  // namespace mola

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
@@ -124,7 +124,6 @@ class StateEstimationSimple : public mola::NavStateFilter
 
     /** @} */
 
-   protected:
     // Implementation of RawDataConsumer
     void onNewObservation(const CObservation::ConstPtr& o) override;
 

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
@@ -122,11 +122,7 @@ class StateEstimationSimple : public mola::NavStateFilter
 
    protected:
     // Implementation of RawDataConsumer
-#if MOLA_VERSION_CHECK(2, 1, 0)
     void onNewObservation(const CObservation::ConstPtr& o) override;
-#else
-    void onNewObservation(const CObservation::Ptr& o) override;
-#endif
 
    private:
     struct State

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
@@ -20,9 +20,13 @@
  */
 #pragma once
 
+// This package
+#include <mola_state_estimation_simple/Parameters.h>
+#include <mola_state_estimation_simple/RegexCache.h>
+
+// MOLA
 #include <mola_kernel/interfaces/NavStateFilter.h>
 #include <mola_kernel/version.h>
-#include <mola_state_estimation_simple/Parameters.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/optional_ref.h>
 #include <mrpt/obs/CObservationGPS.h>
@@ -135,6 +139,11 @@ class StateEstimationSimple : public mola::NavStateFilter
         std::optional<mrpt::math::TTwist3D>            last_twist;
         std::optional<mrpt::math::CMatrixDouble66>     last_twist_cov;
         bool                                           pose_already_updated_with_odom = false;
+
+        // To be built from parameters strings when changed.
+        RegexCache do_process_imu_labels_re;
+        RegexCache do_process_odometry_labels_re;
+        RegexCache do_process_gnss_labels_re;
     };
 
     State                        state_;

--- a/mola_state_estimation_simple/src/Parameters.cpp
+++ b/mola_state_estimation_simple/src/Parameters.cpp
@@ -38,22 +38,9 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
 
     MCP_LOAD_OPT(cfg, enforce_planar_motion);
 
-    {
-        std::string do_process_imu_labels;
-        MCP_LOAD_OPT(cfg, do_process_imu_labels);
-        do_process_imu_labels_re = do_process_imu_labels;
-    }
-
-    {
-        std::string do_process_odometry_labels;
-        MCP_LOAD_OPT(cfg, do_process_odometry_labels);
-        do_process_odometry_labels_re = do_process_odometry_labels;
-    }
-    {
-        std::string do_process_gnss_labels;
-        MCP_LOAD_OPT(cfg, do_process_gnss_labels);
-        do_process_gnss_labels_re = do_process_gnss_labels;
-    }
+    MCP_LOAD_OPT(cfg, do_process_imu_labels_re);
+    MCP_LOAD_OPT(cfg, do_process_odometry_labels_re);
+    MCP_LOAD_OPT(cfg, do_process_gnss_labels_re);
 
     if (cfg.has("initial_twist"))
     {

--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -354,22 +354,51 @@ void StateEstimationSimple::onNewObservation(const CObservation::ConstPtr& o)
                                             << o->GetRuntimeClass()->className);
 
     // IMU:
-    if (auto obsIMU = std::dynamic_pointer_cast<const mrpt::obs::CObservationIMU>(o);
-        obsIMU && std::regex_match(o->sensorLabel, params.do_process_imu_labels_re))
+    if (auto obsIMU = std::dynamic_pointer_cast<const mrpt::obs::CObservationIMU>(o); obsIMU)
     {
-        this->fuse_imu(*obsIMU);
+        if (std::regex_match(
+                o->sensorLabel,
+                state_.do_process_imu_labels_re.get_regex(params.do_process_imu_labels_re)))
+        {
+            this->fuse_imu(*obsIMU);
+        }
+        else
+        {
+            MRPT_LOG_DEBUG_FMT(
+                "Skipping IMU reading labeled '%s' for not passing regex", o->sensorLabel.c_str());
+        }
     }
     // Odometry source:
     else if (auto obsOdom = std::dynamic_pointer_cast<const mrpt::obs::CObservationOdometry>(o);
-             obsOdom && std::regex_match(o->sensorLabel, params.do_process_odometry_labels_re))
+             obsOdom)
     {
-        this->fuse_odometry(*obsOdom, o->sensorLabel);
+        if (std::regex_match(
+                o->sensorLabel, state_.do_process_odometry_labels_re.get_regex(
+                                    params.do_process_odometry_labels_re)))
+        {
+            this->fuse_odometry(*obsOdom, o->sensorLabel);
+        }
+        else
+        {
+            MRPT_LOG_DEBUG_FMT(
+                "Skipping odometry reading labeled '%s' for not passing regex",
+                o->sensorLabel.c_str());
+        }
     }
     // GNSS source:
-    else if (auto obsGPS = std::dynamic_pointer_cast<const mrpt::obs::CObservationGPS>(o);
-             obsGPS && std::regex_match(o->sensorLabel, params.do_process_odometry_labels_re))
+    else if (auto obsGPS = std::dynamic_pointer_cast<const mrpt::obs::CObservationGPS>(o); obsGPS)
     {
-        this->fuse_gnss(*obsGPS);
+        if (std::regex_match(
+                o->sensorLabel,
+                state_.do_process_gnss_labels_re.get_regex(params.do_process_gnss_labels_re)))
+        {
+            this->fuse_gnss(*obsGPS);
+        }
+        else
+        {
+            MRPT_LOG_DEBUG_FMT(
+                "Skipping GNSS reading labeled '%s' for not passing regex", o->sensorLabel.c_str());
+        }
     }
     else
     {

--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -341,11 +341,7 @@ std::optional<NavState> StateEstimationSimple::estimated_navstate(
     return ret;
 }
 
-#if MOLA_VERSION_CHECK(2, 1, 0)
 void StateEstimationSimple::onNewObservation(const CObservation::ConstPtr& o)
-#else
-void StateEstimationSimple::onNewObservation(const CObservation::Ptr& o)
-#endif
 {
     auto lck = std::scoped_lock(state_mtx_);
 

--- a/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
+++ b/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
@@ -132,7 +132,10 @@ void test_odometry_fusion()
         mrpt::obs::CObservationOdometry odom;
         odom.timestamp = mrpt::Clock::fromDouble(1.0);
         odom.odometry  = mrpt::poses::CPose2D(1.0, 0, 0);  // 1m forward
-        estimator.fuse_odometry(odom);
+
+        // Could be: estimator.fuse_odometry(odom);
+        // But let's test the RawDataConsumer API:
+        estimator.onNewObservation(std::make_shared<const mrpt::obs::CObservationOdometry>(odom));
     }
 
     // Check: Current state should reflect the odometry increment
@@ -173,7 +176,9 @@ void test_imu_angular_velocity()
         imu.set(mrpt::obs::IMU_WY, 0.0);
         imu.set(mrpt::obs::IMU_WZ, 1.0);  // 1 rad/s
         imu.sensorPose = mrpt::poses::CPose3D::Identity();  // IMU aligned with body
-        estimator.fuse_imu(imu);
+
+        // Could be also: estimator.fuse_imu(imu);
+        estimator.onNewObservation(std::make_shared<const mrpt::obs::CObservationIMU>(imu));
     }
 
     // Check if twist was updated

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
@@ -171,6 +171,21 @@ class Parameters
      */
     std::optional<mola::Georeferencing> fixed_geo_reference;
 
+    /** Maximum position sigma (in meters) to consider state estimation converged.
+     *  Used when other modules query `has_converged_localization()`.
+     */
+    double convergence_max_position_sigma = 1.0;  // [m]
+
+    /** Maximum orientation sigma (in degrees) to consider state estimation converged.
+     *  Used when other modules query `has_converged_localization()`.
+     */
+    double convergence_max_orientation_sigma_deg = 5.0;  // [deg]
+
+    /** If true and estimate_geo_reference is true, once converged, this module
+     *  will publish the estimated geo-referencing via MapSourceBase.
+     */
+    bool publish_estimated_georef_on_convergence = true;
+
     /** @} */
 
     /** @name Nonlinear optimization

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
@@ -27,8 +27,6 @@
 #include <mrpt/math/TTwist3D.h>
 #include <mrpt/typemeta/TEnumType.h>
 
-#include <regex>
-
 namespace mola::state_estimation_smoother
 {
 
@@ -173,11 +171,13 @@ class Parameters
 
     /** Maximum position sigma (in meters) to consider state estimation converged.
      *  Used when other modules query `has_converged_localization()`.
+     *  This applies to both, the `map->base_link` and `enu->map` poses.
      */
     double convergence_max_position_sigma = 1.0;  // [m]
 
     /** Maximum orientation sigma (in degrees) to consider state estimation converged.
      *  Used when other modules query `has_converged_localization()`.
+     *  This applies to both, the `map->base_link` and `enu->map` poses.
      */
     double convergence_max_orientation_sigma_deg = 5.0;  // [deg]
 
@@ -200,14 +200,14 @@ class Parameters
     /** @name Sensor input names
      * @{  */
 
-    //!< regex for IMU sensor labels (ROS topics) to accept as IMU readings.
-    std::regex do_process_imu_labels_re{".*"};
+    /// regex for IMU sensor labels (ROS topics) to accept as IMU readings.
+    std::string do_process_imu_labels_re = ".*";
 
-    //!< regex for odometry inputs labels (ROS topics) to be accepted as inputs
-    std::regex do_process_odometry_labels_re{".*"};
+    /// regex for odometry inputs labels (ROS topics) to be accepted as inputs
+    std::string do_process_odometry_labels_re = ".*";
 
-    //!< regex for GNSS (GPS) labels (ROS topics) to be accepted as inputs
-    std::regex do_process_gnss_labels_re{".*"};
+    /// regex for GNSS (GPS) labels (ROS topics) to be accepted as inputs
+    std::string do_process_gnss_labels_re = ".*";
 
     /** @} */
 

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/RegexCache.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/RegexCache.h
@@ -1,0 +1,53 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+// TODO: Remove from this package once  mola_kernel 2.5.0 is out.
+
+/**
+ * @file   RegexCache.h
+ * @brief  Cached regular expression
+ * @author Jose Luis Blanco Claraco
+ * @date   Jan 29, 2026
+ */
+#pragma once
+
+#include <optional>
+#include <regex>
+#include <string>
+
+namespace mola
+{
+
+/** Holds a reference to a cached regex. Recompiles only if the expression changed.
+ */
+class RegexCache
+{
+   public:
+    // Returns a reference to a cached regex. Recompiles only if the expression changed.
+    const std::regex& get_regex(const std::string& regExpression)
+    {
+        if (!cachedRegex_ || regExpression != cachedExpression_)
+        {
+            cachedExpression_ = regExpression;
+            cachedRegex_.emplace(cachedExpression_, std::regex::ECMAScript);
+        }
+        return *cachedRegex_;
+    }
+
+   private:
+    std::string               cachedExpression_;
+    std::optional<std::regex> cachedRegex_;
+};
+
+}  // namespace mola

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -23,6 +23,7 @@
 // this package:
 #include <mola_gtsam_factors/id.h>
 #include <mola_kernel/interfaces/LocalizationSourceBase.h>
+#include <mola_kernel/interfaces/MapSourceBase.h>
 #include <mola_kernel/interfaces/NavStateFilter.h>
 #include <mola_kernel/interfaces/RawDataSourceBase.h>
 #include <mola_kernel/interfaces/VizInterface.h>
@@ -104,7 +105,10 @@ namespace mola::state_estimation_smoother
  *
  * \ingroup mola_state_estimation_grp
  */
-class StateEstimationSmoother : public mola::NavStateFilter, public mola::LocalizationSourceBase
+class StateEstimationSmoother : public mola::NavStateFilter,
+                                public mola::LocalizationSourceBase,
+                                public mola::MapSourceBase
+
 {
     DEFINE_MRPT_OBJECT(StateEstimationSmoother, mola::state_estimation_smoother)
    private:
@@ -181,6 +185,13 @@ class StateEstimationSmoother : public mola::NavStateFilter, public mola::Locali
     /// Gets the latest estimated transform of "T_map_to_odometry_frame_i", by frame ID name.
     [[nodiscard]] std::optional<mrpt::poses::CPose3DPDFGaussian> estimated_T_map_to_odometry_frame(
         const std::string& frame_id) const;
+
+    /// Implements NavStateFilter::has_converged_localization
+    [[nodiscard]] bool has_converged_localization(
+        mrpt::poses::CPose3DPDFGaussian& pose) const override;
+
+    /// Returns the current georeferencing, if available
+    [[nodiscard]] std::optional<mola::Georeferencing> current_georeferencing() const;
 
     /** @} */
 
@@ -264,6 +275,9 @@ class StateEstimationSmoother : public mola::NavStateFilter, public mola::Locali
 
         /// Will be populated with the first GNSS coords when in active estimation mode.
         std::optional<mrpt::topography::TGeodeticCoords> tentative_geo_coord_reference;
+
+        /// Flag to track if we've already published the estimated geo-ref
+        bool estimated_georef_published = false;
     };
 
     State                state_;
@@ -290,6 +304,8 @@ class StateEstimationSmoother : public mola::NavStateFilter, public mola::Locali
     /// Delete out-of-window entries in stamp2frame_index and last_estimated_state
     void delete_too_old_entries();
 
+    void publishEstimatedGeoreferencing();
+
     using pair_nearby_frame_iterators_t = std::pair<
         std::map<mrpt::Clock::time_point, frame_index_t>::const_iterator,
         std::map<mrpt::Clock::time_point, frame_index_t>::const_iterator>;
@@ -307,9 +323,6 @@ class StateEstimationSmoother : public mola::NavStateFilter, public mola::Locali
 
     /// Gets the latest state of a pose wrt the reference frame ("map")
     [[nodiscard]] NavState get_latest_state_and_covariance(const frame_index_t idx) const;
-
-    /// Gets the latest estimated transform of T_enu_to_map
-    [[nodiscard]] std::optional<mrpt::poses::CPose3DPDFGaussian> get_estimated_T_enu_to_map() const;
 
     /// Gets the latest estimated transform of "T_map_to_odometry_frame_i", by frame ID name.
     [[nodiscard]] std::optional<mrpt::poses::CPose3DPDFGaussian>

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -197,11 +197,7 @@ class StateEstimationSmoother : public mola::NavStateFilter,
 
    protected:
     // Implementation of RawDataConsumer
-#if MOLA_VERSION_CHECK(2, 1, 0)
     void onNewObservation(const CObservation::ConstPtr& o) override;
-#else
-    void onNewObservation(const CObservation::Ptr& o) override;
-#endif
 
    private:
     Parameters params_;

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -199,7 +199,6 @@ class StateEstimationSmoother : public mola::NavStateFilter,
 
     /** @} */
 
-   protected:
     // Implementation of RawDataConsumer
     void onNewObservation(const CObservation::ConstPtr& o) override;
 

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -29,6 +29,7 @@
 #include <mola_kernel/interfaces/VizInterface.h>
 #include <mola_kernel/version.h>
 #include <mola_state_estimation_smoother/Parameters.h>
+#include <mola_state_estimation_smoother/RegexCache.h>
 
 // MOLA:
 #include <mola_imu_preintegration/ImuIntegrator.h>
@@ -187,8 +188,11 @@ class StateEstimationSmoother : public mola::NavStateFilter,
         const std::string& frame_id) const;
 
     /// Implements NavStateFilter::has_converged_localization
-    [[nodiscard]] bool has_converged_localization(
-        mrpt::poses::CPose3DPDFGaussian& pose) const override;
+    [[nodiscard]] bool has_converged_localization(mrpt::poses::CPose3DPDFGaussian& pose) const
+#if MOLA_VERSION_CHECK(2, 5, 0)
+        override
+#endif
+        ;
 
     /// Returns the current georeferencing, if available
     [[nodiscard]] std::optional<mola::Georeferencing> current_georeferencing() const;
@@ -274,6 +278,11 @@ class StateEstimationSmoother : public mola::NavStateFilter,
 
         /// Flag to track if we've already published the estimated geo-ref
         bool estimated_georef_published = false;
+
+        // To be built from parameters strings when changed.
+        RegexCache do_process_imu_labels_re;
+        RegexCache do_process_odometry_labels_re;
+        RegexCache do_process_gnss_labels_re;
     };
 
     State                state_;

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -149,6 +149,16 @@ params:
   # Fixed geo-reference to use when estimate_geo_reference is false
   # fixed_geo_reference: { latitude_deg: 0.0, longitude_deg: 0.0, altitude: 0.0 }
 
+  # Convergence Detection:
+  # Maximum position sigma (m) to consider converged
+  convergence_max_position_sigma: "${MOLA_SE_CONVERGENCE_POS_SIGMA|1.0}"
+
+  # Maximum orientation sigma (deg) to consider converged
+  convergence_max_orientation_sigma_deg: "${MOLA_SE_CONVERGENCE_ORI_SIGMA|5.0}"
+
+  # If true and estimate_geo_reference is true, publish geo-ref on convergence
+  publish_estimated_georef_on_convergence: "${MOLA_SE_PUBLISH_GEOREF_ON_CONV|true}"
+
   # --------------------------------------------------------------------------
   # Nonlinear Optimization
   # --------------------------------------------------------------------------

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -173,15 +173,15 @@ params:
 
   # Regular expression to filter IMU sensor labels/topics for processing
   # Default accepts all: ".*"
-  # do_process_imu_labels_re: ".*"
+  do_process_imu_labels_re: ".*"
 
   # Regular expression to filter odometry input labels/topics for processing
   # Default accepts all: ".*"
-  # do_process_odometry_labels_re: ".*"
+  do_process_odometry_labels_re: ".*"
 
   # Regular expression to filter GNSS (GPS) labels/topics for processing
   # Default accepts all: ".*"
-  # do_process_gnss_labels_re: ".*"
+  do_process_gnss_labels_re: ".*"
 # ============================================================================
 # End of Configuration
 # ============================================================================

--- a/mola_state_estimation_smoother/ros2-launchs/ros2-state-estimator.launch.py
+++ b/mola_state_estimation_smoother/ros2-launchs/ros2-state-estimator.launch.py
@@ -1,171 +1,120 @@
-
 # ROS 2 launch file
 
 from launch import LaunchDescription
 from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch.conditions import IfCondition
-from launch_ros.actions import Node
-from launch_ros.actions import PushRosNamespace
-from launch.actions import DeclareLaunchArgument
-from launch.actions import SetEnvironmentVariable
-from launch.actions import GroupAction
-from launch.actions import Shutdown
+from launch_ros.actions import Node, PushRosNamespace
+from launch.actions import (DeclareLaunchArgument, SetEnvironmentVariable,
+                            GroupAction, Shutdown, OpaqueFunction)
 from ament_index_python import get_package_share_directory
 import os
 
 
 def generate_launch_description():
-    myDir = get_package_share_directory("mola_lidar_odometry")
 
-    # -------------------
-    #     Arguments
-    # -------------------
-    # Mandatory
-    lidar_topic_name_arg = DeclareLaunchArgument(
-        "lidar_topic_name", description="Topic name to listen for PointCloud2 input from the LiDAR (for example '/ouster/points')")
-    lidar_topic_env_var = SetEnvironmentVariable(
-        name='MOLA_LIDAR_TOPIC', value=LaunchConfiguration('lidar_topic_name'))
-    # ~~~~~~~~~~~~
+    # ~~~~~~~~~~~~~~~~~~~~~~~~
+    #  Smoother arguments
+    # ~~~~~~~~~~~~~~~~~~~~~~~~
+    navstate_kinematic_model_arg = DeclareLaunchArgument(
+        "navstate_kinematic_model",
+        default_value="KinematicModel::ConstantVelocity",
+        description="[Smoother only] Kinematic model for internal motion model factors. Options: KinematicModel::ConstantVelocity, KinematicModel::Tricycle.")
+
+    navstate_sliding_window_sec_arg = DeclareLaunchArgument(
+        "navstate_sliding_window_sec",
+        default_value="2.5",
+        description="[Smoother only] Time window to keep past observations in the filter [seconds].")
+
+    navstate_sigma_random_walk_linacc_arg = DeclareLaunchArgument(
+        "navstate_sigma_random_walk_linacc",
+        default_value="1.0",
+        description="[Smoother only] Random walk model for linear acceleration uncertainty [m/s²].")
+
+    navstate_sigma_random_walk_angacc_arg = DeclareLaunchArgument(
+        "navstate_sigma_random_walk_angacc",
+        default_value="10.0",
+        description="[Smoother only] Random walk angular acceleration uncertainty [rad/s²].")
+
+    estimate_geo_reference_arg = DeclareLaunchArgument(
+        "estimate_geo_reference",
+        default_value="False",
+        description="[Smoother only] Whether to estimate the best geo-referencing for {enu} -> {map} from incoming GNSS readings.")
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~
+    # ros2bridge arguments
+    # ~~~~~~~~~~~~~~~~~~~~~~~~
     ignore_lidar_pose_from_tf_arg = DeclareLaunchArgument(
         "ignore_lidar_pose_from_tf", default_value="false", description="If true, the LiDAR pose will be assumed to be at the origin (base_link). Set to false (default) if you want to read the actual sensor pose from /tf")
     ignore_lidar_pose_from_tf_env_var = SetEnvironmentVariable(
         name='MOLA_USE_FIXED_LIDAR_POSE', value=LaunchConfiguration('ignore_lidar_pose_from_tf'))
-    # ~~~~~~~~~~~~
+
     ignore_imu_pose_from_tf_arg = DeclareLaunchArgument(
         "ignore_imu_pose_from_tf", default_value="false", description="If true, the IMU pose will be assumed to be at the origin (base_link). Set to false (default) if you want to read the actual sensor pose from /tf")
     ignore_imu_pose_from_tf_env_var = SetEnvironmentVariable(
         name='MOLA_USE_FIXED_IMU_POSE', value=LaunchConfiguration('ignore_imu_pose_from_tf'))
-    # ~~~~~~~~~~~~
+
     gnss_topic_name_arg = DeclareLaunchArgument(
         "gnss_topic_name", default_value="gps", description="Topic name to listen for NavSatFix input from a GNSS (for example '/gps')")
     gps_topic_env_var = SetEnvironmentVariable(
         name='MOLA_GNSS_TOPIC', value=LaunchConfiguration('gnss_topic_name'))
-    # ~~~~~~~~~~~~
+
     imu_topic_name_arg = DeclareLaunchArgument(
         "imu_topic_name", default_value="imu", description="Topic name to listen for Imu input (for example '/imu')")
     imu_topic_name_env_var = SetEnvironmentVariable(
         name='MOLA_IMU_TOPIC', value=LaunchConfiguration('imu_topic_name'))
-    # ~~~~~~~~~~~~
-    use_rviz = LaunchConfiguration('use_rviz')
-    use_rviz_arg = DeclareLaunchArgument(
-        "use_rviz", default_value="True", description="Whether to launch RViz2 with default lidar-odometry.rviz configuration")
-    # ~~~~~~~~~~~~
+
     use_mola_gui_arg = DeclareLaunchArgument(
         "use_mola_gui", default_value="True", description="Whether to open MolaViz GUI interface for watching live mapping and control UI")
     use_mola_gui_env_var = SetEnvironmentVariable(
         name='MOLA_WITH_GUI', value=LaunchConfiguration('use_mola_gui'))
-    # ~~~~~~~~~~~~
-    publish_localization_following_rep105_arg = DeclareLaunchArgument(
-        "publish_localization_following_rep105", default_value="True", description="Whether to publish localization TFs in between map->odom (true) or directly map->base_link (false)")
-    publish_localization_following_rep105_env_var = SetEnvironmentVariable(
-        name='MOLA_LOCALIZ_USE_REP105', value=LaunchConfiguration('publish_localization_following_rep105'))
-    # ~~~~~~~~~~~~
-    start_mapping_enabled_arg = DeclareLaunchArgument(
-        "start_mapping_enabled", default_value="True", description="Whether MOLA-LO should start with map update enabled (true), or in localization-only mode (false)")
-    start_mapping_enabled_env_var = SetEnvironmentVariable(
-        name='MOLA_MAPPING_ENABLED', value=LaunchConfiguration('start_mapping_enabled'))
-    # ~~~~~~~~~~~~
-    start_active_arg = DeclareLaunchArgument(
-        "start_active", default_value="True", description="Whether MOLA-LO should start active, that is, processing incoming sensor data (true), or ignoring them (false)")
-    start_active_env_var = SetEnvironmentVariable(
-        name='MOLA_START_ACTIVE', value=LaunchConfiguration('start_active'))
-    # ~~~~~~~~~~~~
-    mola_lo_reference_frame_arg = DeclareLaunchArgument(
-        "mola_lo_reference_frame", default_value="map", description="The /tf frame name to be used for MOLA-LO localization updates")
-    mola_lo_reference_frame_env_var = SetEnvironmentVariable(
-        name='MOLA_LO_PUBLISH_REF_FRAME', value=LaunchConfiguration('mola_lo_reference_frame'))
-    # ~~~~~~~~~~~~
+
     mola_se_reference_frame_arg = DeclareLaunchArgument(
         "mola_state_estimator_reference_frame", default_value="map", description="The /tf frame name to be used as reference for MOLA State Estimators to publish pose updates")
     mola_tf_map_env_var = SetEnvironmentVariable(
         name='MOLA_TF_MAP', value=LaunchConfiguration('mola_state_estimator_reference_frame'))
-    # ~~~~~~~~~~~~
-    mola_lo_pipeline_arg = DeclareLaunchArgument(
-        "mola_lo_pipeline", default_value="../pipelines/lidar3d-default.yaml", description="The LiDAR-Odometry pipeline configuration YAML file defining the LO system. Absolute path, or relative to 'mola-cli-launchs/lidar_odometry_ros2.yaml'. Default is the 'lidar3d-default.yaml' system described in the IJRR 2025 paper.")
-    mola_lo_pipeline_env_var = SetEnvironmentVariable(
-        name='MOLA_ODOMETRY_PIPELINE_YAML', value=LaunchConfiguration('mola_lo_pipeline'))
-    # ~~~~~~~~~~~~
-    generate_simplemap_arg = DeclareLaunchArgument(
-        "generate_simplemap", default_value="False", description="Whether to create a '.simplemap', useful for map post-processing. Refer to online tutorials.")
-    generate_simplemap_env_var = SetEnvironmentVariable(
-        name='MOLA_GENERATE_SIMPLEMAP', value=LaunchConfiguration('generate_simplemap'))
-    # ~~~~~~~~~~~~
-    mola_initial_map_mm_file_arg = DeclareLaunchArgument(
-        "mola_initial_map_mm_file", default_value="\"\"", description="Can be used to provide a metric map '.mm' file to be loaded as initial map. Refer to online tutorials.")
-    mola_initial_map_mm_file_env_var = SetEnvironmentVariable(
-        name='MOLA_LOAD_MM', value=LaunchConfiguration('mola_initial_map_mm_file'))
-    # ~~~~~~~~~~~~
-    mola_initial_map_sm_file_arg = DeclareLaunchArgument(
-        "mola_initial_map_sm_file", default_value="\"\"", description="Can be used to provide a keyframes map '.simplemap' file to be loaded as initial map. Refer to online tutorials.")
-    mola_initial_map_sm_file_env_var = SetEnvironmentVariable(
-        name='MOLA_LOAD_SM', value=LaunchConfiguration('mola_initial_map_sm_file'))
-    # ~~~~~~~~~~~~
+
     mola_footprint_to_base_link_tf_arg = DeclareLaunchArgument(
-        "mola_footprint_to_base_link_tf", default_value="[0, 0, 0, 0, 0, 0]", description="Can be used to define a custom transformation between base_footprint and base_link. The coordinates are [x, y, z, yaw_deg, pitch_deg, roll_deg].")
+        "mola_footprint_to_base_link_tf", default_value="[0, 0, 0, 0, 0, 0]", description="Transformation between base_footprint and base_link.")
     mola_footprint_to_base_link_tf_env_var = SetEnvironmentVariable(
         name='MOLA_TF_FOOTPRINT_TO_BASE_LINK', value=LaunchConfiguration('mola_footprint_to_base_link_tf'))
-    # ~~~~~~~~~~~~
+
     enforce_planar_motion_arg = DeclareLaunchArgument(
         "enforce_planar_motion", default_value="False", description="Whether to enforce z, pitch, and roll to be zero.")
     enforce_planar_motion_env_var = SetEnvironmentVariable(
         name='MOLA_NAVSTATE_ENFORCE_PLANAR_MOTION', value=LaunchConfiguration('enforce_planar_motion'))
-    # ~~~~~~~~~~~~
+
     forward_ros_tf_odom_to_mola_arg = DeclareLaunchArgument(
-        "forward_ros_tf_odom_to_mola", default_value="False", description="Whether to import an existing /tf 'odom'->'base_link' odometry into the MOLA subsystem.")
+        "forward_ros_tf_odom_to_mola", default_value="False", description="Whether to import an existing /tf 'odom'->'base_link' odometry.")
     forward_ros_tf_odom_to_mola_env_var = SetEnvironmentVariable(
         name='MOLA_FORWARD_ROS_TF_ODOM_TO_MOLA', value=LaunchConfiguration('forward_ros_tf_odom_to_mola'))
-    # ~~~~~~~~~~~~
-    initial_localization_method_arg = DeclareLaunchArgument(
-        "initial_localization_method", default_value="InitLocalization::FixedPose", description="What method to use for initialization. See https://docs.mola-slam.org/latest/ros2api.html#initial-localization")
-    initial_localization_method_env_var = SetEnvironmentVariable(
-        name='MOLA_LO_INITIAL_LOCALIZATION_METHOD', value=LaunchConfiguration('initial_localization_method'))
-    # ~~~~~~~~~~~~
-    use_state_estimator_arg = DeclareLaunchArgument(
-        "use_state_estimator",
-        default_value="False",
-        description="If false, the basic state estimator 'mola::state_estimation_simple::StateEstimationSimple' will be used. If true, 'mola::state_estimation_smoother::StateEstimationSmoother' is used instead."
+
+    # Environment variables
+    smoother_env_vars = GroupAction(
+        actions=[
+            SetEnvironmentVariable('MOLA_NAVSTATE_KINEMATIC_MODEL', LaunchConfiguration(
+                'navstate_kinematic_model')),
+            SetEnvironmentVariable('MOLA_NAVSTATE_SLIDING_WINDOW_SEC', LaunchConfiguration(
+                'navstate_sliding_window_sec')),
+            SetEnvironmentVariable('MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC', LaunchConfiguration(
+                'navstate_sigma_random_walk_linacc')),
+            SetEnvironmentVariable('MOLA_NAVSTATE_SIGMA_RANDOM_WALK_ANGACC', LaunchConfiguration(
+                'navstate_sigma_random_walk_angacc')),
+            SetEnvironmentVariable(
+                'MOLA_ESTIMATE_GEO_REF', LaunchConfiguration('estimate_geo_reference')),
+        ]
     )
-    use_state_estimator_env_var = SetEnvironmentVariable(
-        name='MOLA_STATE_ESTIMATOR', value=PythonExpression(
-            ["'mola::state_estimation_smoother::StateEstimationSmoother' if ",
-             LaunchConfiguration(
-                 'use_state_estimator'),
-             " else 'mola::state_estimation_simple::StateEstimationSimple'"
-             ]))
+
     localization_publish_tf_source_env_var = SetEnvironmentVariable(
         name='MOLA_LOCALIZATION_PUBLISH_TF_SOURCE',
-        value=PythonExpression([
-            "'state_estimator' if ", LaunchConfiguration(
-                'use_state_estimator'), " else 'lidar_odometry'"
-        ])
-    )
+        value='state_estimator')
+
     localization_publish_odom_source_env_var = SetEnvironmentVariable(
         name='MOLA_LOCALIZATION_PUBLISH_ODOM_MSGS_SOURCE',
-        value=PythonExpression([
-            "'state_estimator' if ", LaunchConfiguration(
-                'use_state_estimator'), " else 'lidar_odometry'"
-        ])
-    )
-    state_estimator_config_yaml_arg = DeclareLaunchArgument(
-        "state_estimator_config_yaml", default_value='../params/state-estimation-smoother.yaml',
-        description="A YAML file with settings for the state estimator. Absolute path or relative to this launch file")
-    state_estimator_config_yaml_env_var = SetEnvironmentVariable(
-        name='MOLA_STATE_ESTIMATOR_YAML', value=LaunchConfiguration('state_estimator_config_yaml'))
-    # ~~~~~~~~~~~~
-    lidar_scan_validity_minimum_point_count_arg = DeclareLaunchArgument(
-        "lidar_scan_validity_minimum_point_count", default_value="100", description="Minimum number of points in each LiDAR raw scan for it to be considered valid; otherwise, it is ignored.")
-    lidar_scan_validity_minimum_point_env_var = SetEnvironmentVariable(
-        name='MOLA_OBS_VALIDITY_MIN_POINTS', value=LaunchConfiguration('lidar_scan_validity_minimum_point_count'))
-    lidar_scan_validity_enable_env_var = SetEnvironmentVariable(
-        name='MOLA_ENABLE_OBS_VALIDITY_FILTER', value='True')
-    # ~~~~~~~~~~~~
-    mola_deskew_method_arg = DeclareLaunchArgument(
-        "mola_deskew_method", default_value="MotionCompensationMethod::Linear", description="Which motion-compensation method to use to align LiDAR scans more precisely")
-    mola_deskew_method_env_var = SetEnvironmentVariable(
-        name='MOLA_DESKEW_METHOD', value=LaunchConfiguration('mola_deskew_method'))
-    # ~~~~~~~~~~~~
+        value='state_estimator')
+
     mola_tf_base_link_arg = DeclareLaunchArgument(
-        "mola_tf_base_link", default_value="base_link", description="The /tf frame name for the robot base link.")
+        "mola_tf_base_link", default_value="base_link",
+        description="The /tf frame name for the robot base link")
     mola_tf_base_link_env_var = SetEnvironmentVariable(
         name='MOLA_TF_BASE_LINK', value=LaunchConfiguration('mola_tf_base_link'))
 
@@ -197,8 +146,10 @@ def generate_launch_description():
 
     # MOLA subsystem configuration YAML file
     # ------------------------------------------
+    myDir = get_package_share_directory("mola_state_estimation_smoother")
+
     mola_system_yaml_file = os.path.join(
-        myDir, 'mola-cli-launchs', 'lidar_odometry_ros2.yaml')
+        myDir, 'mola-cli-launchs', 'state_estimator_ros2.yaml')
 
     # -------------------
     #        Node
@@ -215,16 +166,6 @@ def generate_launch_description():
             remappings=tf_remaps,
             arguments=[mola_system_yaml_file],
             on_exit=Shutdown()
-        ),
-
-        Node(
-            condition=IfCondition(use_rviz),
-            package='rviz2',
-            executable='rviz2',
-            name='rviz2',
-            remappings=tf_remaps,
-            arguments=[
-                '-d', [os.path.join(myDir, 'rviz2', 'lidar-odometry.rviz')]]
         )
     ])
 
@@ -235,8 +176,6 @@ def generate_launch_description():
         enforce_planar_motion_env_var,
         forward_ros_tf_odom_to_mola_arg,
         forward_ros_tf_odom_to_mola_env_var,
-        generate_simplemap_arg,
-        generate_simplemap_env_var,
         gnss_topic_name_arg,
         gps_topic_env_var,
         ignore_imu_pose_from_tf_arg,
@@ -245,43 +184,23 @@ def generate_launch_description():
         ignore_lidar_pose_from_tf_env_var,
         imu_topic_name_arg,
         imu_topic_name_env_var,
-        initial_localization_method_arg,
-        initial_localization_method_env_var,
-        lidar_scan_validity_enable_env_var,
-        lidar_scan_validity_minimum_point_count_arg,
-        lidar_scan_validity_minimum_point_env_var,
-        lidar_topic_env_var,
-        lidar_topic_name_arg,
-        mola_deskew_method_arg,
-        mola_deskew_method_env_var,
         mola_footprint_to_base_link_tf_arg,
         mola_footprint_to_base_link_tf_env_var,
-        mola_initial_map_mm_file_arg,
-        mola_initial_map_mm_file_env_var,
-        mola_initial_map_sm_file_arg,
-        mola_initial_map_sm_file_env_var,
-        mola_lo_pipeline_arg,
-        mola_lo_pipeline_env_var,
-        mola_lo_reference_frame_arg,
-        mola_lo_reference_frame_env_var,
         mola_se_reference_frame_arg,
         mola_tf_base_link_arg,
         mola_tf_base_link_env_var,
         mola_tf_map_env_var,
-        publish_localization_following_rep105_arg,
-        publish_localization_following_rep105_env_var,
-        start_active_arg,
-        start_active_env_var,
-        start_mapping_enabled_arg,
-        start_mapping_enabled_env_var,
         use_mola_gui_arg,
         use_mola_gui_env_var,
-        use_rviz_arg,
-        use_state_estimator_arg,
-        use_state_estimator_env_var,
-        # Must come later:
-        state_estimator_config_yaml_arg,
-        state_estimator_config_yaml_env_var,
+
+        # Smoother Specific
+        navstate_kinematic_model_arg,
+        navstate_sliding_window_sec_arg,
+        navstate_sigma_random_walk_linacc_arg,
+        navstate_sigma_random_walk_angacc_arg,
+        estimate_geo_reference_arg,
+        smoother_env_vars,
+
         localization_publish_tf_source_env_var,
         localization_publish_odom_source_env_var,
         # group

--- a/mola_state_estimation_smoother/src/Parameters.cpp
+++ b/mola_state_estimation_smoother/src/Parameters.cpp
@@ -108,22 +108,10 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
 
     // name Sensor input names
     // -----------------------------------------------------
-    {
-        std::string do_process_imu_labels;
-        MCP_LOAD_OPT(cfg, do_process_imu_labels);
-        do_process_imu_labels_re = do_process_imu_labels;
-    }
+    MCP_LOAD_OPT(cfg, do_process_imu_labels_re);
+    MCP_LOAD_OPT(cfg, do_process_odometry_labels_re);
+    MCP_LOAD_OPT(cfg, do_process_gnss_labels_re);
 
-    {
-        std::string do_process_odometry_labels;
-        MCP_LOAD_OPT(cfg, do_process_odometry_labels);
-        do_process_odometry_labels_re = do_process_odometry_labels;
-    }
-    {
-        std::string do_process_gnss_labels;
-        MCP_LOAD_OPT(cfg, do_process_gnss_labels);
-        do_process_gnss_labels_re = do_process_gnss_labels;
-    }
     if (cfg.has("initial_twist"))
     {
         ASSERT_(cfg["initial_twist"].isSequence() && cfg["initial_twist"].asSequence().size() == 6);

--- a/mola_state_estimation_smoother/src/Parameters.cpp
+++ b/mola_state_estimation_smoother/src/Parameters.cpp
@@ -96,6 +96,10 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
         gr.T_enu_to_map.cov *= 1e-6;
     }
 
+    MCP_LOAD_OPT(cfg, convergence_max_position_sigma);
+    MCP_LOAD_OPT(cfg, convergence_max_orientation_sigma_deg);
+    MCP_LOAD_OPT(cfg, publish_estimated_georef_on_convergence);
+
     MCP_LOAD_REQ(cfg, kinematic_model);
 
     // Nonlinear optimization

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -472,7 +472,7 @@ void StateEstimationSmoother::fuse_gnss(const mrpt::obs::CObservationGPS& gps)
     const auto observedEnu     = mrpt::gtsam_wrappers::toPoint3(ENU_point);
     const auto enuNoise = gtsam::noiseModel::Gaussian::Covariance(gps.covariance_enu->asEigen());
     auto       enuNoiseRobust = gtsam::noiseModel::Robust::Create(
-              gtsam::noiseModel::mEstimator::Huber::Create(1.5), enuNoise);
+        gtsam::noiseModel::mEstimator::Huber::Create(1.5), enuNoise);
 
     state_.gtsam->newFactors.emplace_shared<mola::factors::FactorGnssMapEnu>(
         symbol_T_enu_to_map, T(this_kf_id), sensorOnVehicle, observedEnu, enuNoiseRobust);
@@ -1110,6 +1110,14 @@ void StateEstimationSmoother::process_pending_gtsam_updates()
 
         pdf.mean = mrpt::poses::CPose3D(mrpt::gtsam_wrappers::toTPose3D(T_enu_to_map));
         pdf.cov  = mrpt::gtsam_wrappers::to_mrpt_se3_cov6(T_enu_to_map_cov);
+
+        if (state_.tentative_geo_coord_reference.has_value())
+        {
+            state_.geo_reference.emplace();
+            state_.geo_reference->geo_coord    = state_.tentative_geo_coord_reference.value();
+            state_.geo_reference->T_enu_to_map = pdf;
+            state_.estimated_georef_published  = false;  // so it's re-published
+        }
     }
 
     // retrieve odometry frames:
@@ -1330,9 +1338,10 @@ void StateEstimationSmoother::initialize_new_frame(
     // Add planar constraints:
     if (params_.enforce_planar_motion)
     {
-        const auto planar_z_noise = gtsam::noiseModel::Diagonal::Sigmas(gtsam::Vector6(
-            PLANAR_XY_SIGMA, PLANAR_XY_SIGMA, PLANAR_XY_SIGMA, PLANAR_XY_SIGMA, PLANAR_XY_SIGMA,
-            PLANAR_Z_SIGMA));
+        const auto planar_z_noise = gtsam::noiseModel::Diagonal::Sigmas(
+            gtsam::Vector6(
+                PLANAR_XY_SIGMA, PLANAR_XY_SIGMA, PLANAR_XY_SIGMA, PLANAR_XY_SIGMA, PLANAR_XY_SIGMA,
+                PLANAR_Z_SIGMA));
 
         state_.gtsam->newFactors.addPrior(T(id), gtsam::Pose3::Identity(), planar_z_noise);
     }
@@ -1464,6 +1473,138 @@ std::optional<mrpt::poses::CPose3DPDFGaussian>
 
     // frame not known or not estimated yet
     return {};
+}
+
+bool StateEstimationSmoother::has_converged_localization(
+    mrpt::poses::CPose3DPDFGaussian& pose) const
+{
+    auto lck = mrpt::lockHelper(stateMutex_);
+
+    // We need at least some frames to have an estimate
+    if (state_.last_estimated_states.empty())
+    {
+        return false;
+    }
+
+    // Get the latest timestamp from the state
+    auto tNowOpt = state_.get_current_extrapolated_stamp();
+    if (!tNowOpt)
+    {
+        return false;
+    }
+
+    // Get latest navstate (this internally calls process_pending_gtsam_updates)
+    const_cast<StateEstimationSmoother*>(this)->process_pending_gtsam_updates();
+
+    // Find the most recent frame
+    if (state_.stamp2frame_index.empty())
+    {
+        return false;
+    }
+
+    const auto& latestIt       = state_.stamp2frame_index.getDirectMap().rbegin();
+    const auto  latestFrameIdx = latestIt->second;
+
+    MRPT_TODO("Refactor to run this in the update estimate loop");
+
+    try
+    {
+        const NavState ns = get_latest_state_and_covariance(latestFrameIdx);
+
+        // Convert info matrix to covariance
+        mrpt::math::CMatrixDouble66 cov = ns.pose.cov_inv.inverse_LLt();
+
+        // Check position uncertainty (diagonal elements 0,1,2 are x,y,z)
+        const double pos_sigma_x   = std::sqrt(cov(0, 0));
+        const double pos_sigma_y   = std::sqrt(cov(1, 1));
+        const double pos_sigma_z   = std::sqrt(cov(2, 2));
+        const double max_pos_sigma = std::max({pos_sigma_x, pos_sigma_y, pos_sigma_z});
+
+        // Check orientation uncertainty (diagonal elements 3,4,5 are yaw,pitch,roll)
+        const double ori_sigma_yaw     = std::sqrt(cov(3, 3));
+        const double ori_sigma_pitch   = std::sqrt(cov(4, 4));
+        const double ori_sigma_roll    = std::sqrt(cov(5, 5));
+        const double max_ori_sigma_rad = std::max({ori_sigma_yaw, ori_sigma_pitch, ori_sigma_roll});
+        const double max_ori_sigma_deg = mrpt::RAD2DEG(max_ori_sigma_rad);
+
+        MRPT_LOG_DEBUG_FMT(
+            "[has_converged_localization] pos_sigmas=(%.3f,%.3f,%.3f) m, "
+            "ori_sigmas=(%.2f,%.2f,%.2f) deg, thresholds=(%.3f m, %.2f deg)",
+            pos_sigma_x, pos_sigma_y, pos_sigma_z, mrpt::RAD2DEG(ori_sigma_yaw),
+            mrpt::RAD2DEG(ori_sigma_pitch), mrpt::RAD2DEG(ori_sigma_roll),
+            params_.convergence_max_position_sigma, params_.convergence_max_orientation_sigma_deg);
+
+        // Check against thresholds
+        const bool converged = (max_pos_sigma <= params_.convergence_max_position_sigma) &&
+                               (max_ori_sigma_deg <= params_.convergence_max_orientation_sigma_deg);
+
+        if (converged)
+        {
+            // Fill output pose
+            pose.mean = ns.pose.mean;
+            pose.cov  = cov;
+
+            // If we just converged and should publish geo-ref, do it now
+            if (params_.estimate_geo_reference && params_.publish_estimated_georef_on_convergence &&
+                !state_.estimated_georef_published)
+            {
+                // Publish the estimated georeferencing
+                const_cast<StateEstimationSmoother*>(this)->publishEstimatedGeoreferencing();
+            }
+        }
+
+        return converged;
+    }
+    catch (const std::exception& e)
+    {
+        MRPT_LOG_DEBUG_FMT(
+            "[has_converged_localization] Exception getting covariance: %s", e.what());
+        return false;
+    }
+}
+
+std::optional<mola::Georeferencing> StateEstimationSmoother::current_georeferencing() const
+{
+    auto lck = mrpt::lockHelper(stateMutex_);
+    return state_.geo_reference;
+}
+
+void StateEstimationSmoother::publishEstimatedGeoreferencing()
+{
+    // Must be called with lock held
+    if (!state_.tentative_geo_coord_reference.has_value())
+    {
+        return;
+    }
+
+    auto T_enu_map_opt = estimated_T_enu_to_map();
+    if (!T_enu_map_opt.has_value())
+    {
+        return;
+    }
+
+    // Store as our now-fixed geo-reference
+    state_.geo_reference.emplace();
+    state_.geo_reference->geo_coord    = *state_.tentative_geo_coord_reference;
+    state_.geo_reference->T_enu_to_map = *T_enu_map_opt;
+
+    // Publish via MapSourceBase
+    MapUpdate mu;
+    mu.method          = "state_estimator";
+    mu.reference_frame = params_.reference_frame_name;
+    mu.timestamp       = mrpt::Clock::now();
+    mu.map_name        = "georef";
+    mu.georeferencing  = state_.geo_reference;
+
+    advertiseUpdatedMap(mu);
+
+    state_.estimated_georef_published = true;
+
+    MRPT_LOG_INFO_STREAM(
+        "Published estimated geo-referencing: "
+        << "lat=" << state_.geo_reference->geo_coord.lat.getAsString()
+        << ", lon=" << state_.geo_reference->geo_coord.lon.getAsString()
+        << ", T_enu_to_map=" << state_.geo_reference->T_enu_to_map.mean.asString());
 }
 
 }  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -420,10 +420,15 @@ void StateEstimationSmoother::fuse_gnss(const mrpt::obs::CObservationGPS& gps)
 
     std::optional<mrpt::topography::TGeodeticCoords> refGeoCoords;
 
-    // First, are we using geo-referencing at all?
-    if (params_.estimate_geo_reference && !state_.geo_reference.has_value())
+    // Determine the reference to use
+    if (state_.geo_reference.has_value())
     {
-        // We are still starting to estimating the geo-reference T_enu2map.
+        // We have a finalized reference (either fixed or already estimated)
+        refGeoCoords = state_.geo_reference->geo_coord;
+    }
+    else if (params_.estimate_geo_reference)
+    {
+        // We are still in the "tentative" phase
         if (!state_.tentative_geo_coord_reference)
         {
             state_.tentative_geo_coord_reference = geoCoords;
@@ -433,19 +438,13 @@ void StateEstimationSmoother::fuse_gnss(const mrpt::obs::CObservationGPS& gps)
                 << geoCoords.lat.getAsString() << ", lon=" << geoCoords.lon.getAsString()
                 << ", h=" << geoCoords.height);
         }
-
         refGeoCoords = state_.tentative_geo_coord_reference;
     }
-    // Use fixed reference coming from an external source:
-    if (!params_.estimate_geo_reference && state_.geo_reference.has_value())
-    {
-        refGeoCoords = state_.geo_reference->geo_coord;
-    }
 
-    // Can we use geo-referencing now:
     if (!refGeoCoords.has_value())
     {
-        MRPT_LOG_DEBUG("[fuse_gnss]: Ignoring reading since there is no geo-reference data (yet?)");
+        MRPT_LOG_DEBUG(
+            "[fuse_gnss]: Ignoring reading; no fixed or tentative geo-reference available.");
         return;
     }
 
@@ -699,16 +698,36 @@ void StateEstimationSmoother::onNewObservation(const CObservation::ConstPtr& o)
     ASSERT_(o);
 
     // IMU:
-    if (auto obsIMU = std::dynamic_pointer_cast<const mrpt::obs::CObservationIMU>(o);
-        obsIMU && std::regex_match(o->sensorLabel, params_.do_process_imu_labels_re))
+    if (auto obsIMU = std::dynamic_pointer_cast<const mrpt::obs::CObservationIMU>(o); obsIMU)
     {
-        this->fuse_imu(*obsIMU);
+        if (std::regex_match(
+                o->sensorLabel,
+                state_.do_process_imu_labels_re.get_regex(params_.do_process_imu_labels_re)))
+        {
+            this->fuse_imu(*obsIMU);
+        }
+        else
+        {
+            MRPT_LOG_DEBUG_FMT(
+                "Skipping IMU reading labeled '%s' for not passing regex", o->sensorLabel.c_str());
+        }
     }
     // Odometry source:
     else if (auto obsOdom = std::dynamic_pointer_cast<const mrpt::obs::CObservationOdometry>(o);
-             obsOdom && std::regex_match(o->sensorLabel, params_.do_process_odometry_labels_re))
+             obsOdom)
     {
-        this->fuse_odometry(*obsOdom, o->sensorLabel);
+        if (std::regex_match(
+                o->sensorLabel, state_.do_process_odometry_labels_re.get_regex(
+                                    params_.do_process_odometry_labels_re)))
+        {
+            this->fuse_odometry(*obsOdom, o->sensorLabel);
+        }
+        else
+        {
+            MRPT_LOG_DEBUG_FMT(
+                "Skipping odometry reading labeled '%s' for not passing regex",
+                o->sensorLabel.c_str());
+        }
     }
     // Robot pose wrt "map":
     else if (auto obsPose = std::dynamic_pointer_cast<const mrpt::obs::CObservationRobotPose>(o);
@@ -724,10 +743,19 @@ void StateEstimationSmoother::onNewObservation(const CObservation::ConstPtr& o)
         this->fuse_pose(obsPose->timestamp, sensedSensorPose, params_.reference_frame_name);
     }
     // GNSS source:
-    else if (auto obsGPS = std::dynamic_pointer_cast<const mrpt::obs::CObservationGPS>(o);
-             obsGPS && std::regex_match(o->sensorLabel, params_.do_process_odometry_labels_re))
+    else if (auto obsGPS = std::dynamic_pointer_cast<const mrpt::obs::CObservationGPS>(o); obsGPS)
     {
-        this->fuse_gnss(*obsGPS);
+        if (std::regex_match(
+                o->sensorLabel,
+                state_.do_process_gnss_labels_re.get_regex(params_.do_process_gnss_labels_re)))
+        {
+            this->fuse_gnss(*obsGPS);
+        }
+        else
+        {
+            MRPT_LOG_DEBUG_FMT(
+                "Skipping GNSS reading labeled '%s' for not passing regex", o->sensorLabel.c_str());
+        }
     }
     else
     {
@@ -1107,12 +1135,73 @@ void StateEstimationSmoother::process_pending_gtsam_updates()
         pdf.mean = mrpt::poses::CPose3D(mrpt::gtsam_wrappers::toTPose3D(T_enu_to_map));
         pdf.cov  = mrpt::gtsam_wrappers::to_mrpt_se3_cov6(T_enu_to_map_cov);
 
-        if (state_.tentative_geo_coord_reference.has_value())
+        // Convert info matrix to covariance
+        if (!state_.stamp2frame_index.empty())
         {
-            state_.geo_reference.emplace();
-            state_.geo_reference->geo_coord    = state_.tentative_geo_coord_reference.value();
-            state_.geo_reference->T_enu_to_map = pdf;
-            state_.estimated_georef_published  = false;  // so it's re-published
+            const auto& latestIt       = state_.stamp2frame_index.getDirectMap().rbegin();
+            const auto  latestFrameIdx = latestIt->second;
+
+            const auto poseCov =
+                gtsam::Matrix6(state_.gtsam->smoother->marginalCovariance(T(latestFrameIdx)));
+            mrpt::math::CMatrixDouble66 cov = mrpt::gtsam_wrappers::to_mrpt_se3_cov6(poseCov);
+
+            // Check MAP->BASE_LINK position uncertainty (diagonal elements 0,1,2 are x,y,z)
+            const double pos_sigma_x   = std::sqrt(cov(0, 0));
+            const double pos_sigma_y   = std::sqrt(cov(1, 1));
+            const double pos_sigma_z   = std::sqrt(cov(2, 2));
+            const double max_pos_sigma = std::max({pos_sigma_x, pos_sigma_y, pos_sigma_z});
+
+            // Check MAP->BASE_LINK orientation uncertainty (diagonal elements 3,4,5 are
+            // yaw,pitch,roll)
+            const double ori_sigma_yaw   = std::sqrt(cov(3, 3));
+            const double ori_sigma_pitch = std::sqrt(cov(4, 4));
+            const double ori_sigma_roll  = std::sqrt(cov(5, 5));
+            const double max_ori_sigma_rad =
+                std::max({ori_sigma_yaw, ori_sigma_pitch, ori_sigma_roll});
+            const double max_ori_sigma_deg = mrpt::RAD2DEG(max_ori_sigma_rad);
+
+            // Check ENU->MAP position uncertainty (diagonal elements 0,1,2 are x,y,z)
+            const double em_pos_sigma_x = std::sqrt(pdf.cov(0, 0));
+            const double em_pos_sigma_y = std::sqrt(pdf.cov(1, 1));
+            const double em_pos_sigma_z = std::sqrt(pdf.cov(2, 2));
+            const double em_max_pos_sigma =
+                std::max({em_pos_sigma_x, em_pos_sigma_y, em_pos_sigma_z});
+
+            // Check ENU->MAP orientation uncertainty (diagonal elements 3,4,5 are yaw,pitch,roll)
+            const double em_ori_sigma_yaw   = std::sqrt(pdf.cov(3, 3));
+            const double em_ori_sigma_pitch = std::sqrt(pdf.cov(4, 4));
+            const double em_ori_sigma_roll  = std::sqrt(pdf.cov(5, 5));
+            const double em_max_ori_sigma_rad =
+                std::max({em_ori_sigma_yaw, em_ori_sigma_pitch, em_ori_sigma_roll});
+            const double em_max_ori_sigma_deg = mrpt::RAD2DEG(em_max_ori_sigma_rad);
+
+            // Check against thresholds
+            const bool converged = (std::max(max_pos_sigma, em_max_pos_sigma) <=
+                                    params_.convergence_max_position_sigma) &&
+                                   (std::max(max_ori_sigma_deg, em_max_ori_sigma_deg) <=
+                                    params_.convergence_max_orientation_sigma_deg);
+
+            MRPT_LOG_DEBUG_FMT(
+                "[process_pending_gtsam_updates] Has converged georeferencing? %s: "
+                "pos_sigmas=(%.3f,%.3f,%.3f) m, "
+                "enu_pos_sigmas=(%.3f,%.3f,%.3f) m, "
+                "ori_sigmas=(%.2f,%.2f,%.2f) deg, "
+                "enu_ori_sigmas=(%.2f,%.2f,%.2f) deg, "
+                "thresholds=(%.3f m, %.2f deg)",
+                converged ? "YES" : "NO", pos_sigma_x, pos_sigma_y, pos_sigma_z, em_pos_sigma_x,
+                em_pos_sigma_y, em_pos_sigma_z, mrpt::RAD2DEG(ori_sigma_yaw),
+                mrpt::RAD2DEG(ori_sigma_pitch), mrpt::RAD2DEG(ori_sigma_roll),
+                mrpt::RAD2DEG(em_ori_sigma_yaw), mrpt::RAD2DEG(em_ori_sigma_pitch),
+                mrpt::RAD2DEG(em_ori_sigma_roll), params_.convergence_max_position_sigma,
+                params_.convergence_max_orientation_sigma_deg);
+
+            if (converged && state_.tentative_geo_coord_reference.has_value())
+            {
+                state_.geo_reference.emplace();
+                state_.geo_reference->geo_coord    = state_.tentative_geo_coord_reference.value();
+                state_.geo_reference->T_enu_to_map = pdf;
+                state_.estimated_georef_published  = false;  // so it's re-published
+            }
         }
     }
 
@@ -1156,6 +1245,15 @@ void StateEstimationSmoother::process_pending_gtsam_updates()
     state_.gtsam->newFactors.resize(0);
     state_.gtsam->newValues.clear();
     state_.gtsam->newKeyStamps.clear();
+
+    // Check convergence for initialization from GNSS / georeferencing.
+    // If we just converged and should publish geo-ref, do it now:
+    if (params_.estimate_geo_reference && params_.publish_estimated_georef_on_convergence &&
+        !state_.estimated_georef_published)
+    {
+        // Publish the estimated georeferencing
+        publishEstimatedGeoreferencing();
+    }
 }
 
 StateEstimationSmoother::pair_nearby_frame_iterators_t StateEstimationSmoother::find_before_after(
@@ -1489,74 +1587,25 @@ bool StateEstimationSmoother::has_converged_localization(
         return false;
     }
 
-    // Get latest navstate (this internally calls process_pending_gtsam_updates)
-    const_cast<StateEstimationSmoother*>(this)->process_pending_gtsam_updates();
-
     // Find the most recent frame
     if (state_.stamp2frame_index.empty())
     {
         return false;
     }
 
-    const auto& latestIt       = state_.stamp2frame_index.getDirectMap().rbegin();
-    const auto  latestFrameIdx = latestIt->second;
+    // Converged if we were told to estimate, and already have it:
+    const bool converged = params_.estimate_geo_reference && state_.geo_reference.has_value();
 
-    MRPT_TODO("Refactor to run this in the update estimate loop");
-
-    try
+    if (converged)
     {
+        const auto& latestIt       = state_.stamp2frame_index.getDirectMap().rbegin();
+        const auto  latestFrameIdx = latestIt->second;
+
         const NavState ns = get_latest_state_and_covariance(latestFrameIdx);
-
-        // Convert info matrix to covariance
-        mrpt::math::CMatrixDouble66 cov = ns.pose.cov_inv.inverse_LLt();
-
-        // Check position uncertainty (diagonal elements 0,1,2 are x,y,z)
-        const double pos_sigma_x   = std::sqrt(cov(0, 0));
-        const double pos_sigma_y   = std::sqrt(cov(1, 1));
-        const double pos_sigma_z   = std::sqrt(cov(2, 2));
-        const double max_pos_sigma = std::max({pos_sigma_x, pos_sigma_y, pos_sigma_z});
-
-        // Check orientation uncertainty (diagonal elements 3,4,5 are yaw,pitch,roll)
-        const double ori_sigma_yaw     = std::sqrt(cov(3, 3));
-        const double ori_sigma_pitch   = std::sqrt(cov(4, 4));
-        const double ori_sigma_roll    = std::sqrt(cov(5, 5));
-        const double max_ori_sigma_rad = std::max({ori_sigma_yaw, ori_sigma_pitch, ori_sigma_roll});
-        const double max_ori_sigma_deg = mrpt::RAD2DEG(max_ori_sigma_rad);
-
-        MRPT_LOG_DEBUG_FMT(
-            "[has_converged_localization] pos_sigmas=(%.3f,%.3f,%.3f) m, "
-            "ori_sigmas=(%.2f,%.2f,%.2f) deg, thresholds=(%.3f m, %.2f deg)",
-            pos_sigma_x, pos_sigma_y, pos_sigma_z, mrpt::RAD2DEG(ori_sigma_yaw),
-            mrpt::RAD2DEG(ori_sigma_pitch), mrpt::RAD2DEG(ori_sigma_roll),
-            params_.convergence_max_position_sigma, params_.convergence_max_orientation_sigma_deg);
-
-        // Check against thresholds
-        const bool converged = (max_pos_sigma <= params_.convergence_max_position_sigma) &&
-                               (max_ori_sigma_deg <= params_.convergence_max_orientation_sigma_deg);
-
-        if (converged)
-        {
-            // Fill output pose
-            pose.mean = ns.pose.mean;
-            pose.cov  = cov;
-
-            // If we just converged and should publish geo-ref, do it now
-            if (params_.estimate_geo_reference && params_.publish_estimated_georef_on_convergence &&
-                !state_.estimated_georef_published)
-            {
-                // Publish the estimated georeferencing
-                const_cast<StateEstimationSmoother*>(this)->publishEstimatedGeoreferencing();
-            }
-        }
-
-        return converged;
+        pose.copyFrom(ns.pose);
     }
-    catch (const std::exception& e)
-    {
-        MRPT_LOG_DEBUG_FMT(
-            "[has_converged_localization] Exception getting covariance: %s", e.what());
-        return false;
-    }
+
+    return converged;
 }
 
 std::optional<mola::Georeferencing> StateEstimationSmoother::current_georeferencing() const
@@ -1596,11 +1645,11 @@ void StateEstimationSmoother::publishEstimatedGeoreferencing()
 
     state_.estimated_georef_published = true;
 
-    MRPT_LOG_INFO_STREAM(
-        "Published estimated geo-referencing: "
-        << "lat=" << state_.geo_reference->geo_coord.lat.getAsString()
-        << ", lon=" << state_.geo_reference->geo_coord.lon.getAsString()
-        << ", T_enu_to_map=" << state_.geo_reference->T_enu_to_map.mean.asString());
+    MRPT_LOG_THROTTLE_INFO_STREAM(
+        5.0, "Published estimated geo-reference: "
+                 << "lat=" << state_.geo_reference->geo_coord.lat.getAsString()
+                 << ", lon=" << state_.geo_reference->geo_coord.lon.getAsString()
+                 << ", T_enu_to_map=" << state_.geo_reference->T_enu_to_map.mean.asString());
 }
 
 }  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -692,11 +692,7 @@ std::set<std::string> StateEstimationSmoother::known_odometry_frame_ids()
     return ret;
 }
 
-#if MOLA_VERSION_CHECK(2, 1, 0)
 void StateEstimationSmoother::onNewObservation(const CObservation::ConstPtr& o)
-#else
-void StateEstimationSmoother::onNewObservation(const CObservation::Ptr& o)
-#endif
 {
     const ProfilerEntry tle(profiler_, "onNewObservation");
 

--- a/mola_state_estimation_smoother/tests/test-lidar-imu-leveling.cpp
+++ b/mola_state_estimation_smoother/tests/test-lidar-imu-leveling.cpp
@@ -133,8 +133,8 @@ void run_test()
 
     // Check leveling
     // Tolerances depend on IMU noise and filter tuning, but should be close to 0
-    ASSERT_NEAR_(p, 0.0, mrpt::DEG2RAD(3.0));
-    ASSERT_NEAR_(r, 0.0, mrpt::DEG2RAD(3.0));
+    ASSERT_NEAR_(p, 0.0, mrpt::DEG2RAD(4.0));
+    ASSERT_NEAR_(r, 0.0, mrpt::DEG2RAD(4.0));
 
     ASSERT_(stateEst.known_odometry_frame_ids().size() == 1);
     for (const auto& odom_frame : stateEst.known_odometry_frame_ids())

--- a/mola_state_estimation_smoother/tests/test-navstate-odom-gnss-fusion.cpp
+++ b/mola_state_estimation_smoother/tests/test-navstate-odom-gnss-fusion.cpp
@@ -228,7 +228,9 @@ void run_test(const TestCase& testCase)
             cov(2, 2)             = mrpt::square(GNSS_NOISE_Z_M);
 
             // Send to state estimator:
-            stateEst.fuse_gnss(obsGps);
+            // Can use: stateEst.fuse_gnss(obsGps);
+            // But let's use the Raw Data Consumer API to get it covered in tests:
+            stateEst.onNewObservation(std::make_shared<const mrpt::obs::CObservationGPS>(obsGps));
         }
 
         // Enforce updating estimation from time to time:
@@ -326,6 +328,14 @@ void run_test(const TestCase& testCase)
         std::cout << "T_map_to_odom[" << odom_frame << "]:\n"
                   << mola::state_estimation_smoother::pose_pdf_to_string_with_sigmas(*T_map_to_odom)
                   << "\n";
+    }
+
+    // Check if geo-referencing has converged:
+    if (testCase.has_gnss)
+    {
+        mrpt::poses::CPose3DPDFGaussian veh_pose_in_map;
+        bool hasConverged = stateEst.has_converged_localization(veh_pose_in_map);
+        ASSERT_(hasConverged);
     }
 
     // done.

--- a/mola_state_estimation_smoother/tests/test-static-gnss-imu-orientation.cpp
+++ b/mola_state_estimation_smoother/tests/test-static-gnss-imu-orientation.cpp
@@ -259,7 +259,9 @@ void run_test(const TestCase& testCase)
             obsImu.set(mrpt::obs::IMU_WZ, rng.drawGaussian1D(0, 0.01));
 
             // Send to state estimator
-            stateEst.fuse_imu(obsImu);
+            // Can use: stateEst.fuse_imu(obsImu);
+            // But let's use the Raw Data Consumer API to get it covered in tests:
+            stateEst.onNewObservation(std::make_shared<const mrpt::obs::CObservationIMU>(obsImu));
 
             if (VERBOSE && i % 5 == 0)
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localization convergence detection with configurable position/orientation thresholds and optional auto-publish of estimated geo-referencing; ability to query current georeferencing.

* **Configuration**
  * New convergence params and publish toggle; sensor-label filters are now string-configurable (enabled by default).

* **Behavior Changes**
  * IMU/odometry/GNSS readings can be filtered by label patterns (skipped with debug logs); launch flow simplified toward the smoother-focused configuration.

* **Tests**
  * Relaxed leveling test tolerances (pitch/roll) from 3.0° to 4.0°.

* **Documentation**
  * Added standalone and integration launch guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->