### PR TITLE
Add ROS 2 launch-testing integration tests for StateEstimationSmoother

### DIFF
--- a/.github/workflows/build-ros.yml
+++ b/.github/workflows/build-ros.yml
@@ -5,20 +5,13 @@ on: [ push ]
 
 jobs:
   build_docker:
-    # On Linux, iterates on all ROS 1 and ROS 2 distributions.
+    # On Linux, iterates on all ROS 2 distributions.
     runs-on: ubuntu-latest
     env:
       DEBIAN_FRONTEND: noninteractive
+    continue-on-error: ${{ matrix.allow_failure == true }}
     strategy:
       matrix:
-        # Define the Docker image(s) associated with each ROS distribution.
-        # The include syntax allows additional variables to be defined, like
-        # docker_image in this case. See documentation:
-        # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-configurations-in-a-matrix-build
-        #
-        # Platforms are defined in REP 3 and REP 2000:
-        # https://ros.org/reps/rep-0003.html
-        # https://ros.org/reps/rep-2000.html
         include:
           # Humble Hawksbill (May 2022 - May 2027)
           - docker_image: ubuntu:jammy
@@ -37,20 +30,31 @@ jobs:
           - docker_image: ubuntu:noble
             ros_distribution: jazzy
             use_ros_testing: true
+            coverage_run: true
 
           # Rolling Ridley (No End-Of-Life)
-          - docker_image: ubuntu:noble
-            ros_distribution: rolling
-            use_ros_testing: false
+          # TODO: migrate to ubuntu:resolute once rolling packages are published there.
+          # Track: https://discourse.openrobotics.org/t/preparing-for-rolling-sync-2026-04-23/54223
+          #- docker_image: ubuntu:noble
+          #  ros_distribution: rolling
+          #  use_ros_testing: false
 
-          - docker_image: ubuntu:noble
-            ros_distribution: rolling
-            use_ros_testing: true
+          #- docker_image: ubuntu:noble
+          #  ros_distribution: rolling
+          #  use_ros_testing: true
 
-          - docker_image: ubuntu:noble
-            ros_distribution: rolling
-            use_ros2-testing: true
-            coverage_run: true
+          #- docker_image: ubuntu:noble
+          #  ros_distribution: rolling
+          #  use_ros_testing: true
+          #  coverage_run: true
+
+          # Lyrical Luth (May 2026 - May 2031, LTS)
+          # Beta packages available on resolute; GA release expected May 22, 2026.
+          # allow_failure until GA is released.
+          #- docker_image: ubuntu:resolute
+          #  ros_distribution: lyrical
+          #  use_ros_testing: true
+          #  allow_failure: true
 
     container:
       image: ${{ matrix.docker_image }}
@@ -61,17 +65,48 @@ jobs:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           apt-get -y update
-          apt-get -y install git
+          apt-get -y install git curl gnupg2 ca-certificates
           git clone https://$TOKEN@github.com/$GITHUB_REPOSITORY.git --recursive "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git checkout $GITHUB_SHA
           git submodule update --init --recursive
 
+      # apt-key was removed in Ubuntu 26.04 (Resolute Raccoon). For resolute-based
+      # builds we set up the ROS repo manually before setup-ros runs, which would
+      # otherwise call apt-key internally and fail.
+      - name: Setup ROS apt repository (Ubuntu 26.04+)
+        if: matrix.docker_image == 'ubuntu:resolute'
+        run: |
+          curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+            -o /usr/share/keyrings/ros-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
+            http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" \
+            | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
+            http://packages.ros.org/ros2-testing/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" \
+            | tee /etc/apt/sources.list.d/ros2-testing.list > /dev/null
+          apt-get update
+
       - name: setup ROS environment
+        if: matrix.docker_image != 'ubuntu:resolute'
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
           use-ros2-testing: ${{ matrix.use_ros_testing }}
+
+      # On resolute, setup-ros can't be used (calls apt-key which is gone).
+      # Install the equivalent packages manually instead.
+      - name: Setup ROS environment (Ubuntu 26.04+)
+        if: matrix.docker_image == 'ubuntu:resolute'
+        run: |
+          apt-get install -y \
+            ros-${{ matrix.ros_distribution }}-ros-base \
+            python3-rosdep \
+            python3-colcon-common-extensions \
+            python3-colcon-mixin \
+            ros-dev-tools
+          rosdep init || true
+          rosdep update
 
       - name: Install rosdep dependencies
         run: |
@@ -93,7 +128,6 @@ jobs:
           # Inject Coverage Build Type
           if [ "${{ matrix.coverage_run }}" = "true" ]; then
             echo "Enabling Coverage build type..."
-            # This flag forces the use of the gcov flags defined in CMakeLists.txt
             EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -DCMAKE_BUILD_TYPE=Coverage"
           fi
 
