### PR TITLE
Add guards against failures for missing input .mm files

### DIFF
--- a/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
+++ b/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
@@ -152,7 +152,12 @@ void run_sm_georef(Cli& cli)
         std::cout << "[mola-sm-georeferencing-cli] Loading mm map: '"
                   << cli.argWriteMMInto.getValue() << "'..." << std::endl;
 
-        mm.load_from_file(cli.argWriteMMInto.getValue());
+        const bool loadOk = mm.load_from_file(cli.argWriteMMInto.getValue());
+        if (!loadOk)
+        {
+            THROW_EXCEPTION_FMT(
+                "Error loading input map file: '%s'", cli.argWriteMMInto.getValue().c_str());
+        }
 
         // overwrite metadata:
         mm.georeferencing = smGeo.geo_ref;

--- a/mola_georeferencing/apps/mola-trajectory-georef-cli.cpp
+++ b/mola_georeferencing/apps/mola-trajectory-georef-cli.cpp
@@ -57,7 +57,11 @@ void run_traj_georef(Cli& cli)
         std::cout << "[mola-trajectory-georef-cli] Reading input map from: '" << filMM << "'..."
                   << std::endl;
 
-        mm.load_from_file(filMM);
+        const bool loadOk = mm.load_from_file(filMM);
+        if (!loadOk)
+        {
+            THROW_EXCEPTION_FMT("Error loading input map file: '%s'", filMM.c_str());
+        }
 
         std::cout << "[mola-trajectory-georef-cli] Done read map: " << mm.contents_summary()
                   << std::endl;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in georeferencing command-line tools. The tools now validate that map files load successfully before processing any georeference data. If a map file is invalid or corrupted, the tools fail gracefully with a clear error message instead of silently continuing with potentially corrupted data, which prevents downstream issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->