### PR TITLE
mola-mm-add-geodetic: Don't create output map if input geodetics are …

### DIFF
--- a/mola_georeferencing/apps/mola-mm-add-geodetic-cli.cpp
+++ b/mola_georeferencing/apps/mola-mm-add-geodetic-cli.cpp
@@ -112,8 +112,6 @@ void add_geodetic_fields_to_layer(
     mrpt::maps::CPointsMap& pointMap, const mp2p_icp::metric_map_t::Georeferencing& georef,
     bool verbose)
 {
-#if MRPT_VERSION >= 0x020f02  // 2.15.2 introduced "double" fields
-
     const size_t numPoints = pointMap.size();
 
     if (verbose)
@@ -208,10 +206,6 @@ void add_geodetic_fields_to_layer(
         std::cout << "  Done processing layer."
                   << "\n";
     }
-#else
-    THROW_EXCEPTION(
-        "This functionality requires MRPT version 2.15.2 or newer (for double fields support).");
-#endif
 }
 
 void run_add_geodetic(Cli& cli)
@@ -279,6 +273,16 @@ void run_add_geodetic(Cli& cli)
         std::cout << "    Longitude: " << georef->geo_coord.lon.getAsString() << "\n";
         std::cout << "    Height:    " << georef->geo_coord.height << " m"
                   << "\n";
+    }
+
+    // We may have a .georef file, estimated from IMU only so the ENU frame is defined, but
+    // without geodetic coordinates. Then, returns and exist without creating a new output map:
+    if (georef->geo_coord.isClear())
+    {
+        std::cout << "[mola-mm-add-geodetic] Georeferencing file does not contain valid geodetic "
+                     "coordinates. No geodetic fields will be added.\n";
+        std::cout << "[mola-mm-add-geodetic] Exiting without creating output map.\n";
+        return;
     }
 
     // Determine which layers to process


### PR DESCRIPTION
…missing.

We may still have a valid input .georef, obtained from IMU only, but without geodetics coordinates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of geodetic data; maps containing georeferencing information but lacking valid geodetic coordinates are now properly skipped with informative messages, preventing unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->