### PR TITLE
feat(georeferencing): detect degenerate GNSS configurations

### DIFF
--- a/mola_georeferencing/include/mola_georeferencing/simplemap_georeference.h
+++ b/mola_georeferencing/include/mola_georeferencing/simplemap_georeference.h
@@ -100,6 +100,14 @@ struct GNSSFrames
 {
     std::vector<FrameGNSS>                           frames;
     std::optional<mrpt::topography::TGeodeticCoords> refCoord;
+
+    /// Set to true by extract_gnss_frames_from_sm() when the spatial spread of
+    /// the GNSS observations is too small with respect to their uncertainty
+    /// (specifically, when the ENU bounding-box diagonal is not larger than 3x
+    /// the minimum per-axis sigma). In such a degenerate configuration, the
+    /// georeferencing/global-attitude problem is ill-conditioned (e.g. the map
+    /// roll/pitch becomes unobservable and can take absurd values).
+    bool possibly_degenerate = false;
 };
 
 GNSSFrames extract_gnss_frames_from_sm(

--- a/mola_georeferencing/src/simplemap_georeference.cpp
+++ b/mola_georeferencing/src/simplemap_georeference.cpp
@@ -32,6 +32,9 @@
 #include <mola_gtsam_factors/FactorGnssEnu.h>
 #include <mola_gtsam_factors/MeasuredGravityFactor.h>
 
+#include <algorithm>
+#include <limits>
+
 mola::SMGeoReferencingOutput mola::simplemap_georeference(
     const mrpt::maps::CSimpleMap& sm, const SMGeoReferencingParams& params)
 {
@@ -262,6 +265,51 @@ mola::GNSSFrames mola::extract_gnss_frames_from_sm(
                           << f.sigma_N << "/" << f.sigma_U << " m"
                           << "\n";
             }
+        }
+    }
+
+    // Degeneracy check: the spatial spread of the GNSS observations must be
+    // large compared to their uncertainty, otherwise the global-attitude
+    // (roll/pitch/yaw) problem is ill-conditioned. We compare the ENU
+    // bounding-box diagonal against 3x the smallest per-axis sigma.
+    if (ret.frames.size() >= 2)
+    {
+        mrpt::math::TPoint3D bbMin    = ret.frames.front().enu;
+        mrpt::math::TPoint3D bbMax    = ret.frames.front().enu;
+        double               minSigma = std::numeric_limits<double>::max();
+
+        for (const auto& f : ret.frames)
+        {
+            bbMin.x = std::min(bbMin.x, f.enu.x);
+            bbMin.y = std::min(bbMin.y, f.enu.y);
+            bbMin.z = std::min(bbMin.z, f.enu.z);
+            bbMax.x = std::max(bbMax.x, f.enu.x);
+            bbMax.y = std::max(bbMax.y, f.enu.y);
+            bbMax.z = std::max(bbMax.z, f.enu.z);
+
+            minSigma = std::min({minSigma, f.sigma_E, f.sigma_N, f.sigma_U});
+        }
+
+        const double bboxDiagonal = (bbMax - bbMin).norm();
+
+        if (bboxDiagonal <= 3.0 * minSigma)
+        {
+            ret.possibly_degenerate = true;
+
+            std::cerr << "\n"
+                      << "############################################################\n"
+                      << "# [extract_gnss_frames_from_sm] WARNING: POSSIBLY DEGENERATE\n"
+                      << "# GNSS configuration detected.\n"
+                      << "#   ENU bounding-box diagonal: " << bboxDiagonal << " m\n"
+                      << "#   minimum per-axis sigma:    " << minSigma << " m\n"
+                      << "#   (diagonal must be > 3x the minimum sigma = " << 3.0 * minSigma
+                      << " m)\n"
+                      << "# The spatial spread of the " << ret.frames.size()
+                      << " GNSS observations is too small with respect to\n"
+                      << "# their uncertainty. The estimated global attitude (map roll/pitch/yaw)\n"
+                      << "# is likely unobservable and may take absurd values.\n"
+                      << "############################################################\n"
+                      << std::endl;
         }
     }
 

--- a/mola_georeferencing/tests/CMakeLists.txt
+++ b/mola_georeferencing/tests/CMakeLists.txt
@@ -18,3 +18,10 @@ mola_add_test(
   LINK_LIBRARIES
     mola::mola_georeferencing
 )
+
+mola_add_test(
+  TARGET  test_gnss_degeneracy
+  SOURCES test_gnss_degeneracy.cpp
+  LINK_LIBRARIES
+    mola::mola_georeferencing
+)

