### PR TITLE
mola-sm-georeferencing: support yaml output format

### DIFF
--- a/docs/georef-apps.rst
+++ b/docs/georef-apps.rst
@@ -26,15 +26,27 @@ map file, use:
       # georeference it:
       mola-sm-georeferencing -i datasetWithGPS.simplemap --write-into myMap.mm
 
-Alternatively, the georeferenciation metadata can be also stored, independently of a metric map,
-in an independent file with:
+Alternatively, the georeferencing metadata can also be stored independently of a metric map
+in a standalone file. Two output formats are supported:
 
 .. code-block:: bash
 
-      # georeference it:
-      mola-sm-georeferencing -i datasetWithGPS.simplemap --output myMap.georef
+      # Binary gzip format (compact, suitable for archiving):
+      mola-sm-georeferencing -i datasetWithGPS.simplemap -o myMap.georef
 
+      # YAML format (human-readable, easy to inspect or edit):
+      mola-sm-georeferencing -i datasetWithGPS.simplemap -o myMap.yaml
 
+The output format is selected automatically from the file extension: ``*.georef`` produces
+a binary gzip file, while ``*.yaml`` or ``*.yml`` (or any other extension) produces a
+human-readable YAML file.  Both formats are accepted by all other MOLA/mp2p_icp tools that
+consume georeferencing data (e.g. ``sm2mm --georef``, ``mm-georef``,
+``mola-trajectory-georef``).
+
+.. note::
+
+   If neither ``--write-into`` nor ``-o`` is provided, the tool will print a warning and
+   discard the computed result. Always supply at least one output destination.
 
 .. dropdown:: Full CLI reference
    :icon: code-review
@@ -45,7 +57,8 @@ in an independent file with:
 
          mola-sm-georeferencing  [-v <INFO>] [--no-imu-gravity] [-l <foobar.so>]
                                  [--imu-gravity-sigma-deg <3.0>]
-                                 [--horizontality-sigma <1.0>] [-o <map.georef>]
+                                 [--horizontality-sigma <1.0>]
+                                 [-o <(map.georef|map.yaml)>]
                                  [--write-into <map.mm>] -i <map.simplemap> [--]
                                  [--version] [-h]
 
@@ -70,8 +83,11 @@ in an independent file with:
          For short trajectories (not >10x the GPS uncertainty), this helps to
          avoid degeneracy.
 
-         -o <map.georef>,  --output <map.georef>
-         Write the obtained georeferencing metadata to a .georef file
+         -o <(map.georef|map.yaml)>,  --output <(map.georef|map.yaml)>
+         Write the obtained georeferencing metadata to a file. The format is
+         determined by the file extension: binary gzip (``*.georef``) or YAML
+         (``*.yaml``, ``*.yml``). Both formats are accepted by all MOLA/mp2p_icp
+         tools that consume georeferencing data.
 
          --write-into <map.mm>
          An existing .mm file in which to write the georeferencing metadata

--- a/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
+++ b/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
@@ -13,10 +13,14 @@
 */
 
 #include <mola_georeferencing/simplemap_georeference.h>
+#include <mp2p_icp/metricmap.h>
 #include <mrpt/3rdparty/tclap/CmdLine.h>
+#include <mrpt/containers/yaml.h>
 #include <mrpt/io/CFileGZOutputStream.h>
 #include <mrpt/system/filesystem.h>
 #include <mrpt/system/os.h>
+
+#include <fstream>
 
 // CLI flags:
 
@@ -33,8 +37,14 @@ struct Cli
         cmd};
 
     TCLAP::ValueArg<std::string> argOutput{
-        "o",   "output",     "Write the obtained georeferencing metadata to a .georef file",
-        false, "map.georef", "map.georef",
+        "o",
+        "output",
+        "Write the obtained georeferencing metadata to a file. The format is "
+        "determined by the file extension: binary gzip (`*.georef`) or YAML "
+        "(`*.yaml`, `*.yml`).",
+        false,
+        "map.georef",
+        "(map.georef|map.yaml)",
         cmd};
 
     TCLAP::ValueArg<double> argHorz{
@@ -76,6 +86,11 @@ struct Cli
         false, "INFO",      "INFO",
         cmd};
 };
+
+static bool is_binary_georef(const std::string& fil)
+{
+    return mrpt::system::extractFileExtension(fil) == "georef";
+}
 
 void run_sm_georef(Cli& cli)
 {
@@ -145,6 +160,17 @@ void run_sm_georef(Cli& cli)
               << "h: " << geo_ref.geo_coord.height << "\n"
               << "T_enu_to_map: " << geo_ref.T_enu_to_map.asString() << "\n";
 
+    // Warn if the user has not requested any output at all.
+    if (!cli.argWriteMMInto.isSet() && !cli.argOutput.isSet())
+    {
+        std::cerr
+            << "[mola-sm-georeferencing-cli] WARNING: Georeferencing was computed successfully "
+               "but no output destination was specified.\n"
+               "  Use '--write-into <map.mm>' to inject it into a metric map, or\n"
+               "  '-o <map.georef|map.yaml>' to save it to a standalone file.\n"
+               "  The result will be discarded.\n";
+    }
+
     if (cli.argWriteMMInto.isSet())
     {
         mp2p_icp::metric_map_t mm;
@@ -182,12 +208,26 @@ void run_sm_georef(Cli& cli)
         std::cout << "[mola-sm-georeferencing-cli] Writing georef data file: '" << outFil << "'..."
                   << std::endl;
 
-        mrpt::io::CFileGZOutputStream                         f(outFil);
-        std::optional<mp2p_icp::metric_map_t::Georeferencing> g;
-        g = smGeo.geo_ref;
+        std::optional<mp2p_icp::metric_map_t::Georeferencing> g = smGeo.geo_ref;
 
-        auto arch = mrpt::serialization::archiveFrom(f);
-        arch << g;
+        if (is_binary_georef(outFil))
+        {
+            // Binary gzip format (*.georef)
+            mrpt::io::CFileGZOutputStream f(outFil);
+            auto                          arch = mrpt::serialization::archiveFrom(f);
+            arch << g;
+        }
+        else
+        {
+            // YAML format (*.yaml, *.yml, or any other extension)
+            const auto    yamlData = mp2p_icp::ToYAML(g);
+            std::ofstream of(outFil);
+            if (!of.is_open())
+            {
+                THROW_EXCEPTION_FMT("Cannot open output file for writing: '%s'", outFil.c_str());
+            }
+            of << yamlData;
+        }
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for YAML output format (.yaml, .yml) alongside binary gzip format (.georef) for georeferencing metadata
  * Automatic format detection based on output file extension
  * Added warning message when no output destination is specified

* **Documentation**
  * Updated CLI reference with new output format options and syntax examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->