@@ -107,24 +141,16 @@ jobs:
       - name: Run unit tests
         run: |
           . /opt/ros/*/setup.sh
-          # Run tests regardless of coverage setting, as they are required to generate the .gcda files
           colcon test --event-handlers console_direct+
           colcon test-result --verbose
 
       - name: Generate coverage report
         if: matrix.coverage_run == true
         run: |
-          # 1. Capture coverage data across the entire workspace.
-          #    --ignore-errors mismatch fixes geninfo parsing errors
-          #    --rc geninfo_unexecuted_blocks=1 fixes warnings about unexecuted blocks
           lcov --capture --directory . --output-file coverage.info \
             --ignore-errors mismatch --rc geninfo_unexecuted_blocks=1
-
-          # 2. Filter the report: Remove all files outside of your source code
           lcov --remove coverage.info '/opt/ros/*' '/usr/*' \
             --ignore-errors unused --output-file coverage_filtered.info
-
-          # 3. Print a summary to the log
           echo "--- Coverage Summary for mola-state-estimation ---"
           lcov --list coverage_filtered.info
           echo "------------------------------------------"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ incremental optimization. The primary estimator for multi-sensor fusion.
 | MOLA-CLI launch | `mola_state_estimation_smoother/mola-cli-launchs/state_estimator_ros2.yaml` |
 | CLI app | `mola_state_estimation_smoother/apps/mola-navstate-cli.cpp` |
 | Tests (6) | `mola_state_estimation_smoother/tests/test-*.cpp` |
+| Integration tests | `mola_state_estimation_smoother/test/integration/test_*.py` |
 
 Key traits:
 - Inherits `mola::NavStateFilter`, `mola::LocalizationSourceBase`,
@@ -199,3 +200,5 @@ Major parameter groups:
 
 The project uses `clang-format` (config in `.clang-format` at repo root).
 CI enforces formatting via `.github/workflows/check-clang-format.yml`.
+Don't use long hyphens. Use American spelling. Use braced statements instead of
+one-liners.

--- a/docs/mola_state_estimators.rst
+++ b/docs/mola_state_estimators.rst
@@ -34,7 +34,7 @@ What? Why? How?
 
 Next we show different possible use cases.
 
-.. dropdown:: Merging GNSS + IMU
+.. dropdown:: Merging wheel odometry + GNSS + IMU
    :icon: code-review
 
 
@@ -45,8 +45,15 @@ Next we show different possible use cases.
 
       ros2 launch mola_state_estimation_smoother ros2-state-estimator.launch.py \
         estimate_geo_reference:=True \
-        imu_topic_name:=imu \
-        gnss_topic_name:=gps1
+        odom1_topic:=/wheel_odom \
+        imu_topic_name:=/imu \
+        gnss_topic_name:=/gps1
+
+   Up to three ``nav_msgs/Odometry`` sources can be fused simultaneously via
+   ``odom1_topic``, ``odom2_topic``, and ``odom3_topic`` (empty string disables
+   each one). Without at least one odometry source the smoother relies solely on
+   the constant-velocity kinematic model between GNSS fixes, which degrades for
+   non-smooth motion.
 
 
 .. dropdown:: Fusing two ``nav_msgs/Odometry`` sources (e.g. wheel + visual odometry)
@@ -60,22 +67,23 @@ Next we show different possible use cases.
    treats them as independent odometry frames and estimates the optimal
    ``T_map_to_odom_X`` transform for each one.
 
-   **Step 1 — Start fake sensor publishers (for testing without a real robot):**
+   **Step 1 — Start the fake sensor publisher (for testing without a real robot):**
 
    .. code-block:: bash
 
-      # Fake wheel odometry: 2% systematic scale drift in X, 50 Hz
-      python3 $(ros2 pkg prefix mola_demos)/share/mola_demos/demos/fake_wheel_odom_publisher.py
+      # Wheel odom (50 Hz) + visual odom (30 Hz, Y drift) + IMU (100 Hz) —
+      # all from a single script, circular motion at vx=1 m/s, wz=0.2 rad/s:
+      python3 $(ros2 pkg prefix mola_demos)/share/mola_demos/demos/fake_sensor_publisher.py \
+        --ros-args \
+        -p scenario:=circle \
+        -p odom2_topic:=/visual_odom \
+        -p imu_topic:=/imu
 
-      # Fake visual/lidar odometry: 3 mm/step lateral drift, 30 Hz
-      python3 $(ros2 pkg prefix mola_demos)/share/mola_demos/demos/fake_visual_odom_publisher.py
-
-      # Fake IMU: gravity-aligned accelerometer + gyroscope, 100 Hz
-      python3 $(ros2 pkg prefix mola_demos)/share/mola_demos/demos/fake_imu_publisher.py
-
-   Both fake odometry nodes share the same ground-truth motion (circle at vx=1 m/s,
-   wz=0.2 rad/s) but have different noise and drift characteristics so that the smoother
-   can demonstrate visible fusion benefit.
+   The two odometry streams share the same ground-truth circular motion but have
+   different noise and drift characteristics so the smoother can demonstrate
+   visible fusion benefit.  The script supports three scenarios via ``scenario:=``
+   (``circle``, ``moving``, ``static``) and can also publish GNSS by setting
+   ``gnss_topic:=/gps``.
 
    **Step 2 — Launch the smoother:**
 

--- a/mola_state_estimation_smoother/CMakeLists.txt
+++ b/mola_state_estimation_smoother/CMakeLists.txt
@@ -98,10 +98,23 @@ if(DETECTED_ROS2)
   # find dependencies
   find_package(ament_cmake REQUIRED)
 
+  # Install integration-test data files so tests can locate them via ament_index
+  install(
+    DIRECTORY test/integration/data
+    DESTINATION share/${PROJECT_NAME}/test/integration/
+  )
+
   if(BUILD_TESTING)
     find_package(ament_cmake_gtest REQUIRED)
+    find_package(ament_cmake_pytest REQUIRED)
+    find_package(launch_testing_ament_cmake REQUIRED)
 
     add_subdirectory(tests)
+
+    add_launch_test(test/integration/test_static_convergence.py
+      TIMEOUT 90)
+    add_launch_test(test/integration/test_moving_georef.py
+      TIMEOUT 180)
   endif()
 
   ament_package()

--- a/mola_state_estimation_smoother/package.xml
+++ b/mola_state_estimation_smoother/package.xml
@@ -46,6 +46,18 @@
   <!-- Needed by the mola-cli launch files -->
   <exec_depend>mola_launcher</exec_depend>
 
+  <!-- Integration test dependencies -->
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
+  <test_depend>rclpy</test_depend>
+  <test_depend>nav_msgs</test_depend>
+  <test_depend>sensor_msgs</test_depend>
+  <test_depend>geometry_msgs</test_depend>
+  <test_depend>tf2_ros</test_depend>
+  <test_depend>mola_launcher</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
+
   <doc_depend>doxygen</doc_depend>
 
   <export>

--- a/mola_state_estimation_smoother/package.xml
+++ b/mola_state_estimation_smoother/package.xml
@@ -57,6 +57,7 @@
   <test_depend>tf2_ros</test_depend>
   <test_depend>mola_launcher</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>mola_bridge_ros2</test_depend>
 
   <doc_depend>doxygen</doc_depend>
 

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -36,7 +36,7 @@ params:
   kinematic_model: "${MOLA_NAVSTATE_KINEMATIC_MODEL|KinematicModel::ConstantVelocity}"
 
   # Time window to keep past observations in the filter [seconds]
-  sliding_window_length: ${MOLA_NAVSTATE_SLIDING_WINDOW_SEC|2.5}
+  sliding_window_length: ${MOLA_NAVSTATE_SLIDING_WINDOW_SEC|6.0}
 
   # Minimum time difference between frames to create a new frame [seconds]
   min_time_difference_to_create_new_frame: 0.01
@@ -89,10 +89,19 @@ params:
   # If enabled, the estimator will enforce z, pitch, and roll to be always 0:
   enforce_planar_motion: ${MOLA_NAVSTATE_ENFORCE_PLANAR_MOTION|false}
 
-  # If set, the first ever frame will also have an SE(3) edge favoring it to be the identity in
-  # the "reference_frame", with a sigma given by this value. Use a small number, like 1e-6, for
-  # initialing the first odometry pose near the map origin. Do not set when using geo-referenced
-  # maps.
+  # If set, pins the first robot frame to the "reference_frame" origin with the given sigma [m/rad].
+  #
+  # When to set (use 1e-6):
+  #   - estimate_geo_reference=true  : the map frame is defined by where the robot starts;
+  #     without this anchor the GTSAM graph has a rank-deficient null-space in the
+  #     T_enu_to_map direction and geo-reference estimation will not converge.
+  #   - Pure odometry (no GNSS)      : no absolute constraint exists; the anchor defines the
+  #     map origin.
+  #
+  # When to leave empty:
+  #   - estimate_geo_reference=false with GNSS and a pre-built geo-referenced map: the robot
+  #     may start anywhere in the map; the fixed T_enu_to_map + GNSS directly constrain its
+  #     absolute position without needing an origin anchor.
   link_first_pose_to_reference_origin_sigma: ${MOLA_LINK_FIRST_POSE_SIGMA|}
 
   # --------------------------------------------------------------------------
@@ -101,7 +110,7 @@ params:
 
   # Optional initial guess for the twist (vx vy vz: m/s, wx wy wz: rad/s):
   # Initial velocity twist (linear: vx, vy, vz; angular: wx, wy, wz)
-  initial_twist: ["${MOLA_INITIAL_VX|0.0}", 0.0, 0.0, 0.0, 0.0, 0.0]
+  initial_twist: [ "${MOLA_INITIAL_VX|0.0}", 0.0, 0.0, 0.0, 0.0, 0.0 ]
 
   # Defaults: somewhat confident that the vehicle is near rest.
   # Change these if needed to start with the vehicle at high speed.
@@ -182,6 +191,7 @@ params:
   # Regular expression to filter GNSS (GPS) labels/topics for processing
   # Default accepts all: ".*"
   do_process_gnss_labels_re: ".*"
+
 # ============================================================================
 # End of Configuration
 # ============================================================================

--- a/mola_state_estimation_smoother/ros2-launchs/ros2-state-estimator.launch.py
+++ b/mola_state_estimation_smoother/ros2-launchs/ros2-state-estimator.launch.py
@@ -13,7 +13,8 @@ from launch.substitutions import LaunchConfiguration
 from launch.conditions import IfCondition
 from launch_ros.actions import Node, PushRosNamespace
 from launch.actions import (DeclareLaunchArgument, SetEnvironmentVariable,
-                            GroupAction, Shutdown, OpaqueFunction)
+                            UnsetEnvironmentVariable, GroupAction, Shutdown,
+                            OpaqueFunction)
 from ament_index_python import get_package_share_directory
 import os
 
@@ -174,7 +175,7 @@ def generate_launch_description():
         if estimate_geo_ref in ('true', '1', 'yes'):
             return [SetEnvironmentVariable(
                 name='MOLA_LINK_FIRST_POSE_SIGMA', value='1e-6')]
-        return []
+        return [UnsetEnvironmentVariable(name='MOLA_LINK_FIRST_POSE_SIGMA')]
 
     link_first_pose_sigma_action = OpaqueFunction(
         function=_set_link_first_pose_sigma)

--- a/mola_state_estimation_smoother/ros2-launchs/ros2-state-estimator.launch.py
+++ b/mola_state_estimation_smoother/ros2-launchs/ros2-state-estimator.launch.py
@@ -13,7 +13,7 @@ from launch.substitutions import LaunchConfiguration
 from launch.conditions import IfCondition
 from launch_ros.actions import Node, PushRosNamespace
 from launch.actions import (DeclareLaunchArgument, SetEnvironmentVariable,
-                            GroupAction, Shutdown)
+                            GroupAction, Shutdown, OpaqueFunction)
 from ament_index_python import get_package_share_directory
 import os
 
@@ -48,6 +48,27 @@ def generate_launch_description():
         default_value="False",
         description="Estimate geo-referencing from GNSS readings.")
 
+    odom1_topic_arg = DeclareLaunchArgument(
+        "odom1_topic", default_value="",
+        description="1st nav_msgs/Odometry topic (empty to disable)")
+    odom1_label_arg = DeclareLaunchArgument(
+        "odom1_label", default_value="odom1",
+        description="Sensor label for 1st odometry source")
+
+    odom2_topic_arg = DeclareLaunchArgument(
+        "odom2_topic", default_value="",
+        description="2nd nav_msgs/Odometry topic (empty to disable)")
+    odom2_label_arg = DeclareLaunchArgument(
+        "odom2_label", default_value="odom2",
+        description="Sensor label for 2nd odometry source")
+
+    odom3_topic_arg = DeclareLaunchArgument(
+        "odom3_topic", default_value="",
+        description="3rd nav_msgs/Odometry topic (empty to disable)")
+    odom3_label_arg = DeclareLaunchArgument(
+        "odom3_label", default_value="odom3",
+        description="Sensor label for 3rd odometry source")
+
     smoother_env_vars = GroupAction(actions=[
         SetEnvironmentVariable('MOLA_NAVSTATE_KINEMATIC_MODEL',
                                LaunchConfiguration('navstate_kinematic_model')),
@@ -59,6 +80,12 @@ def generate_launch_description():
                                LaunchConfiguration('navstate_sigma_random_walk_angacc')),
         SetEnvironmentVariable('MOLA_ESTIMATE_GEO_REF',
                                LaunchConfiguration('estimate_geo_reference')),
+        SetEnvironmentVariable('ODOM1_TOPIC', LaunchConfiguration('odom1_topic')),
+        SetEnvironmentVariable('ODOM1_LABEL', LaunchConfiguration('odom1_label')),
+        SetEnvironmentVariable('ODOM2_TOPIC', LaunchConfiguration('odom2_topic')),
+        SetEnvironmentVariable('ODOM2_LABEL', LaunchConfiguration('odom2_label')),
+        SetEnvironmentVariable('ODOM3_TOPIC', LaunchConfiguration('odom3_topic')),
+        SetEnvironmentVariable('ODOM3_LABEL', LaunchConfiguration('odom3_label')),
     ])
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -137,6 +164,21 @@ def generate_launch_description():
         name='MOLA_LOCALIZATION_PUBLISH_ODOM_MSGS_SOURCE',
         value='state_estimation')
 
+    def _set_link_first_pose_sigma(context, *args, **kwargs):
+        # When estimating geo-reference the map frame is defined by where the robot
+        # starts, so we must anchor the first pose to the map origin (sigma=1e-6).
+        # When localizing in a pre-built geo-referenced map the robot can start
+        # anywhere, so MOLA_LINK_FIRST_POSE_SIGMA must be left empty.
+        estimate_geo_ref = LaunchConfiguration(
+            'estimate_geo_reference').perform(context).strip().lower()
+        if estimate_geo_ref in ('true', '1', 'yes'):
+            return [SetEnvironmentVariable(
+                name='MOLA_LINK_FIRST_POSE_SIGMA', value='1e-6')]
+        return []
+
+    link_first_pose_sigma_action = OpaqueFunction(
+        function=_set_link_first_pose_sigma)
+
     # Namespace
     namespace = LaunchConfiguration('namespace')
     use_namespace = LaunchConfiguration('use_namespace')
@@ -179,6 +221,9 @@ def generate_launch_description():
         navstate_sigma_random_walk_linacc_arg,
         navstate_sigma_random_walk_angacc_arg,
         estimate_geo_reference_arg,
+        odom1_topic_arg, odom1_label_arg,
+        odom2_topic_arg, odom2_label_arg,
+        odom3_topic_arg, odom3_label_arg,
         smoother_env_vars,
         # BridgeROS2
         enforce_planar_motion_arg, enforce_planar_motion_env,
@@ -193,6 +238,7 @@ def generate_launch_description():
         use_mola_gui_arg, use_mola_gui_env,
         localization_publish_tf_source_env,
         localization_publish_odom_source_env,
+        link_first_pose_sigma_action,
         # Node
         node_group
     ])

--- a/mola_state_estimation_smoother/test/integration/common.py
+++ b/mola_state_estimation_smoother/test/integration/common.py
@@ -1,0 +1,241 @@
+# Common utilities for integration tests of mola_state_estimation_smoother.
+#
+# Geodetic convention:
+#   flat-Earth approximation, valid for trajectories shorter than ~100 m around the
+#   test origin (Almeria, matching existing C++ unit tests).
+#
+# IMU quaternion convention (imu_attitude_azimuth_offset_deg=0):
+#   The MOLA smoother internally computes ENU_yaw = quat_yaw + 90 deg + offset.
+#   With offset=0, quat_yaw must equal (vehicle_ENU_yaw - 90 deg).
+#   See also test-static-gnss-imu-orientation.cpp, vehicleToAzimuth formula.
+import math
+import time
+
+import numpy as np
+
+# Geodetic test origin  (must match static_test_smoother_params.yaml fixed_geo_reference)
+GT_LAT0_DEG = 36.8407
+GT_LON0_DEG = -2.4093
+GT_ALT0_M = 100.0
+
+# Ground truth for static scenario: 30 m East, 50 m North, yaw=60 deg ENU
+STATIC_GT_X = 30.0
+STATIC_GT_Y = 50.0
+STATIC_GT_Z = 0.0
+STATIC_GT_YAW_RAD = math.radians(60.0)
+
+# Moving trajectory parameters: sinusoidal zigzag at 1 m/s
+MOVING_V = 1.0        # forward speed [m/s]
+MOVING_A = 2.0        # lateral amplitude [m]
+MOVING_OMEGA = 0.5    # lateral frequency [rad/s]
+MOVING_DURATION_S = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Math helpers
+# ---------------------------------------------------------------------------
+
+def wrap_pi(angle):
+    """Wrap angle (radians) to [-pi, pi]."""
+    return (angle + math.pi) % (2 * math.pi) - math.pi
+
+
+def quaternion_from_euler_zyx(roll, pitch, yaw):
+    """ZYX Euler -> quaternion, returns (x, y, z, w)."""
+    cy, sy = math.cos(yaw / 2), math.sin(yaw / 2)
+    cp, sp = math.cos(pitch / 2), math.sin(pitch / 2)
+    cr, sr = math.cos(roll / 2), math.sin(roll / 2)
+    w = cr * cp * cy + sr * sp * sy
+    x = sr * cp * cy - cr * sp * sy
+    y = cr * sp * cy + sr * cp * sy
+    z = cr * cp * sy - sr * sp * cy
+    return x, y, z, w
+
+
+def imu_quat_from_enu_pose(gt_yaw_enu, gt_pitch=0.0, gt_roll=0.0):
+    """
+    Build IMU orientation quaternion compatible with
+    imu_attitude_azimuth_offset_deg=0.
+
+    The smoother recovers ENU yaw via: ENU_yaw = quat_yaw + pi/2 + offset.
+    With offset=0 we must publish: quat_yaw = gt_yaw_enu - pi/2.
+    """
+    imu_yaw = gt_yaw_enu - math.pi / 2
+    return quaternion_from_euler_zyx(gt_roll, gt_pitch, imu_yaw)
+
+
+def imu_linear_acc_body(gt_yaw, gt_pitch=0.0, gt_roll=0.0,
+                        world_accel_x=0.0, world_accel_y=0.0):
+    """
+    Specific force measured by IMU in body frame (m/s²).
+    Equals (vehicle translational accel - gravity) rotated into body frame.
+    For a flat, slowly-accelerating robot this is close to (0, 0, +9.81).
+    """
+    g_world = np.array([0.0, 0.0, -9.81])
+    a_world = np.array([world_accel_x, world_accel_y, 0.0])
+    sf_world = a_world - g_world  # specific force in world frame
+
+    # Rotation matrix world -> body (ZYX): R^T of body->world
+    cy, sy = math.cos(gt_yaw), math.sin(gt_yaw)
+    cp, sp = math.cos(gt_pitch), math.sin(gt_pitch)
+    cr, sr = math.cos(gt_roll), math.sin(gt_roll)
+    # R_body_to_world (standard ZYX):
+    R = np.array([
+        [cy * cp, cy * sp * sr - sy * cr, cy * sp * cr + sy * sr],
+        [sy * cp, sy * sp * sr + cy * cr, sy * sp * cr - cy * sr],
+        [-sp,     cp * sr,                cp * cr               ],
+    ])
+    return R.T @ sf_world  # world to body
+
+
+# ---------------------------------------------------------------------------
+# Ground-truth trajectories
+# ---------------------------------------------------------------------------
+
+def static_gt_pose():
+    """Return (x, y, z, yaw, pitch, roll) for the static scenario."""
+    return STATIC_GT_X, STATIC_GT_Y, STATIC_GT_Z, STATIC_GT_YAW_RAD, 0.0, 0.0
+
+
+def moving_gt_pose(t):
+    """Return (x, y, z, yaw, pitch, roll) at trajectory time t [s]."""
+    x = MOVING_V * t
+    y = MOVING_A * math.sin(MOVING_OMEGA * t)
+    vy = MOVING_A * MOVING_OMEGA * math.cos(MOVING_OMEGA * t)
+    yaw = math.atan2(vy, MOVING_V)
+    return x, y, 0.0, yaw, 0.0, 0.0
+
+
+def moving_gt_twist(t):
+    """Return body-frame twist (vx, vy, vz, wx, wy, wz) at time t [s]."""
+    vx_w = MOVING_V
+    vy_w = MOVING_A * MOVING_OMEGA * math.cos(MOVING_OMEGA * t)
+    _, _, _, yaw, _, _ = moving_gt_pose(t)
+    # Rotate world velocities to body frame
+    vx = vx_w * math.cos(yaw) + vy_w * math.sin(yaw)
+    vy = -vx_w * math.sin(yaw) + vy_w * math.cos(yaw)
+    # Angular velocity dYaw/dt
+    denom = MOVING_V ** 2 + (MOVING_A * MOVING_OMEGA * math.cos(MOVING_OMEGA * t)) ** 2
+    wz = (
+        -MOVING_V * MOVING_A * MOVING_OMEGA ** 2 * math.sin(MOVING_OMEGA * t)
+        / max(denom, 1e-9)
+    )
+    return vx, vy, 0.0, 0.0, 0.0, wz
+
+
+def moving_gt_world_accel(t):
+    """Return world-frame translational acceleration at time t [s]."""
+    ay_w = -MOVING_A * MOVING_OMEGA ** 2 * math.sin(MOVING_OMEGA * t)
+    return 0.0, ay_w
+
+
+# ---------------------------------------------------------------------------
+# Geodetic helpers (flat-Earth approximation, good for <100 m)
+# ---------------------------------------------------------------------------
+
+_M_PER_DEG_LAT = 111320.0
+
+
+def enu_to_latlon(east_m, north_m, alt_m,
+                  lat0_deg=GT_LAT0_DEG, lon0_deg=GT_LON0_DEG, alt0_m=GT_ALT0_M):
+    """ENU [m] -> (lat_deg, lon_deg, alt_m)."""
+    m_per_deg_lon = _M_PER_DEG_LAT * math.cos(math.radians(lat0_deg))
+    lat = lat0_deg + north_m / _M_PER_DEG_LAT
+    lon = lon0_deg + east_m / max(m_per_deg_lon, 1e-9)
+    return lat, lon, alt0_m + alt_m
+
+
+def latlon_to_enu(lat_deg, lon_deg, alt,
+                  lat0_deg=GT_LAT0_DEG, lon0_deg=GT_LON0_DEG, alt0_m=GT_ALT0_M):
+    """(lat_deg, lon_deg, alt_m) -> ENU [m]."""
+    m_per_deg_lon = _M_PER_DEG_LAT * math.cos(math.radians(lat0_deg))
+    north = (lat_deg - lat0_deg) * _M_PER_DEG_LAT
+    east = (lon_deg - lon0_deg) * m_per_deg_lon
+    return east, north, alt - alt0_m
+
+
+def _round_trip_check():
+    """Smoke-check flat-Earth round-trip at module import time."""
+    e0, n0 = 30.0, 50.0
+    lat, lon, alt = enu_to_latlon(e0, n0, 0.0)
+    e1, n1, _ = latlon_to_enu(lat, lon, alt)
+    assert abs(e0 - e1) < 0.01 and abs(n0 - n1) < 0.01, (
+        f"flat-Earth round-trip error: ({e0},{n0}) -> ({e1},{n1})")
+
+
+_round_trip_check()
+
+
+# ---------------------------------------------------------------------------
+# Latest-pose store (thread-safe via GIL for scalar writes)
+# ---------------------------------------------------------------------------
+
+class PoseLatest:
+    """Stores the most recent (x, y, yaw) from a ROS subscription callback."""
+
+    def __init__(self):
+        self._data = None
+
+    def update(self, x, y, yaw):
+        self._data = (x, y, yaw)
+
+    def latest(self):
+        return self._data
+
+
+# ---------------------------------------------------------------------------
+# Convergence assertion
+# ---------------------------------------------------------------------------
+
+def wait_for_convergence(
+    node,
+    gt_provider,
+    est_provider,
+    *,
+    max_pos_err_m,
+    max_heading_err_deg,
+    settle_seconds=2.0,
+    timeout_seconds=60.0,
+    warm_up_seconds=0.0,
+):
+    """
+    Spin *node* until the estimated pose converges to the GT pose or timeout.
+
+    Convergence requires the error to stay below threshold continuously for
+    *settle_seconds*.  *warm_up_seconds* is a spin-only period before checking.
+    """
+    import rclpy
+
+    deadline = time.time() + warm_up_seconds + timeout_seconds
+    warm_up_end = time.time() + warm_up_seconds
+    settled_since = None
+    pos_err = float("inf")
+    yaw_err = float("inf")
+
+    while time.time() < deadline:
+        rclpy.spin_once(node, timeout_sec=0.05)
+
+        if time.time() < warm_up_end:
+            continue
+
+        gt = gt_provider.latest()
+        est = est_provider.latest()
+        if gt is None or est is None:
+            continue
+
+        pos_err = math.hypot(gt[0] - est[0], gt[1] - est[1])
+        yaw_err = wrap_pi(gt[2] - est[2])
+
+        if (pos_err < max_pos_err_m and
+                abs(yaw_err) < math.radians(max_heading_err_deg)):
+            if settled_since is None:
+                settled_since = time.time()
+            if time.time() - settled_since >= settle_seconds:
+                return
+        else:
+            settled_since = None
+
+    raise AssertionError(
+        f"did not converge within {timeout_seconds:.0f} s: "
+        f"pos_err={pos_err:.2f} m, yaw_err={math.degrees(yaw_err):.2f} deg"
+    )

--- a/mola_state_estimation_smoother/test/integration/common.py
+++ b/mola_state_estimation_smoother/test/integration/common.py
@@ -8,10 +8,14 @@
 #   The MOLA smoother internally computes ENU_yaw = quat_yaw + 90 deg + offset.
 #   With offset=0, quat_yaw must equal (vehicle_ENU_yaw - 90 deg).
 #   See also test-static-gnss-imu-orientation.cpp, vehicleToAzimuth formula.
+import logging
 import math
 import time
 
 import numpy as np
+
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s %(levelname)s: %(message)s')
 
 # Geodetic test origin  (must match static_test_smoother_params.yaml fixed_geo_reference)
 GT_LAT0_DEG = 36.8407
@@ -83,7 +87,7 @@ def imu_linear_acc_body(gt_yaw, gt_pitch=0.0, gt_roll=0.0,
     R = np.array([
         [cy * cp, cy * sp * sr - sy * cr, cy * sp * cr + sy * sr],
         [sy * cp, sy * sp * sr + cy * cr, sy * sp * cr - cy * sr],
-        [-sp,     cp * sr,                cp * cr               ],
+        [-sp,     cp * sr,                cp * cr],
     ])
     return R.T @ sf_world  # world to body
 
@@ -115,7 +119,8 @@ def moving_gt_twist(t):
     vx = vx_w * math.cos(yaw) + vy_w * math.sin(yaw)
     vy = -vx_w * math.sin(yaw) + vy_w * math.cos(yaw)
     # Angular velocity dYaw/dt
-    denom = MOVING_V ** 2 + (MOVING_A * MOVING_OMEGA * math.cos(MOVING_OMEGA * t)) ** 2
+    denom = MOVING_V ** 2 + (MOVING_A * MOVING_OMEGA *
+                             math.cos(MOVING_OMEGA * t)) ** 2
     wz = (
         -MOVING_V * MOVING_A * MOVING_OMEGA ** 2 * math.sin(MOVING_OMEGA * t)
         / max(denom, 1e-9)
@@ -178,6 +183,10 @@ class PoseLatest:
 
     def update(self, x, y, yaw):
         self._data = (x, y, yaw)
+        logging.info(
+            "Pose received: x=%.3f m, y=%.3f m, yaw=%.3f rad",
+            x, y, yaw,
+        )
 
     def latest(self):
         return self._data
@@ -225,12 +234,28 @@ def wait_for_convergence(
 
         pos_err = math.hypot(gt[0] - est[0], gt[1] - est[1])
         yaw_err = wrap_pi(gt[2] - est[2])
+        passed = (
+            pos_err < max_pos_err_m and
+            abs(yaw_err) < math.radians(max_heading_err_deg)
+        )
 
-        if (pos_err < max_pos_err_m and
-                abs(yaw_err) < math.radians(max_heading_err_deg)):
+        logging.info(
+            "Convergence check: pos_err=%.3f m, yaw_err=%.3f deg, pass=%s",
+            pos_err,
+            math.degrees(yaw_err),
+            passed,
+        )
+
+        if passed:
             if settled_since is None:
                 settled_since = time.time()
             if time.time() - settled_since >= settle_seconds:
+                logging.info(
+                    "Converged after %.1f s: pos_err=%.3f m, yaw_err=%.3f deg",
+                    settle_seconds,
+                    pos_err,
+                    math.degrees(yaw_err),
+                )
                 return
         else:
             settled_since = None

--- a/mola_state_estimation_smoother/test/integration/common.py
+++ b/mola_state_estimation_smoother/test/integration/common.py
@@ -180,16 +180,14 @@ class PoseLatest:
 
     def __init__(self):
         self._data = None
+        self._updated_at = None
 
     def update(self, x, y, yaw):
         self._data = (x, y, yaw)
-        logging.info(
-            "Pose received: x=%.3f m, y=%.3f m, yaw=%.3f rad",
-            x, y, yaw,
-        )
+        self._updated_at = time.monotonic()
 
     def latest(self):
-        return self._data
+        return self._data, self._updated_at
 
 
 # ---------------------------------------------------------------------------
@@ -206,6 +204,7 @@ def wait_for_convergence(
     settle_seconds=2.0,
     timeout_seconds=60.0,
     warm_up_seconds=0.0,
+    max_sample_age_seconds=0.5,
 ):
     """
     Spin *node* until the estimated pose converges to the GT pose or timeout.
@@ -215,21 +214,29 @@ def wait_for_convergence(
     """
     import rclpy
 
-    deadline = time.time() + warm_up_seconds + timeout_seconds
-    warm_up_end = time.time() + warm_up_seconds
+    start = time.monotonic()
+    deadline = start + warm_up_seconds + timeout_seconds
+    warm_up_end = start + warm_up_seconds
     settled_since = None
     pos_err = float("inf")
     yaw_err = float("inf")
 
-    while time.time() < deadline:
+    while time.monotonic() < deadline:
         rclpy.spin_once(node, timeout_sec=0.05)
 
-        if time.time() < warm_up_end:
+        now = time.monotonic()
+        if now < warm_up_end:
             continue
 
-        gt = gt_provider.latest()
-        est = est_provider.latest()
-        if gt is None or est is None:
+        gt, gt_t = gt_provider.latest()
+        est, est_t = est_provider.latest()
+        if (
+            gt is None or est is None or
+            gt_t is None or est_t is None or
+            now - gt_t > max_sample_age_seconds or
+            now - est_t > max_sample_age_seconds
+        ):
+            settled_since = None
             continue
 
         pos_err = math.hypot(gt[0] - est[0], gt[1] - est[1])
@@ -239,17 +246,10 @@ def wait_for_convergence(
             abs(yaw_err) < math.radians(max_heading_err_deg)
         )
 
-        logging.info(
-            "Convergence check: pos_err=%.3f m, yaw_err=%.3f deg, pass=%s",
-            pos_err,
-            math.degrees(yaw_err),
-            passed,
-        )
-
         if passed:
             if settled_since is None:
-                settled_since = time.time()
-            if time.time() - settled_since >= settle_seconds:
+                settled_since = now
+            if now - settled_since >= settle_seconds:
                 logging.info(
                     "Converged after %.1f s: pos_err=%.3f m, yaw_err=%.3f deg",
                     settle_seconds,

--- a/mola_state_estimation_smoother/test/integration/data/moving_test_smoother_params.yaml
+++ b/mola_state_estimation_smoother/test/integration/data/moving_test_smoother_params.yaml
@@ -1,0 +1,46 @@
+# MOLA state estimator params for the moving geo-ref integration test.
+# Standalone copy of state-estimation-smoother.yaml with:
+#   estimate_geo_reference: true (smoother discovers geo-ref from GNSS)
+#   no fixed_geo_reference, no first-pose anchor
+
+params:
+  vehicle_frame_name: "base_link"
+  reference_frame_name: "map"
+  enu_frame_name: "enu"
+
+  kinematic_model: "KinematicModel::ConstantVelocity"
+  sliding_window_length: 4.0
+  min_time_difference_to_create_new_frame: 0.01
+  max_time_to_use_velocity_model: 2.0
+  gnss_nearby_keyframe_stamp_tolerance: 1.0
+  imu_nearby_keyframe_stamp_tolerance: 0.10
+  time_between_frames_to_warning: 5.0
+
+  sigma_random_walk_acceleration_linear: 1.0
+  sigma_random_walk_acceleration_angular: 10.0
+  sigma_integrator_position: 0.1
+  sigma_integrator_orientation: 1.0
+  sigma_twist_from_consecutive_poses_linear: 1.0
+  sigma_twist_from_consecutive_poses_angular: 1.0
+
+  enforce_planar_motion: true
+
+  initial_twist: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  initial_twist_sigma_lin: 20.0
+  initial_twist_sigma_ang: 3.0
+
+  imu_attitude_sigma_deg: "2.0"
+  imu_attitude_azimuth_offset_deg: "0.0"
+  imu_normalized_gravity_alignment_sigma: "0.4"
+
+  estimate_geo_reference: true
+
+  convergence_max_position_sigma: "1.0"
+  convergence_max_orientation_sigma_deg: "5.0"
+  publish_estimated_georef_on_convergence: true
+
+  additional_isam2_update_steps: 3
+
+  do_process_imu_labels_re: ".*"
+  do_process_odometry_labels_re: ".*"
+  do_process_gnss_labels_re: ".*"

--- a/mola_state_estimation_smoother/test/integration/data/moving_test_smoother_params.yaml
+++ b/mola_state_estimation_smoother/test/integration/data/moving_test_smoother_params.yaml
@@ -9,7 +9,7 @@ params:
   enu_frame_name: "enu"
 
   kinematic_model: "KinematicModel::ConstantVelocity"
-  sliding_window_length: 4.0
+  sliding_window_length: 8.0 # long enough to merge several GNSS data
   min_time_difference_to_create_new_frame: 0.01
   max_time_to_use_velocity_model: 2.0
   gnss_nearby_keyframe_stamp_tolerance: 1.0
@@ -23,9 +23,9 @@ params:
   sigma_twist_from_consecutive_poses_linear: 1.0
   sigma_twist_from_consecutive_poses_angular: 1.0
 
-  enforce_planar_motion: true
+  enforce_planar_motion: false
 
-  initial_twist: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  initial_twist: [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ]
   initial_twist_sigma_lin: 20.0
   initial_twist_sigma_ang: 3.0
 
@@ -38,6 +38,7 @@ params:
   convergence_max_position_sigma: "1.0"
   convergence_max_orientation_sigma_deg: "5.0"
   publish_estimated_georef_on_convergence: true
+  link_first_pose_to_reference_origin_sigma: 1e-6
 
   additional_isam2_update_steps: 3
 

--- a/mola_state_estimation_smoother/test/integration/data/static_test_smoother_params.yaml
+++ b/mola_state_estimation_smoother/test/integration/data/static_test_smoother_params.yaml
@@ -1,0 +1,50 @@
+# MOLA state estimator params for the static convergence integration test.
+# Standalone copy of state-estimation-smoother.yaml with:
+#   estimate_geo_reference: false (hardcoded, no env-var lookup)
+#   fixed_geo_reference: Almeria test origin used by existing C++ unit tests
+
+params:
+  vehicle_frame_name: "base_link"
+  reference_frame_name: "map"
+  enu_frame_name: "enu"
+
+  kinematic_model: "KinematicModel::ConstantVelocity"
+  sliding_window_length: 4.0
+  min_time_difference_to_create_new_frame: 0.01
+  max_time_to_use_velocity_model: 2.0
+  gnss_nearby_keyframe_stamp_tolerance: 1.0
+  imu_nearby_keyframe_stamp_tolerance: 0.10
+  time_between_frames_to_warning: 5.0
+
+  sigma_random_walk_acceleration_linear: 1.0
+  sigma_random_walk_acceleration_angular: 10.0
+  sigma_integrator_position: 0.1
+  sigma_integrator_orientation: 1.0
+  sigma_twist_from_consecutive_poses_linear: 1.0
+  sigma_twist_from_consecutive_poses_angular: 1.0
+
+  enforce_planar_motion: true
+
+  initial_twist: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  initial_twist_sigma_lin: 20.0
+  initial_twist_sigma_ang: 3.0
+
+  imu_attitude_sigma_deg: "2.0"
+  imu_attitude_azimuth_offset_deg: "0.0"
+  imu_normalized_gravity_alignment_sigma: "0.4"
+
+  estimate_geo_reference: false
+  fixed_geo_reference:
+    latitude_deg: 36.8407
+    longitude_deg: -2.4093
+    altitude: 100.0
+
+  convergence_max_position_sigma: "1.0"
+  convergence_max_orientation_sigma_deg: "5.0"
+  publish_estimated_georef_on_convergence: true
+
+  additional_isam2_update_steps: 3
+
+  do_process_imu_labels_re: ".*"
+  do_process_odometry_labels_re: ".*"
+  do_process_gnss_labels_re: ".*"

--- a/mola_state_estimation_smoother/test/integration/data/static_test_smoother_params.yaml
+++ b/mola_state_estimation_smoother/test/integration/data/static_test_smoother_params.yaml
@@ -9,7 +9,7 @@ params:
   enu_frame_name: "enu"
 
   kinematic_model: "KinematicModel::ConstantVelocity"
-  sliding_window_length: 4.0
+  sliding_window_length: 8.0 # long enough to merge several GNSS data
   min_time_difference_to_create_new_frame: 0.01
   max_time_to_use_velocity_model: 2.0
   gnss_nearby_keyframe_stamp_tolerance: 1.0
@@ -23,9 +23,9 @@ params:
   sigma_twist_from_consecutive_poses_linear: 1.0
   sigma_twist_from_consecutive_poses_angular: 1.0
 
-  enforce_planar_motion: true
+  enforce_planar_motion: false
 
-  initial_twist: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  initial_twist: [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ]
   initial_twist_sigma_lin: 20.0
   initial_twist_sigma_ang: 3.0
 

--- a/mola_state_estimation_smoother/test/integration/sensor_mock_node.py
+++ b/mola_state_estimation_smoother/test/integration/sensor_mock_node.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+# Synthetic sensor publisher for mola_state_estimation_smoother integration tests.
+#
+# Publishes noisy odometry, GNSS, and IMU messages that match a closed-form
+# ground-truth trajectory, plus ground_truth/pose for the checker to consume.
+#
+# Run as a standalone ROS 2 node:
+#   python3 sensor_mock_node.py --ros-args -p scenario:=static -p seed:=42
+import math
+import os
+import sys
+import time
+
+import numpy as np
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy
+
+from geometry_msgs.msg import PoseStamped
+from nav_msgs.msg import Odometry
+from sensor_msgs.msg import Imu, NavSatFix, NavSatStatus
+from tf2_msgs.msg import TFMessage
+from geometry_msgs.msg import TransformStamped
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import (
+    GT_LAT0_DEG, GT_LON0_DEG, GT_ALT0_M,
+    enu_to_latlon, imu_quat_from_enu_pose, imu_linear_acc_body,
+    moving_gt_pose, moving_gt_twist, moving_gt_world_accel,
+    static_gt_pose, quaternion_from_euler_zyx,
+    MOVING_DURATION_S,
+)
+
+_TRANSIENT_LOCAL_QOS = QoSProfile(
+    depth=1,
+    durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+    reliability=QoSReliabilityPolicy.RELIABLE,
+)
+
+
+class SensorMockNode(Node):
+    def __init__(self):
+        super().__init__('sensor_mock')
+
+        self.declare_parameter('scenario', 'static')
+        self.declare_parameter('seed', 42)
+        self.declare_parameter('startup_delay_sec', 3.0)
+
+        # Rates [Hz]
+        self.declare_parameter('odom_rate', 10.0)
+        self.declare_parameter('gnss_rate', 2.0)
+        self.declare_parameter('imu_rate', 20.0)
+
+        # Noise sigmas
+        self.declare_parameter('gnss_xy_sigma_m', 1.0)
+        self.declare_parameter('gnss_z_sigma_m', 2.0)
+        self.declare_parameter('imu_yaw_sigma_rad', math.radians(2.0))
+        self.declare_parameter('imu_acc_sigma', 0.2)
+        self.declare_parameter('odom_lin_sigma', 0.02)
+        self.declare_parameter('odom_ang_sigma', math.radians(0.5))
+
+        # Frame names
+        self.declare_parameter('odom_frame', 'odom')
+        self.declare_parameter('base_link_frame', 'base_link')
+        self.declare_parameter('imu_frame', 'imu')
+        self.declare_parameter('gnss_frame', 'gnss')
+
+        self._scenario = self.get_parameter('scenario').value
+        seed = self.get_parameter('seed').value
+        self._rng = np.random.default_rng(seed)
+        self._startup_delay = self.get_parameter('startup_delay_sec').value
+
+        self._odom_frame = self.get_parameter('odom_frame').value
+        self._base_link = self.get_parameter('base_link_frame').value
+        self._imu_frame = self.get_parameter('imu_frame').value
+        self._gnss_frame = self.get_parameter('gnss_frame').value
+
+        self._gnss_xy_sigma = self.get_parameter('gnss_xy_sigma_m').value
+        self._gnss_z_sigma = self.get_parameter('gnss_z_sigma_m').value
+        self._imu_yaw_sigma = self.get_parameter('imu_yaw_sigma_rad').value
+        self._imu_acc_sigma = self.get_parameter('imu_acc_sigma').value
+        self._odom_lin_sigma = self.get_parameter('odom_lin_sigma').value
+        self._odom_ang_sigma = self.get_parameter('odom_ang_sigma').value
+
+        # Publishers
+        self._pub_odom = self.create_publisher(Odometry, '/wheel_odom', 10)
+        self._pub_gnss = self.create_publisher(NavSatFix, '/gps', 10)
+        self._pub_imu = self.create_publisher(Imu, '/imu', 10)
+        self._pub_gt = self.create_publisher(PoseStamped, '/ground_truth/pose', 10)
+        self._pub_tf_static = self.create_publisher(TFMessage, '/tf_static',
+                                                     _TRANSIENT_LOCAL_QOS)
+
+        # Accumulated dead-reckoning pose in odom frame (x, y, yaw)
+        self._odom_x = 0.0
+        self._odom_y = 0.0
+        self._odom_yaw = 0.0
+
+        self._t_start = None  # wall time when publishing first started
+
+        odom_dt = 1.0 / self.get_parameter('odom_rate').value
+        gnss_dt = 1.0 / self.get_parameter('gnss_rate').value
+        imu_dt = 1.0 / self.get_parameter('imu_rate').value
+
+        self.create_timer(odom_dt, self._odom_cb)
+        self.create_timer(gnss_dt, self._gnss_cb)
+        self.create_timer(imu_dt, self._imu_cb)
+        # Re-publish tf_static periodically so late subscribers get it
+        self.create_timer(5.0, self._publish_tf_static)
+
+        # Publish tf_static immediately
+        self._publish_tf_static()
+        self.get_logger().info(
+            f"SensorMockNode started: scenario={self._scenario}, seed={seed}, "
+            f"startup_delay={self._startup_delay} s"
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _elapsed(self):
+        """Seconds since first sensor message (None if still in delay)."""
+        if self._t_start is None:
+            return None
+        return time.monotonic() - self._t_start
+
+    def _maybe_start(self):
+        """Return True if past the startup delay, starting the clock if needed."""
+        now = time.monotonic()
+        if self._t_start is None:
+            if not hasattr(self, '_t_node_start'):
+                self._t_node_start = now
+            if now - self._t_node_start < self._startup_delay:
+                return False
+            self._t_start = now
+            self.get_logger().info("Sensor mock: starting publication")
+        return True
+
+    def _gt_at(self, t):
+        """Return (x, y, z, yaw, pitch, roll) at trajectory time t."""
+        if self._scenario == 'static':
+            return static_gt_pose()
+        return moving_gt_pose(t)
+
+    def _gt_twist_at(self, t):
+        """Return body-frame twist (vx, vy, vz, wx, wy, wz) at trajectory time t."""
+        if self._scenario == 'static':
+            return 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+        return moving_gt_twist(t)
+
+    def _now_stamp(self):
+        return self.get_clock().now().to_msg()
+
+    # ------------------------------------------------------------------
+    # Static TF: base_link -> imu / gnss (identity, TRANSIENT_LOCAL)
+    # ------------------------------------------------------------------
+
+    def _publish_tf_static(self):
+        now = self._now_stamp()
+        msgs = []
+        for child in (self._imu_frame, self._gnss_frame):
+            tf = TransformStamped()
+            tf.header.stamp = now
+            tf.header.frame_id = self._base_link
+            tf.child_frame_id = child
+            tf.transform.rotation.w = 1.0
+            msgs.append(tf)
+        self._pub_tf_static.publish(TFMessage(transforms=msgs))
+
+    # ------------------------------------------------------------------
+    # Odometry callback
+    # ------------------------------------------------------------------
+
+    def _odom_cb(self):
+        if not self._maybe_start():
+            return
+
+        t = self._elapsed()
+        x, y, z, yaw, pitch, roll = self._gt_at(t)
+        vx, vy, vz, wx, wy, wz = self._gt_twist_at(t)
+
+        # Integrate noisy twist into odom pose
+        odom_dt = 1.0 / self.get_parameter('odom_rate').value
+        noisy_vx = vx + self._rng.normal(0, self._odom_lin_sigma)
+        noisy_wz = wz + self._rng.normal(0, self._odom_ang_sigma)
+
+        self._odom_x += (noisy_vx * math.cos(self._odom_yaw)) * odom_dt
+        self._odom_y += (noisy_vx * math.sin(self._odom_yaw)) * odom_dt
+        self._odom_yaw += noisy_wz * odom_dt
+
+        qx, qy, qz, qw = quaternion_from_euler_zyx(0.0, 0.0, self._odom_yaw)
+
+        msg = Odometry()
+        msg.header.stamp = self._now_stamp()
+        msg.header.frame_id = self._odom_frame
+        msg.child_frame_id = self._base_link
+
+        msg.pose.pose.position.x = self._odom_x
+        msg.pose.pose.position.y = self._odom_y
+        msg.pose.pose.orientation.x = qx
+        msg.pose.pose.orientation.y = qy
+        msg.pose.pose.orientation.z = qz
+        msg.pose.pose.orientation.w = qw
+
+        # Diagonal pose covariance (xy and yaw)
+        msg.pose.covariance[0] = (self._odom_lin_sigma * t) ** 2 + 0.01
+        msg.pose.covariance[7] = (self._odom_lin_sigma * t) ** 2 + 0.01
+        msg.pose.covariance[35] = (self._odom_ang_sigma * t) ** 2 + 0.001
+
+        # Twist in body frame
+        msg.twist.twist.linear.x = vx + self._rng.normal(0, self._odom_lin_sigma)
+        msg.twist.twist.linear.y = vy + self._rng.normal(0, self._odom_lin_sigma)
+        msg.twist.twist.angular.z = wz + self._rng.normal(0, self._odom_ang_sigma)
+        msg.twist.covariance[0] = self._odom_lin_sigma ** 2
+        msg.twist.covariance[7] = self._odom_lin_sigma ** 2
+        msg.twist.covariance[35] = self._odom_ang_sigma ** 2
+
+        self._pub_odom.publish(msg)
+        self._publish_gt(t, x, y, yaw)
+
+    # ------------------------------------------------------------------
+    # GNSS callback
+    # ------------------------------------------------------------------
+
+    def _gnss_cb(self):
+        if not self._maybe_start():
+            return
+
+        t = self._elapsed()
+        x, y, z, yaw, pitch, roll = self._gt_at(t)
+
+        # Convert ENU to geodetic (flat-Earth)
+        lat, lon, alt = enu_to_latlon(
+            x + self._rng.normal(0, self._gnss_xy_sigma),
+            y + self._rng.normal(0, self._gnss_xy_sigma),
+            z + self._rng.normal(0, self._gnss_z_sigma),
+        )
+
+        msg = NavSatFix()
+        msg.header.stamp = self._now_stamp()
+        msg.header.frame_id = self._gnss_frame
+        msg.status.status = NavSatStatus.STATUS_FIX
+        msg.status.service = NavSatStatus.SERVICE_GPS
+        msg.latitude = lat
+        msg.longitude = lon
+        msg.altitude = alt
+        # ENU covariance (xx, yy, zz on diagonal)
+        msg.position_covariance_type = NavSatFix.COVARIANCE_TYPE_DIAGONAL_KNOWN
+        msg.position_covariance[0] = self._gnss_xy_sigma ** 2
+        msg.position_covariance[4] = self._gnss_xy_sigma ** 2
+        msg.position_covariance[8] = self._gnss_z_sigma ** 2
+
+        self._pub_gnss.publish(msg)
+
+    # ------------------------------------------------------------------
+    # IMU callback
+    # ------------------------------------------------------------------
+
+    def _imu_cb(self):
+        if not self._maybe_start():
+            return
+
+        t = self._elapsed()
+        x, y, z, yaw, pitch, roll = self._gt_at(t)
+        vx, vy, vz, wx, wy, wz = self._gt_twist_at(t)
+
+        # Orientation quaternion (IMU convention: quat_yaw = enu_yaw - pi/2)
+        noisy_yaw = yaw + self._rng.normal(0, self._imu_yaw_sigma)
+        qx, qy, qz, qw = imu_quat_from_enu_pose(noisy_yaw, pitch, roll)
+
+        # Linear acceleration in body frame
+        if self._scenario == 'moving':
+            ax_w, ay_w = moving_gt_world_accel(t)
+        else:
+            ax_w, ay_w = 0.0, 0.0
+        acc = imu_linear_acc_body(yaw, pitch, roll, ax_w, ay_w)
+
+        msg = Imu()
+        msg.header.stamp = self._now_stamp()
+        msg.header.frame_id = self._imu_frame
+
+        msg.orientation.x = qx
+        msg.orientation.y = qy
+        msg.orientation.z = qz
+        msg.orientation.w = qw
+        cov_quat = self._imu_yaw_sigma ** 2
+        msg.orientation_covariance[0] = cov_quat
+        msg.orientation_covariance[4] = cov_quat
+        msg.orientation_covariance[8] = cov_quat
+
+        msg.angular_velocity.x = self._rng.normal(0, math.radians(0.5))
+        msg.angular_velocity.y = self._rng.normal(0, math.radians(0.5))
+        msg.angular_velocity.z = wz + self._rng.normal(0, math.radians(1.0))
+        msg.angular_velocity_covariance[0] = math.radians(1.0) ** 2
+        msg.angular_velocity_covariance[4] = math.radians(1.0) ** 2
+        msg.angular_velocity_covariance[8] = math.radians(1.0) ** 2
+
+        msg.linear_acceleration.x = acc[0] + self._rng.normal(0, self._imu_acc_sigma)
+        msg.linear_acceleration.y = acc[1] + self._rng.normal(0, self._imu_acc_sigma)
+        msg.linear_acceleration.z = acc[2] + self._rng.normal(0, self._imu_acc_sigma)
+        cov_acc = self._imu_acc_sigma ** 2
+        msg.linear_acceleration_covariance[0] = cov_acc
+        msg.linear_acceleration_covariance[4] = cov_acc
+        msg.linear_acceleration_covariance[8] = cov_acc
+
+        self._pub_imu.publish(msg)
+
+    # ------------------------------------------------------------------
+    # Ground-truth pose publisher (called from odom callback)
+    # ------------------------------------------------------------------
+
+    def _publish_gt(self, t, x, y, yaw):
+        qx, qy, qz, qw = quaternion_from_euler_zyx(0.0, 0.0, yaw)
+        msg = PoseStamped()
+        msg.header.stamp = self._now_stamp()
+        msg.header.frame_id = 'enu'
+        msg.pose.position.x = x
+        msg.pose.position.y = y
+        msg.pose.orientation.x = qx
+        msg.pose.orientation.y = qy
+        msg.pose.orientation.z = qz
+        msg.pose.orientation.w = qw
+        self._pub_gt.publish(msg)
+
+
+def main():
+    rclpy.init()
+    node = SensorMockNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/mola_state_estimation_smoother/test/integration/sensor_mock_node.py
+++ b/mola_state_estimation_smoother/test/integration/sensor_mock_node.py
@@ -6,6 +6,13 @@
 #
 # Run as a standalone ROS 2 node:
 #   python3 sensor_mock_node.py --ros-args -p scenario:=static -p seed:=42
+from common import (
+    GT_LAT0_DEG, GT_LON0_DEG, GT_ALT0_M,
+    enu_to_latlon, imu_quat_from_enu_pose, imu_linear_acc_body,
+    moving_gt_pose, moving_gt_twist, moving_gt_world_accel,
+    static_gt_pose, quaternion_from_euler_zyx,
+    MOVING_DURATION_S,
+)
 import math
 import os
 import sys
@@ -23,13 +30,6 @@ from tf2_msgs.msg import TFMessage
 from geometry_msgs.msg import TransformStamped
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from common import (
-    GT_LAT0_DEG, GT_LON0_DEG, GT_ALT0_M,
-    enu_to_latlon, imu_quat_from_enu_pose, imu_linear_acc_body,
-    moving_gt_pose, moving_gt_twist, moving_gt_world_accel,
-    static_gt_pose, quaternion_from_euler_zyx,
-    MOVING_DURATION_S,
-)
 
 _TRANSIENT_LOCAL_QOS = QoSProfile(
     depth=1,
@@ -86,9 +86,10 @@ class SensorMockNode(Node):
         self._pub_odom = self.create_publisher(Odometry, '/wheel_odom', 10)
         self._pub_gnss = self.create_publisher(NavSatFix, '/gps', 10)
         self._pub_imu = self.create_publisher(Imu, '/imu', 10)
-        self._pub_gt = self.create_publisher(PoseStamped, '/ground_truth/pose', 10)
+        self._pub_gt = self.create_publisher(
+            PoseStamped, '/ground_truth/pose', 10)
         self._pub_tf_static = self.create_publisher(TFMessage, '/tf_static',
-                                                     _TRANSIENT_LOCAL_QOS)
+                                                    _TRANSIENT_LOCAL_QOS)
 
         # Accumulated dead-reckoning pose in odom frame (x, y, yaw)
         self._odom_x = 0.0
@@ -176,8 +177,8 @@ class SensorMockNode(Node):
             return
 
         t = self._elapsed()
-        x, y, z, yaw, pitch, roll = self._gt_at(t)
-        vx, vy, vz, wx, wy, wz = self._gt_twist_at(t)
+        x, y, _z, yaw, _pitch, _roll = self._gt_at(t)
+        vx, vy, vz, _wx, _wy, wz = self._gt_twist_at(t)
 
         # Integrate noisy twist into odom pose
         odom_dt = 1.0 / self.get_parameter('odom_rate').value
@@ -208,9 +209,12 @@ class SensorMockNode(Node):
         msg.pose.covariance[35] = (self._odom_ang_sigma * t) ** 2 + 0.001
 
         # Twist in body frame
-        msg.twist.twist.linear.x = vx + self._rng.normal(0, self._odom_lin_sigma)
-        msg.twist.twist.linear.y = vy + self._rng.normal(0, self._odom_lin_sigma)
-        msg.twist.twist.angular.z = wz + self._rng.normal(0, self._odom_ang_sigma)
+        msg.twist.twist.linear.x = vx + \
+            self._rng.normal(0, self._odom_lin_sigma)
+        msg.twist.twist.linear.y = vy + \
+            self._rng.normal(0, self._odom_lin_sigma)
+        msg.twist.twist.angular.z = wz + \
+            self._rng.normal(0, self._odom_ang_sigma)
         msg.twist.covariance[0] = self._odom_lin_sigma ** 2
         msg.twist.covariance[7] = self._odom_lin_sigma ** 2
         msg.twist.covariance[35] = self._odom_ang_sigma ** 2
@@ -295,9 +299,12 @@ class SensorMockNode(Node):
         msg.angular_velocity_covariance[4] = math.radians(1.0) ** 2
         msg.angular_velocity_covariance[8] = math.radians(1.0) ** 2
 
-        msg.linear_acceleration.x = acc[0] + self._rng.normal(0, self._imu_acc_sigma)
-        msg.linear_acceleration.y = acc[1] + self._rng.normal(0, self._imu_acc_sigma)
-        msg.linear_acceleration.z = acc[2] + self._rng.normal(0, self._imu_acc_sigma)
+        msg.linear_acceleration.x = acc[0] + \
+            self._rng.normal(0, self._imu_acc_sigma)
+        msg.linear_acceleration.y = acc[1] + \
+            self._rng.normal(0, self._imu_acc_sigma)
+        msg.linear_acceleration.z = acc[2] + \
+            self._rng.normal(0, self._imu_acc_sigma)
         cov_acc = self._imu_acc_sigma ** 2
         msg.linear_acceleration_covariance[0] = cov_acc
         msg.linear_acceleration_covariance[4] = cov_acc

--- a/mola_state_estimation_smoother/test/integration/test_moving_georef.py
+++ b/mola_state_estimation_smoother/test/integration/test_moving_georef.py
@@ -61,6 +61,9 @@ def generate_test_description():
             'ODOM1_LABEL': 'wheel_odom',
             'IMU_TOPIC': '/imu',
             'GNSS_TOPIC': '/gps',
+            'ODOM2_TOPIC': '',  # remove after all distros have mola_yaml>=2.6.1
+            'ODOM3_TOPIC': '',  # remove after all distros have mola_yaml>=2.6.1
+            'ODOM4_TOPIC': '',  # remove after all distros have mola_yaml>=2.6.1
             'MOLA_USE_FIXED_IMU_POSE': 'true',
             'IMU_POSE_X': '0', 'IMU_POSE_Y': '0', 'IMU_POSE_Z': '0',
             'IMU_POSE_YAW': '0', 'IMU_POSE_PITCH': '0', 'IMU_POSE_ROLL': '0',
@@ -163,7 +166,8 @@ class TestMovingGeoRef(unittest.TestCase):
         settled_since = None
         pos_err = float('inf')
         yaw_err_deg = float('inf')
-        T_map_from_enu = None  # (tx, ty, dyaw) such that map = R(dyaw)·enu + (tx,ty)
+        # (tx, ty, dyaw) such that map = R(dyaw)·enu + (tx,ty)
+        T_map_from_enu = None
 
         while time.monotonic() < deadline:
             rclpy.spin_once(self.checker, timeout_sec=0.05)

--- a/mola_state_estimation_smoother/test/integration/test_moving_georef.py
+++ b/mola_state_estimation_smoother/test/integration/test_moving_georef.py
@@ -1,0 +1,152 @@
+# Integration test — Scenario B: moving robot, self-estimated geo-reference.
+#
+# Launches mola-cli with estimate_geo_reference=true and a sensor mock that
+# publishes a sinusoidal 60-second trajectory (v=1 m/s, A=2 m, omega=0.5 rad/s).
+#
+# Asserts that after a 20-second warm-up the estimator's pose tracks the
+# ground truth within 1.5 m and 10 deg.
+import math
+import os
+import sys
+import time
+import unittest
+
+import launch
+import launch.actions
+import launch_ros.actions
+import launch_testing
+import launch_testing.actions
+import pytest
+import rclpy
+from ament_index_python import get_package_share_directory
+
+from geometry_msgs.msg import PoseStamped
+from nav_msgs.msg import Odometry
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import PoseLatest, wait_for_convergence
+
+_SKIP_ENV = 'MOLA_SKIP_INTEGRATION_TESTS'
+
+# ------------------------------------------------------------------
+# Launch description
+# ------------------------------------------------------------------
+
+@pytest.mark.launch_test
+def generate_test_description():
+    if os.environ.get(_SKIP_ENV):
+        return launch.LaunchDescription([
+            launch_testing.actions.ReadyToTest(),
+        ])
+
+    pkg_share = get_package_share_directory('mola_state_estimation_smoother')
+    mola_yaml = os.path.join(pkg_share, 'mola-cli-launchs', 'state_estimator_ros2.yaml')
+    moving_params = os.path.join(
+        pkg_share, 'test', 'integration', 'data', 'moving_test_smoother_params.yaml')
+
+    mock_script = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                'sensor_mock_node.py')
+
+    mola_node = launch_ros.actions.Node(
+        package='mola_launcher',
+        executable='mola-cli',
+        output='screen',
+        arguments=[mola_yaml],
+        remappings=[('/tf', 'tf'), ('/tf_static', 'tf_static')],
+        additional_env={
+            'MOLA_WITH_GUI': 'false',
+            'MOLA_STATE_ESTIMATOR_YAML': moving_params,
+            'ODOM1_TOPIC': '/wheel_odom',
+            'ODOM1_LABEL': 'wheel_odom',
+            'IMU_TOPIC': '/imu',
+            'GNSS_TOPIC': '/gps',
+            'MOLA_USE_FIXED_IMU_POSE': 'true',
+            'IMU_POSE_X': '0', 'IMU_POSE_Y': '0', 'IMU_POSE_Z': '0',
+            'IMU_POSE_YAW': '0', 'IMU_POSE_PITCH': '0', 'IMU_POSE_ROLL': '0',
+            'MOLA_USE_FIXED_GNSS_POSE': 'true',
+            'GNSS_POSE_X': '0', 'GNSS_POSE_Y': '0', 'GNSS_POSE_Z': '0',
+            'GNSS_POSE_YAW': '0', 'GNSS_POSE_PITCH': '0', 'GNSS_POSE_ROLL': '0',
+            'MOLA_LOCALIZATION_PUBLISH_ODOM_MSGS': 'true',
+            'MOLA_LOCALIZATION_PUBLISH_ODOM_MSGS_SOURCE': 'state_estimation',
+            'MOLA_LOCALIZATION_PUBLISH_TF': 'true',
+            'MOLA_LOCALIZATION_PUBLISH_TF_SOURCE': 'state_estimation',
+            'MOLA_NAVSTATE_ENFORCE_PLANAR_MOTION': 'true',
+            'MOLA_ESTIMATE_GEO_REF': 'true',
+            'RCUTILS_LOGGING_BUFFERED_STREAM': '1',
+        },
+    )
+
+    mock_proc = launch.actions.ExecuteProcess(
+        cmd=['python3', mock_script,
+             '--ros-args',
+             '-p', 'scenario:=moving',
+             '-p', 'seed:=1234',
+             '-p', 'startup_delay_sec:=4.0',
+             '-p', 'odom_rate:=10.0',
+             '-p', 'gnss_rate:=2.0',
+             '-p', 'imu_rate:=20.0'],
+        output='screen',
+    )
+
+    return launch.LaunchDescription([
+        mola_node,
+        mock_proc,
+        launch_testing.actions.ReadyToTest(),
+    ])
+
+
+# ------------------------------------------------------------------
+# Active test
+# ------------------------------------------------------------------
+
+class TestMovingGeoRef(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.checker = rclpy.create_node('checker_moving')
+        cls.est_pose = PoseLatest()
+        cls.gt_pose = PoseLatest()
+
+        def _yaw_from_quat(q):
+            siny_cosp = 2.0 * (q.w * q.z + q.x * q.y)
+            cosy_cosp = 1.0 - 2.0 * (q.y * q.y + q.z * q.z)
+            return math.atan2(siny_cosp, cosy_cosp)
+
+        def _est_cb(msg):
+            x = msg.pose.pose.position.x
+            y = msg.pose.pose.position.y
+            cls.est_pose.update(x, y, _yaw_from_quat(msg.pose.pose.orientation))
+
+        def _gt_cb(msg):
+            x = msg.pose.position.x
+            y = msg.pose.position.y
+            cls.gt_pose.update(x, y, _yaw_from_quat(msg.pose.orientation))
+
+        cls.checker.create_subscription(
+            Odometry, 'state_estimation/pose', _est_cb, 10)
+        cls.checker.create_subscription(
+            PoseStamped, '/ground_truth/pose', _gt_cb, 10)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.checker.destroy_node()
+        rclpy.shutdown()
+
+    def test_moving_trajectory_tracking(self):
+        if os.environ.get(_SKIP_ENV):
+            self.skipTest('MOLA_SKIP_INTEGRATION_TESTS is set')
+
+        # Allow 20 s for the smoother to converge on the geo-reference, then
+        # check that the estimated pose tracks GT within the moving thresholds
+        # for at least 3 s continuously.
+        wait_for_convergence(
+            self.checker,
+            self.gt_pose,
+            self.est_pose,
+            max_pos_err_m=1.5,
+            max_heading_err_deg=10.0,
+            settle_seconds=3.0,
+            timeout_seconds=100.0,
+            warm_up_seconds=20.0,
+        )

--- a/mola_state_estimation_smoother/test/integration/test_moving_georef.py
+++ b/mola_state_estimation_smoother/test/integration/test_moving_georef.py
@@ -19,10 +19,8 @@ import launch_testing.actions
 import pytest
 import rclpy
 from ament_index_python import get_package_share_directory
-
 from geometry_msgs.msg import PoseStamped
 from nav_msgs.msg import Odometry
-
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from common import PoseLatest, wait_for_convergence  # noqa: E402, isort:skip
@@ -75,8 +73,8 @@ def generate_test_description():
             'MOLA_LOCALIZATION_PUBLISH_TF_SOURCE': 'state_estimation',
             'MOLA_NAVSTATE_ENFORCE_PLANAR_MOTION': 'true',
             'MOLA_ESTIMATE_GEO_REF': 'true',
-            'MOLA_VERBOSITY_BRIDGE_ROS2': 'DEBUG',
-            'MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR': 'DEBUG',
+            'MOLA_VERBOSITY_BRIDGE_ROS2': 'INFO',
+            'MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR': 'INFO',
             'RCUTILS_LOGGING_BUFFERED_STREAM': '1',
         },
     )
@@ -119,15 +117,16 @@ class TestMovingGeoRef(unittest.TestCase):
             return math.atan2(siny_cosp, cosy_cosp)
 
         def _est_cb(msg):
-            x = msg.pose.pose.position.x
-            y = msg.pose.pose.position.y
-            cls.est_pose.update(x, y, _yaw_from_quat(
-                msg.pose.pose.orientation))
+            cls.est_pose.update(
+                msg.pose.pose.position.x,
+                msg.pose.pose.position.y,
+                _yaw_from_quat(msg.pose.pose.orientation))
 
         def _gt_cb(msg):
-            x = msg.pose.position.x
-            y = msg.pose.position.y
-            cls.gt_pose.update(x, y, _yaw_from_quat(msg.pose.orientation))
+            cls.gt_pose.update(
+                msg.pose.position.x,
+                msg.pose.position.y,
+                _yaw_from_quat(msg.pose.orientation))
 
         cls.checker.create_subscription(
             Odometry, 'state_estimation/pose', _est_cb, 10)
@@ -143,16 +142,65 @@ class TestMovingGeoRef(unittest.TestCase):
         if os.environ.get(_SKIP_ENV):
             self.skipTest('MOLA_SKIP_INTEGRATION_TESTS is set')
 
-        # Allow 20 s for the smoother to converge on the geo-reference, then
-        # check that the estimated pose tracks GT within the moving thresholds
-        # for at least 3 s continuously.
-        wait_for_convergence(
-            self.checker,
-            self.gt_pose,
-            self.est_pose,
-            max_pos_err_m=1.5,
-            max_heading_err_deg=10.0,
-            settle_seconds=3.0,
-            timeout_seconds=100.0,
-            warm_up_seconds=20.0,
+        # Compare estimated pose in map frame vs GT in ENU frame.
+        # The true T_enu_to_map is identity by construction (robot anchored at ENU
+        # origin), so map == true ENU and the frames are directly comparable.
+        # Using the Odometry topic (map frame) avoids compounding with the smoother's
+        # estimated T_enu_to_map, which carries a ~2m bootstrap bias from the first
+        # noisy GNSS reading.
+        #
+        # All time comparisons use time.monotonic() — PoseLatest._updated_at is
+        # also stamped with time.monotonic(), so they are directly comparable.
+        max_pos_err_m = 1.5
+        max_heading_err_deg = 10.0
+        settle_seconds = 3.0
+        warm_up_seconds = 10.0
+        timeout_seconds = 25.0
+
+        deadline = time.monotonic() + warm_up_seconds + timeout_seconds
+        warm_up_end = time.monotonic() + warm_up_seconds
+        settled_since = None
+        pos_err = float('inf')
+        yaw_err_deg = float('inf')
+
+        while time.monotonic() < deadline:
+            rclpy.spin_once(self.checker, timeout_sec=0.05)
+
+            now = time.monotonic()
+            if now < warm_up_end:
+                continue
+
+            gt, gt_t = self.gt_pose.latest()
+            est, est_t = self.est_pose.latest()
+            if (gt is None or est is None or
+                    gt_t is None or est_t is None or
+                    now - gt_t > 0.5 or now - est_t > 0.5):
+                continue
+
+            pos_err = math.hypot(gt[0] - est[0], gt[1] - est[1])
+            yaw_err = math.degrees(
+                math.atan2(math.sin(gt[2] - est[2]),
+                           math.cos(gt[2] - est[2])))
+            yaw_err_deg = abs(yaw_err)
+            passed = pos_err < max_pos_err_m and yaw_err_deg < max_heading_err_deg
+
+            print(
+                f'[moving] gt=({gt[0]:.2f},{gt[1]:.2f},{math.degrees(gt[2]):.1f}°) '
+                f'est_map=({est[0]:.2f},{est[1]:.2f},{math.degrees(est[2]):.1f}°) '
+                f'pos_err={pos_err:.3f}m yaw_err={yaw_err:.1f}° pass={passed}',
+                flush=True)
+
+            if passed:
+                if settled_since is None:
+                    settled_since = now
+                if now - settled_since >= settle_seconds:
+                    print(f'[moving] CONVERGED after {settle_seconds:.1f}s settled',
+                          flush=True)
+                    return
+            else:
+                settled_since = None
+
+        raise AssertionError(
+            f'did not converge within {timeout_seconds:.0f}s: '
+            f'pos_err={pos_err:.2f}m yaw_err={yaw_err_deg:.2f}deg'
         )

--- a/mola_state_estimation_smoother/test/integration/test_moving_georef.py
+++ b/mola_state_estimation_smoother/test/integration/test_moving_georef.py
@@ -23,14 +23,16 @@ from ament_index_python import get_package_share_directory
 from geometry_msgs.msg import PoseStamped
 from nav_msgs.msg import Odometry
 
+
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from common import PoseLatest, wait_for_convergence
+from common import PoseLatest, wait_for_convergence  # noqa: E402, isort:skip
 
 _SKIP_ENV = 'MOLA_SKIP_INTEGRATION_TESTS'
 
 # ------------------------------------------------------------------
 # Launch description
 # ------------------------------------------------------------------
+
 
 @pytest.mark.launch_test
 def generate_test_description():
@@ -40,12 +42,13 @@ def generate_test_description():
         ])
 
     pkg_share = get_package_share_directory('mola_state_estimation_smoother')
-    mola_yaml = os.path.join(pkg_share, 'mola-cli-launchs', 'state_estimator_ros2.yaml')
+    mola_yaml = os.path.join(
+        pkg_share, 'mola-cli-launchs', 'state_estimator_ros2.yaml')
     moving_params = os.path.join(
         pkg_share, 'test', 'integration', 'data', 'moving_test_smoother_params.yaml')
 
     mock_script = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                'sensor_mock_node.py')
+                               'sensor_mock_node.py')
 
     mola_node = launch_ros.actions.Node(
         package='mola_launcher',
@@ -72,6 +75,8 @@ def generate_test_description():
             'MOLA_LOCALIZATION_PUBLISH_TF_SOURCE': 'state_estimation',
             'MOLA_NAVSTATE_ENFORCE_PLANAR_MOTION': 'true',
             'MOLA_ESTIMATE_GEO_REF': 'true',
+            'MOLA_VERBOSITY_BRIDGE_ROS2': 'DEBUG',
+            'MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR': 'DEBUG',
             'RCUTILS_LOGGING_BUFFERED_STREAM': '1',
         },
     )
@@ -116,7 +121,8 @@ class TestMovingGeoRef(unittest.TestCase):
         def _est_cb(msg):
             x = msg.pose.pose.position.x
             y = msg.pose.pose.position.y
-            cls.est_pose.update(x, y, _yaw_from_quat(msg.pose.pose.orientation))
+            cls.est_pose.update(x, y, _yaw_from_quat(
+                msg.pose.pose.orientation))
 
         def _gt_cb(msg):
             x = msg.pose.position.x

--- a/mola_state_estimation_smoother/test/integration/test_moving_georef.py
+++ b/mola_state_estimation_smoother/test/integration/test_moving_georef.py
@@ -142,50 +142,74 @@ class TestMovingGeoRef(unittest.TestCase):
         if os.environ.get(_SKIP_ENV):
             self.skipTest('MOLA_SKIP_INTEGRATION_TESTS is set')
 
-        # Compare estimated pose in map frame vs GT in ENU frame.
-        # The true T_enu_to_map is identity by construction (robot anchored at ENU
-        # origin), so map == true ENU and the frames are directly comparable.
-        # Using the Odometry topic (map frame) avoids compounding with the smoother's
-        # estimated T_enu_to_map, which carries a ~2m bootstrap bias from the first
-        # noisy GNSS reading.
+        # The estimator publishes pose in the `map` frame, while ground truth is
+        # in the `enu` frame. With link_first_pose_to_reference_origin_sigma=1e-6
+        # the smoother anchors the robot's first pose to the map origin with
+        # identity orientation, so map == enu only if the robot starts at ENU
+        # origin with yaw=0. In this scenario GT(t=0) = (0, 0, atan2(A·omega, V))
+        # = (0, 0, 45°), so T_enu_to_map is a -45° rotation about the origin and
+        # the two frames are NOT directly comparable.
         #
-        # All time comparisons use time.monotonic() — PoseLatest._updated_at is
-        # also stamped with time.monotonic(), so they are directly comparable.
+        # We recover T_map_from_enu from the first matched (gt, est) pair
+        # captured during the warm-up window, then transform GT into map.
         max_pos_err_m = 1.5
         max_heading_err_deg = 10.0
         settle_seconds = 3.0
-        warm_up_seconds = 10.0
-        timeout_seconds = 25.0
+        warm_up_seconds = 20.0
+        timeout_seconds = 40.0
 
         deadline = time.monotonic() + warm_up_seconds + timeout_seconds
         warm_up_end = time.monotonic() + warm_up_seconds
         settled_since = None
         pos_err = float('inf')
         yaw_err_deg = float('inf')
+        T_map_from_enu = None  # (tx, ty, dyaw) such that map = R(dyaw)·enu + (tx,ty)
 
         while time.monotonic() < deadline:
             rclpy.spin_once(self.checker, timeout_sec=0.05)
 
             now = time.monotonic()
-            if now < warm_up_end:
-                continue
 
             gt, gt_t = self.gt_pose.latest()
             est, est_t = self.est_pose.latest()
-            if (gt is None or est is None or
-                    gt_t is None or est_t is None or
-                    now - gt_t > 0.5 or now - est_t > 0.5):
+            fresh = (gt is not None and est is not None and
+                     gt_t is not None and est_t is not None and
+                     now - gt_t < 0.5 and now - est_t < 0.5)
+
+            # Lock T_map_from_enu using the very first fresh sample. At t≈0 the
+            # estimator's pose equals the map-anchored origin, so this pair pins
+            # the transform between the two frames for the rest of the run.
+            if T_map_from_enu is None and fresh:
+                dyaw = est[2] - gt[2]
+                c, s = math.cos(dyaw), math.sin(dyaw)
+                tx = est[0] - (c * gt[0] - s * gt[1])
+                ty = est[1] - (s * gt[0] + c * gt[1])
+                T_map_from_enu = (tx, ty, dyaw)
+                print(f'[moving] locked T_map_from_enu=({tx:.3f},{ty:.3f},'
+                      f'{math.degrees(dyaw):.2f}°)', flush=True)
+
+            if now < warm_up_end:
                 continue
 
-            pos_err = math.hypot(gt[0] - est[0], gt[1] - est[1])
+            if not fresh or T_map_from_enu is None:
+                continue
+
+            tx, ty, dyaw = T_map_from_enu
+            c, s = math.cos(dyaw), math.sin(dyaw)
+            gt_in_map_x = c * gt[0] - s * gt[1] + tx
+            gt_in_map_y = s * gt[0] + c * gt[1] + ty
+            gt_in_map_yaw = gt[2] + dyaw
+
+            pos_err = math.hypot(gt_in_map_x - est[0], gt_in_map_y - est[1])
             yaw_err = math.degrees(
-                math.atan2(math.sin(gt[2] - est[2]),
-                           math.cos(gt[2] - est[2])))
+                math.atan2(math.sin(gt_in_map_yaw - est[2]),
+                           math.cos(gt_in_map_yaw - est[2])))
             yaw_err_deg = abs(yaw_err)
             passed = pos_err < max_pos_err_m and yaw_err_deg < max_heading_err_deg
 
             print(
-                f'[moving] gt=({gt[0]:.2f},{gt[1]:.2f},{math.degrees(gt[2]):.1f}°) '
+                f'[moving] gt_map=({gt_in_map_x:.2f},{gt_in_map_y:.2f},'
+                f'{math.degrees(gt_in_map_yaw):.1f}°) '
                 f'est_map=({est[0]:.2f},{est[1]:.2f},{math.degrees(est[2]):.1f}°) '
                 f'pos_err={pos_err:.3f}m yaw_err={yaw_err:.1f}° pass={passed}',
                 flush=True)

--- a/mola_state_estimation_smoother/test/integration/test_static_convergence.py
+++ b/mola_state_estimation_smoother/test/integration/test_static_convergence.py
@@ -26,13 +26,14 @@ from geometry_msgs.msg import PoseStamped
 from nav_msgs.msg import Odometry
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from common import PoseLatest, wrap_pi, wait_for_convergence
+from common import PoseLatest, wrap_pi, wait_for_convergence  # noqa: E402, isort:skip
 
 _SKIP_ENV = 'MOLA_SKIP_INTEGRATION_TESTS'
 
 # ------------------------------------------------------------------
 # Launch description
 # ------------------------------------------------------------------
+
 
 @pytest.mark.launch_test
 def generate_test_description():
@@ -42,12 +43,13 @@ def generate_test_description():
         ])
 
     pkg_share = get_package_share_directory('mola_state_estimation_smoother')
-    mola_yaml = os.path.join(pkg_share, 'mola-cli-launchs', 'state_estimator_ros2.yaml')
+    mola_yaml = os.path.join(
+        pkg_share, 'mola-cli-launchs', 'state_estimator_ros2.yaml')
     static_params = os.path.join(
         pkg_share, 'test', 'integration', 'data', 'static_test_smoother_params.yaml')
 
     mock_script = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                'sensor_mock_node.py')
+                               'sensor_mock_node.py')
 
     mola_node = launch_ros.actions.Node(
         package='mola_launcher',
@@ -73,6 +75,8 @@ def generate_test_description():
             'MOLA_LOCALIZATION_PUBLISH_TF': 'true',
             'MOLA_LOCALIZATION_PUBLISH_TF_SOURCE': 'state_estimation',
             'MOLA_NAVSTATE_ENFORCE_PLANAR_MOTION': 'true',
+            'MOLA_VERBOSITY_BRIDGE_ROS2': 'DEBUG',
+            'MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR': 'DEBUG',
             'RCUTILS_LOGGING_BUFFERED_STREAM': '1',
         },
     )

--- a/mola_state_estimation_smoother/test/integration/test_static_convergence.py
+++ b/mola_state_estimation_smoother/test/integration/test_static_convergence.py
@@ -64,6 +64,9 @@ def generate_test_description():
             'ODOM1_LABEL': 'wheel_odom',
             'IMU_TOPIC': '/imu',
             'GNSS_TOPIC': '/gps',
+            'ODOM2_TOPIC': '',  # remove after all distros have mola_yaml>=2.6.1
+            'ODOM3_TOPIC': '',  # remove after all distros have mola_yaml>=2.6.1
+            'ODOM4_TOPIC': '',  # remove after all distros have mola_yaml>=2.6.1
             'MOLA_USE_FIXED_IMU_POSE': 'true',
             'IMU_POSE_X': '0', 'IMU_POSE_Y': '0', 'IMU_POSE_Z': '0',
             'IMU_POSE_YAW': '0', 'IMU_POSE_PITCH': '0', 'IMU_POSE_ROLL': '0',

--- a/mola_state_estimation_smoother/test/integration/test_static_convergence.py
+++ b/mola_state_estimation_smoother/test/integration/test_static_convergence.py
@@ -75,8 +75,8 @@ def generate_test_description():
             'MOLA_LOCALIZATION_PUBLISH_TF': 'true',
             'MOLA_LOCALIZATION_PUBLISH_TF_SOURCE': 'state_estimation',
             'MOLA_NAVSTATE_ENFORCE_PLANAR_MOTION': 'true',
-            'MOLA_VERBOSITY_BRIDGE_ROS2': 'DEBUG',
-            'MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR': 'DEBUG',
+            'MOLA_VERBOSITY_BRIDGE_ROS2': 'INFO',
+            'MOLA_VERBOSITY_MOLA_STATE_ESTIMATOR': 'INFO',
             'RCUTILS_LOGGING_BUFFERED_STREAM': '1',
         },
     )

--- a/mola_state_estimation_smoother/test/integration/test_static_convergence.py
+++ b/mola_state_estimation_smoother/test/integration/test_static_convergence.py
@@ -1,0 +1,166 @@
+# Integration test — Scenario A: static vehicle, fixed geo-reference.
+#
+# Launches mola-cli (StateEstimationSmoother + BridgeROS2) and a Python
+# sensor mock that publishes noisy odometry, GNSS, and IMU for a robot
+# standing still 30 m East / 50 m North of the ENU origin at yaw=60 deg.
+#
+# Asserts that the estimator's published pose converges to within 0.5 m and
+# 5 deg of ground truth within 60 s of wall-clock streaming.
+import math
+import os
+import sys
+import time
+import unittest
+
+import launch
+import launch.actions
+import launch_ros.actions
+import launch_testing
+import launch_testing.actions
+import launch_testing.markers
+import pytest
+import rclpy
+from ament_index_python import get_package_share_directory
+
+from geometry_msgs.msg import PoseStamped
+from nav_msgs.msg import Odometry
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import PoseLatest, wrap_pi, wait_for_convergence
+
+_SKIP_ENV = 'MOLA_SKIP_INTEGRATION_TESTS'
+
+# ------------------------------------------------------------------
+# Launch description
+# ------------------------------------------------------------------
+
+@pytest.mark.launch_test
+def generate_test_description():
+    if os.environ.get(_SKIP_ENV):
+        return launch.LaunchDescription([
+            launch_testing.actions.ReadyToTest(),
+        ])
+
+    pkg_share = get_package_share_directory('mola_state_estimation_smoother')
+    mola_yaml = os.path.join(pkg_share, 'mola-cli-launchs', 'state_estimator_ros2.yaml')
+    static_params = os.path.join(
+        pkg_share, 'test', 'integration', 'data', 'static_test_smoother_params.yaml')
+
+    mock_script = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                'sensor_mock_node.py')
+
+    mola_node = launch_ros.actions.Node(
+        package='mola_launcher',
+        executable='mola-cli',
+        output='screen',
+        arguments=[mola_yaml],
+        remappings=[('/tf', 'tf'), ('/tf_static', 'tf_static')],
+        additional_env={
+            'MOLA_WITH_GUI': 'false',
+            'MOLA_STATE_ESTIMATOR_YAML': static_params,
+            'ODOM1_TOPIC': '/wheel_odom',
+            'ODOM1_LABEL': 'wheel_odom',
+            'IMU_TOPIC': '/imu',
+            'GNSS_TOPIC': '/gps',
+            'MOLA_USE_FIXED_IMU_POSE': 'true',
+            'IMU_POSE_X': '0', 'IMU_POSE_Y': '0', 'IMU_POSE_Z': '0',
+            'IMU_POSE_YAW': '0', 'IMU_POSE_PITCH': '0', 'IMU_POSE_ROLL': '0',
+            'MOLA_USE_FIXED_GNSS_POSE': 'true',
+            'GNSS_POSE_X': '0', 'GNSS_POSE_Y': '0', 'GNSS_POSE_Z': '0',
+            'GNSS_POSE_YAW': '0', 'GNSS_POSE_PITCH': '0', 'GNSS_POSE_ROLL': '0',
+            'MOLA_LOCALIZATION_PUBLISH_ODOM_MSGS': 'true',
+            'MOLA_LOCALIZATION_PUBLISH_ODOM_MSGS_SOURCE': 'state_estimation',
+            'MOLA_LOCALIZATION_PUBLISH_TF': 'true',
+            'MOLA_LOCALIZATION_PUBLISH_TF_SOURCE': 'state_estimation',
+            'MOLA_NAVSTATE_ENFORCE_PLANAR_MOTION': 'true',
+            'RCUTILS_LOGGING_BUFFERED_STREAM': '1',
+        },
+    )
+
+    mock_node = launch_ros.actions.Node(
+        package='mola_state_estimation_smoother',
+        executable='sensor_mock_node.py',
+        output='screen',
+        parameters=[{
+            'scenario': 'static',
+            'seed': 42,
+            'startup_delay_sec': 4.0,
+            'odom_rate': 10.0,
+            'gnss_rate': 2.0,
+            'imu_rate': 20.0,
+        }],
+    )
+
+    # Fall back to ExecuteProcess if the node is not installed as an entry point
+    mock_proc = launch.actions.ExecuteProcess(
+        cmd=['python3', mock_script,
+             '--ros-args',
+             '-p', 'scenario:=static',
+             '-p', 'seed:=42',
+             '-p', 'startup_delay_sec:=4.0',
+             '-p', 'odom_rate:=10.0',
+             '-p', 'gnss_rate:=2.0',
+             '-p', 'imu_rate:=20.0'],
+        output='screen',
+    )
+
+    return launch.LaunchDescription([
+        mola_node,
+        mock_proc,
+        launch_testing.actions.ReadyToTest(),
+    ])
+
+
+# ------------------------------------------------------------------
+# Active test (runs while the launch is alive)
+# ------------------------------------------------------------------
+
+class TestStaticConvergence(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.checker = rclpy.create_node('checker_static')
+        cls.est_pose = PoseLatest()
+        cls.gt_pose = PoseLatest()
+
+        def _est_cb(msg):
+            x = msg.pose.pose.position.x
+            y = msg.pose.pose.position.y
+            q = msg.pose.pose.orientation
+            siny_cosp = 2.0 * (q.w * q.z + q.x * q.y)
+            cosy_cosp = 1.0 - 2.0 * (q.y * q.y + q.z * q.z)
+            cls.est_pose.update(x, y, math.atan2(siny_cosp, cosy_cosp))
+
+        def _gt_cb(msg):
+            x = msg.pose.position.x
+            y = msg.pose.position.y
+            q = msg.pose.orientation
+            siny_cosp = 2.0 * (q.w * q.z + q.x * q.y)
+            cosy_cosp = 1.0 - 2.0 * (q.y * q.y + q.z * q.z)
+            cls.gt_pose.update(x, y, math.atan2(siny_cosp, cosy_cosp))
+
+        cls.checker.create_subscription(
+            Odometry, 'state_estimation/pose', _est_cb, 10)
+        cls.checker.create_subscription(
+            PoseStamped, '/ground_truth/pose', _gt_cb, 10)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.checker.destroy_node()
+        rclpy.shutdown()
+
+    def test_pose_convergence(self):
+        if os.environ.get(_SKIP_ENV):
+            self.skipTest('MOLA_SKIP_INTEGRATION_TESTS is set')
+
+        wait_for_convergence(
+            self.checker,
+            self.gt_pose,
+            self.est_pose,
+            max_pos_err_m=0.5,
+            max_heading_err_deg=5.0,
+            settle_seconds=2.0,
+            timeout_seconds=60.0,
+            warm_up_seconds=5.0,
+        )

--- a/mola_state_estimation_smoother/test/integration/test_static_convergence.py
+++ b/mola_state_estimation_smoother/test/integration/test_static_convergence.py
@@ -81,21 +81,7 @@ def generate_test_description():
         },
     )
 
-    mock_node = launch_ros.actions.Node(
-        package='mola_state_estimation_smoother',
-        executable='sensor_mock_node.py',
-        output='screen',
-        parameters=[{
-            'scenario': 'static',
-            'seed': 42,
-            'startup_delay_sec': 4.0,
-            'odom_rate': 10.0,
-            'gnss_rate': 2.0,
-            'imu_rate': 20.0,
-        }],
-    )
-
-    # Fall back to ExecuteProcess if the node is not installed as an entry point
+    # Use ExecuteProcess to launch the mock node:
     mock_proc = launch.actions.ExecuteProcess(
         cmd=['python3', mock_script,
              '--ros-args',


### PR DESCRIPTION
Two end-to-end test scenarios driven by a Python sensor mock node:
  A. Static vehicle with fixed geo-reference (timeout 90 s, convergence
     threshold 0.5 m / 5 deg).
  B. Moving sinusoidal trajectory with self-estimated geo-reference
     (timeout 180 s, threshold 1.5 m / 10 deg after 20 s warm-up).

New files under test/integration/:
  common.py            -- GT trajectories, flat-Earth geodetic helpers,
                          IMU quaternion convention, wait_for_convergence()
  sensor_mock_node.py  -- rclpy node publishing /wheel_odom, /gps, /imu,
                          /ground_truth/pose with configurable noise/seed
  test_static_convergence.py  -- launch_testing test for Scenario A
  test_moving_georef.py       -- launch_testing test for Scenario B
  data/static_test_smoother_params.yaml
  data/moving_test_smoother_params.yaml

CMakeLists.txt: add_launch_test() calls + install data YAML files.
package.xml: add test_depend entries (launch_testing, rclpy, nav_msgs, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added launch-based integration tests (static and moving geo-ref), deterministic sensor simulator, ground-truth trajectories, and convergence-check utilities.

* **Chores**
  * Installed integration test data/configs with the package and declared integration test dependencies.

* **Documentation**
  * Updated GNSS+IMU example to include wheel odometry, multi-odometry guidance, and simplified publisher usage.

* **Configuration**
  * Increased default observation window and added optional odometry inputs plus runtime geo-reference handling in launches.

* **CI**
  * Adjusted CI workflow matrix and test targets for ROS 2-focused runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->