--- a/mola_georeferencing/tests/test_gnss_degeneracy.cpp
+++ b/mola_georeferencing/tests/test_gnss_degeneracy.cpp
@@ -1,0 +1,129 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this package
+ alone or in combination with the complete SLAM system.
+*/
+
+#include <mola_georeferencing/simplemap_georeference.h>
+#include <mrpt/maps/CSimpleMap.h>
+#include <mrpt/obs/CObservationGPS.h>
+#include <mrpt/poses/CPose3DPDFGaussian.h>
+
+#include <iostream>
+
+namespace
+{
+// Builds a CSimpleMap with one GNSS observation per keyframe, at the given
+// geodetic coordinates and with an isotropic ENU sigma (via covariance_enu).
+mrpt::maps::CSimpleMap make_sm_with_gnss(
+    const std::vector<mrpt::topography::TGeodeticCoords>& coords, double sigma_m)
+{
+    mrpt::maps::CSimpleMap sm;
+
+    for (size_t i = 0; i < coords.size(); i++)
+    {
+        auto pose_pdf  = mrpt::poses::CPose3DPDFGaussian::Create();
+        pose_pdf->mean = mrpt::poses::CPose3D(static_cast<double>(i), 0, 0, 0, 0, 0);
+
+        auto sf  = mrpt::obs::CSensoryFrame::Create();
+        auto obs = mrpt::obs::CObservationGPS::Create();
+
+        mrpt::obs::gnss::Message_NMEA_GGA gga;
+        gga.fields.latitude_degrees  = coords[i].lat;
+        gga.fields.longitude_degrees = coords[i].lon;
+        gga.fields.altitude_meters   = coords[i].height;
+        gga.fields.fix_quality       = 4;  // RTK fixed
+        gga.fields.thereis_HDOP      = true;
+        gga.fields.HDOP              = 1.0f;
+        obs->setMsg(gga);
+
+        // Provide an explicit ENU covariance so the sigma is deterministic:
+        mrpt::math::CMatrixDouble33 cov;
+        cov.setDiagonal(sigma_m * sigma_m);
+        obs->covariance_enu = cov;
+
+        sf->insert(obs);
+        sm.insert(pose_pdf, sf);
+    }
+
+    return sm;
+}
+
+void expect(bool cond, const std::string& msg)
+{
+    if (!cond)
+    {
+        throw std::runtime_error("Test assertion failed: " + msg);
+    }
+}
+
+// A cluster of GNSS fixes spanning only ~0.2 m with a 0.5 m sigma -> degenerate.
+void test_degenerate_cluster()
+{
+    std::cout << "[test] degenerate cluster...\n";
+
+    const double                                   baseLat = 37.0;
+    const double                                   baseLon = -2.0;
+    const double                                   baseH   = 100.0;
+    std::vector<mrpt::topography::TGeodeticCoords> coords;
+
+    // ~1e-6 deg latitude ~= 0.11 m. Keep all points within a tiny box:
+    for (int i = 0; i < 5; i++)
+    {
+        coords.emplace_back(baseLat + i * 1e-6, baseLon + i * 1e-6, baseH + i * 0.02);
+    }
+
+    const auto sm     = make_sm_with_gnss(coords, /*sigma_m=*/0.5);
+    const auto frames = mola::extract_gnss_frames_from_sm(sm);
+
+    expect(frames.frames.size() == 5, "all 5 GNSS frames should be extracted");
+    expect(frames.possibly_degenerate, "tiny spatial spread must be flagged as degenerate");
+}
+
+// GNSS fixes spread over ~100 m with a 0.5 m sigma -> NOT degenerate.
+void test_non_degenerate_spread()
+{
+    std::cout << "[test] non-degenerate spread...\n";
+
+    const double                                   baseLat = 37.0;
+    const double                                   baseLon = -2.0;
+    const double                                   baseH   = 100.0;
+    std::vector<mrpt::topography::TGeodeticCoords> coords;
+
+    // ~1e-4 deg latitude ~= 11 m per step -> ~44 m diagonal over 5 frames:
+    for (int i = 0; i < 5; i++)
+    {
+        coords.emplace_back(baseLat + i * 1e-4, baseLon + i * 1e-4, baseH);
+    }
+
+    const auto sm     = make_sm_with_gnss(coords, /*sigma_m=*/0.5);
+    const auto frames = mola::extract_gnss_frames_from_sm(sm);
+
+    expect(frames.frames.size() == 5, "all 5 GNSS frames should be extracted");
+    expect(!frames.possibly_degenerate, "a wide spatial spread must NOT be flagged as degenerate");
+}
+}  // namespace
+
+int main()
+{
+    try
+    {
+        test_degenerate_cluster();
+        test_non_degenerate_spread();
+        std::cout << "\n[Success] GNSS degeneracy detection tests passed!\n";
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "\n[Test Failed] " << e.what() << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
extract_gnss_frames_from_sm() now flags a possibly-degenerate GNSS configuration when the ENU bounding-box diagonal is not larger than 3x the minimum per-axis sigma. In that case the global map attitude (roll/pitch/yaw) is unobservable and may take absurd values.

The reusable function does not throw: it sets a new GNSSFrames::possibly_degenerate flag and prints a warning to std::cerr.

Adds a unit test covering both the degenerate (clustered) and the well-spread (non-degenerate) cases.