### PR TITLE
feat: expose new params in the georeference cli app

### DIFF
--- a/docs/georef-apps.rst
+++ b/docs/georef-apps.rst
@@ -56,6 +56,8 @@ consume georeferencing data (e.g. ``sm2mm --georef``, ``mm-georef``,
       USAGE:
 
          mola-sm-georeferencing  [-v <INFO>] [--no-imu-gravity] [-l <foobar.so>]
+                                 [--min-gnss-fix-quality <0>]
+                                 [--min-gnss-sigma <0.20>]
                                  [--imu-gravity-sigma-deg <3.0>]
                                  [--horizontality-sigma <1.0>]
                                  [-o <(map.georef|map.yaml)>]
@@ -75,6 +77,15 @@ consume georeferencing data (e.g. ``sm2mm --georef``, ``mm-georef``,
          -l <foobar.so>,  --load-plugins <foobar.so>
          One or more (comma separated) *.so files to load as plugins, e.g.
          defining new CMetricMap classes
+
+         --min-gnss-fix-quality <0>
+         If non-zero, discard GNSS frames whose NMEA GGA fix quality is below
+         this value (1=GPS, 2=DGPS, 4=RTK fixed, 5=RTK float). Default: 0
+         (filter disabled).
+
+         --min-gnss-sigma <0.20>
+         Minimum per-axis GNSS uncertainty (meters) used as a floor for the ENU
+         noise model. Default: 0.20
 
          --imu-gravity-sigma-deg <3.0>
          IMU gravity alignment uncertainty (degrees).

--- a/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
+++ b/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
@@ -65,6 +65,27 @@ struct Cli
                                                   "3.0",
                                                   cmd};
 
+    TCLAP::ValueArg<double> argMinUncertaintyXYZ{
+        "",
+        "min-gnss-sigma",
+        "Minimum per-axis GNSS uncertainty (meters) used as a floor for the "
+        "ENU noise model. Default: 0.20",
+        false,
+        0.20,
+        "0.20",
+        cmd};
+
+    TCLAP::ValueArg<unsigned int> argMinFixQuality{
+        "",
+        "min-gnss-fix-quality",
+        "If non-zero, discard GNSS frames whose NMEA GGA fix quality is below "
+        "this value (1=GPS, 2=DGPS, 4=RTK fixed, 5=RTK float). Default: 0 "
+        "(filter disabled).",
+        false,
+        0,
+        "0",
+        cmd};
+
     TCLAP::ValueArg<std::string> argPlugins{
         "l",
         "load-plugins",
@@ -130,7 +151,15 @@ void run_sm_georef(Cli& cli)
         p.fgParams.addHorizontalityConstraints = true;
         p.fgParams.horizontalitySigmaZ         = cli.argHorz.getValue();
     }
-    // TODO: p.fgParams.minimumUncertaintyXYZ = xxx;
+    if (cli.argMinUncertaintyXYZ.isSet())
+    {
+        p.fgParams.minimumUncertaintyXYZ = cli.argMinUncertaintyXYZ.getValue();
+    }
+
+    if (cli.argMinFixQuality.isSet())
+    {
+        p.minimumGNSSFixQuality = cli.argMinFixQuality.getValue();
+    }
 
     if (cli.argNoIMUGravity.getValue())
     {

--- a/mola_georeferencing/include/mola_georeferencing/simplemap_georeference.h
+++ b/mola_georeferencing/include/mola_georeferencing/simplemap_georeference.h
@@ -60,6 +60,11 @@ struct SMGeoReferencingParams
     /// Otherwise (default), the first GNSS entry will become the reference.
     std::optional<mrpt::topography::TGeodeticCoords> geodeticReference;
 
+    /// If non-zero, GNSS frames whose NMEA GGA fix quality is below this
+    /// threshold will be discarded (e.g. 1=GPS, 2=DGPS, 4=RTK fixed, 5=RTK
+    /// float). Default (0) disables the filter, keeping all valid frames.
+    unsigned int minimumGNSSFixQuality = 0;
+
     AddGNSSFactorParams fgParams;
 
     /// If true, use IMU acceleration data found in the simplemap to add
@@ -99,7 +104,8 @@ struct GNSSFrames
 
 GNSSFrames extract_gnss_frames_from_sm(
     const mrpt::maps::CSimpleMap&                           sm,
-    const std::optional<mrpt::topography::TGeodeticCoords>& refCoord = std::nullopt);
+    const std::optional<mrpt::topography::TGeodeticCoords>& refCoord          = std::nullopt,
+    unsigned int                                            minimumFixQuality = 0);
 
 struct FrameIMUAcc
 {

--- a/mola_georeferencing/src/simplemap_georeference.cpp
+++ b/mola_georeferencing/src/simplemap_georeference.cpp
@@ -39,7 +39,8 @@ mola::SMGeoReferencingOutput mola::simplemap_georeference(
 
     ASSERT_(!sm.empty());
 
-    const GNSSFrames smFrames = extract_gnss_frames_from_sm(sm, params.geodeticReference);
+    const GNSSFrames smFrames =
+        extract_gnss_frames_from_sm(sm, params.geodeticReference, params.minimumGNSSFixQuality);
 
     if (params.logger)
     {
@@ -165,8 +166,12 @@ mola::SMGeoReferencingOutput mola::simplemap_georeference(
 
 mola::GNSSFrames mola::extract_gnss_frames_from_sm(
     const mrpt::maps::CSimpleMap&                           sm,
-    const std::optional<mrpt::topography::TGeodeticCoords>& refCoordIn)
+    const std::optional<mrpt::topography::TGeodeticCoords>& refCoordIn,
+    unsigned int                                            minimumFixQuality)
 {
+    thread_local bool DEBUG_PRINT_GNSS_FRAMES =
+        mrpt::get_env<bool>("MOLA_SM_GEOREF_PRINT_GNSS_FRAMES", false);
+
     GNSSFrames ret;
 
     ret.refCoord = refCoordIn;
@@ -189,6 +194,16 @@ mola::GNSSFrames mola::extract_gnss_frames_from_sm(
             if (!obs->hasMsgType(mrpt::obs::gnss::NMEA_GGA))
             {
                 continue;
+            }
+
+            // Optional fix-quality filter (disabled when minimumFixQuality==0):
+            if (minimumFixQuality > 0)
+            {
+                const auto& ggaMsg = obs->getMsgByClass<mrpt::obs::gnss::Message_NMEA_GGA>();
+                if (ggaMsg.fields.fix_quality < minimumFixQuality)
+                {
+                    continue;  // skip low-quality fix
+                }
             }
 
             auto& f = ret.frames.emplace_back();
@@ -237,6 +252,16 @@ mola::GNSSFrames mola::extract_gnss_frames_from_sm(
 
             // Convert GNSS obs to ENU:
             mrpt::topography::geodeticToENU_WGS84(f.coords, f.enu, *ret.refCoord);
+
+            if (DEBUG_PRINT_GNSS_FRAMES)
+            {
+                std::cout << "gnss frame for sm[" << i << "]: " << std::fixed
+                          << std::setprecision(6) << " lat: " << f.coords.lat
+                          << " deg, lon: " << f.coords.lon << " deg, alt: " << f.coords.height
+                          << " m, ENU: " << f.enu << " m, sigmas (E/N/U): " << f.sigma_E << "/"
+                          << f.sigma_N << "/" << f.sigma_U << " m"
+                          << "\n";
+            }
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--min-gnss-sigma` flag to set a minimum GNSS uncertainty floor (per-axis noise-model floor)
  * Added `--min-gnss-fix-quality` flag to filter out GNSS frames below a specified NMEA GGA fix quality threshold

* **Documentation**
  * Updated CLI reference with new georeferencing tuning options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->