### PR TITLE
fix(smoother): don't crash on estimated_navstate() for unregistered odometry frame

### DIFF
--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -728,8 +728,21 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
     // 3) Convert pose to the requested frame_id:
     if (frame_id != params_.reference_frame_name)
     {
+        // The requested odometry frame may not have been registered yet
+        // (e.g. the very first query, before any fuse_pose()/fuse_odometry()
+        // call has registered it via add_or_get_odom_frame_id()). Treat that
+        // the same as "not ready yet" instead of throwing.
+        const auto it = state_.known_odom_frames.find_key(frame_id);
+        if (it == state_.known_odom_frames.getDirectMap().end())
+        {
+            MRPT_LOG_THROTTLE_DEBUG_FMT(
+                5.0, "[estimated_navstate] Requested unknown odometry frame_id='%s'",
+                frame_id.c_str());
+            return {};
+        }
+
         // Transform:
-        const auto requestedFrameIdx    = state_.known_odom_frames.direct(frame_id);
+        const auto requestedFrameIdx    = it->second;
         const auto posePdfFrame_wrt_map = state_.last_estimated_frames.at(requestedFrameIdx);
 
         mrpt::poses::CPose3DPDFGaussianInf posePdfFrame_wrt_map_inf;

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -729,13 +729,22 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
     if (frame_id != params_.reference_frame_name)
     {
         // The requested odometry frame may not have been registered yet
-        // (e.g. the very first query, before any fuse_pose()/fuse_odometry()
-        // call has registered it via add_or_get_odom_frame_id()). Treat that
-        // the same as "not ready yet" instead of throwing.
+        // (e.g. the very first query of a brand-new frame_id, before any
+        // fuse_pose()/fuse_odometry() call has registered it via
+        // add_or_get_odom_frame_id()). Treat that as "not ready yet" instead
+        // of throwing, the same as the other early-return cases above: a
+        // freshly-registered frame would only get an uninformative prior
+        // (sigma=INIT_ODOM_FRAME_POSE_SIGMA) anyway, which callers already
+        // reject as a usable motion model, so registering it here on a mere
+        // read would just leave a permanent, never-updated entry in the
+        // factor graph if frame_id never gets fused (e.g. a typo). If this
+        // persists instead of resolving after the first fuse_*() call for
+        // frame_id, it most likely indicates a frame-name mismatch between
+        // this module's configured frame names and a producer module's.
         const auto it = state_.known_odom_frames.find_key(frame_id);
         if (it == state_.known_odom_frames.getDirectMap().end())
         {
-            MRPT_LOG_THROTTLE_DEBUG_FMT(
+            MRPT_LOG_THROTTLE_WARN_FMT(
                 5.0, "[estimated_navstate] Requested unknown odometry frame_id='%s'",
                 frame_id.c_str());
             return {};

--- a/mola_state_estimation_smoother/tests/test-navstate-basic.cpp
+++ b/mola_state_estimation_smoother/tests/test-navstate-basic.cpp
@@ -327,6 +327,39 @@ void test_noisy_straight()
     ASSERT_NEAR_(ret->twist.wz, .0, 0.01);
 }
 
+// --------------------------------------
+// Regression test for a crash where estimated_navstate() would throw
+// "Key not found" (instead of returning nullopt) when queried for an
+// odometry frame_id that has a keyframe nearby in time (so it passes the
+// "no nearby frame" check) but has never itself been registered via
+// fuse_pose()/fuse_odometry() for that particular frame_id -- e.g. a caller
+// asking about its own "odom" frame before ever reporting a pose in it.
+void test_unregistered_odom_frame_does_not_throw()
+{
+    const auto& _ = Data::Instance();
+
+    mola::state_estimation_smoother::StateEstimationSmoother nav;
+    nav.initialize(mrpt::containers::yaml::FromText(navStateParams));
+
+    const auto t0 = mrpt::Clock::fromDouble(.0);
+
+    // Create a keyframe via the reference frame ("map"), never touching
+    // the "odom" odometry frame:
+    nav.fuse_pose(t0, _.pdf0, "map");
+    ASSERT_(nav.known_odometry_frame_ids().empty());
+
+    // Querying a never-registered odometry frame_id must not throw:
+    const auto ret = nav.estimated_navstate(t0, "odom");
+    ASSERT_(!ret.has_value());
+
+    // Once "odom" gets registered, the same query must succeed:
+    nav.fuse_pose(t0, _.pdf0, "odom");
+    ASSERT_(!nav.known_odometry_frame_ids().empty());
+
+    const auto ret2 = nav.estimated_navstate(t0, "odom");
+    ASSERT_(ret2.has_value());
+}
+
 }  // namespace
 
 int main(int argc, char** argv)
@@ -339,6 +372,7 @@ int main(int argc, char** argv)
         {"test_2_poses_too_late", test_2_poses_too_late},
         {"test_3_poses", test_3_poses},
         {"test_noisy_straight", test_noisy_straight},
+        {"test_unregistered_odom_frame_does_not_throw", test_unregistered_odom_frame_does_not_throw},
     };
 
     int runOnlyIdx = -1;


### PR DESCRIPTION
## Summary
- `StateEstimationSmoother::estimated_navstate()` used `bimap::direct(frame_id)`, which throws `Key not found` when `frame_id` hasn't been registered yet via `add_or_get_odom_frame_id()`.
- This crashes deterministically the very first time `mola::LidarOdometry` is run with `StateEstimationSmoother` as the state estimator: `LidarOdometry` queries `estimated_navstate()` with its own `publish_reference_frame` (default `"odom"`) on its very first scan callback, *before* it has ever called `fuse_pose()` for that frame (which is what registers it). The same setup works fine with `StateEstimationSimple`, which simply ignores `frame_id`.
- Fix: use a safe `find_key()` lookup and return `std::nullopt` (treated as "motion model not ready yet", same as the existing timeout/no-nearby-frame cases) instead of throwing when the requested odometry frame isn't registered.

## Test plan
- [x] Rebuilt `mola_state_estimation_smoother` with the fix.
- [x] Reproduced the original crash via `mola-cli` + `Rosbag2Dataset` + `LidarOdometry` + `StateEstimationSmoother` on the Capra HQ outdoor bag (LiDAR+wheel-odom+IMU+GNSS fusion config) — exception no longer occurs; ran cleanly for 20s of dataset time, 199 LiDAR scans processed, clean exit code 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of unknown odometry frame IDs—now gracefully returns an empty result instead of failing, with enhanced debug logging for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->