### PR TITLE
fix(state_estimation_simple): preserve linear twist across fuse_imu()

### DIFF
--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -116,16 +116,30 @@ void StateEstimationSimple::fuse_imu(const mrpt::obs::CObservationIMU& imu)
     // Transform frames: IMU -> vehicle:
     imuReading.rotate(imu.sensorPose.asTPose());
 
-    state_.last_twist.emplace();
+    // IMU only observes angular velocity: preserve linear (vx,vy,vz) from the
+    // last fuse_pose().
+    if (!state_.last_twist)
+    {
+        state_.last_twist.emplace();
+    }
     state_.last_twist->wx = imuReading.wx;
     state_.last_twist->wy = imuReading.wy;
     state_.last_twist->wz = imuReading.wz;
 
+    const double varRot = mrpt::square(params.sigma_imu_angular_velocity);
+    if (!state_.last_twist_cov)
     {
-        auto&        twistCov = state_.last_twist_cov.emplace();
-        const double varXYZ   = mrpt::square(5.0);  // No info on XYZ
-        const double varRot   = mrpt::square(params.sigma_imu_angular_velocity);
-        twistCov.setDiagonal({varXYZ, varXYZ, varXYZ, varRot, varRot, varRot});
+        const double varXYZ_no_info = mrpt::square(5.0);  // wide linear prior, [m²/s²]
+        auto&        twistCov       = state_.last_twist_cov.emplace();
+        twistCov.setDiagonal(
+            {varXYZ_no_info, varXYZ_no_info, varXYZ_no_info, varRot, varRot, varRot});
+    }
+    else
+    {
+        auto& twistCov = *state_.last_twist_cov;
+        twistCov(3, 3) = varRot;
+        twistCov(4, 4) = varRot;
+        twistCov(5, 5) = varRot;
     }
 
     MRPT_LOG_DEBUG_STREAM("fuse_imu(): new twist: " << state_.last_twist->asString());


### PR DESCRIPTION
## Summary

- `StateEstimationSimple::fuse_imu()` calls `state_.last_twist.emplace()` and `state_.last_twist_cov.emplace()` unconditionally, default-constructing both. That zeroes the linear `(vx, vy, vz)` and clobbers their covariance entries that `fuse_pose()` had just produced from the pose delta, on every IMU sample.
- After every IMU update the estimator therefore reports zero linear velocity, regardless of the actual platform motion. Downstream this manifests as `estimated_navstate()` returning a velocity-extrapolated pose with covariance dominated by `sigma_relative_pose_linear` only, breaking gates in consumers (e.g. `mola_lidar_odometry`'s `min_motion_model_xyz_cov_inv` check, after which the local map stops growing).
- Fix: only `emplace()` `last_twist` / `last_twist_cov` when they aren't set yet. Always overwrite the angular components and the rotational diagonal of the covariance from the IMU; leave the linear components and their covariance entries untouched so they keep coming from `fuse_pose()` / `fuse_twist()`. The wide linear prior (`sigma = 5 m/s`) is only applied as a fallback when no prior twist exists.

Regression introduced in 15a1fce ("Add tests for simple estimator").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IMU sensor fusion to better preserve existing velocity estimates during state updates, while maintaining appropriate uncertainty handling based on available covariance data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->