### PR TITLE
feat(smoother): batch fixed-lag smoother + async backend & fast predictor for real-time use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ incremental optimization. The primary estimator for multi-sensor fusion.
 | ROS 2 launch | `mola_state_estimation_smoother/ros2-launchs/ros2-state-estimator.launch.py` |
 | MOLA-CLI launch | `mola_state_estimation_smoother/mola-cli-launchs/state_estimator_ros2.yaml` |
 | CLI app | `mola_state_estimation_smoother/apps/mola-navstate-cli.cpp` |
-| Tests (6) | `mola_state_estimation_smoother/tests/test-*.cpp` |
+| Tests (9) | `mola_state_estimation_smoother/tests/test-*.cpp` |
 | Integration tests | `mola_state_estimation_smoother/test/integration/test_*.py` |
 
 Key traits:
@@ -71,6 +71,32 @@ Key traits:
 - Optional ENU-to-map georeferencing from GNSS.
 - Thread-safe (`std::recursive_mutex`).
 - Configuration via YAML with `${ENV_VAR|default}` substitution.
+- Out-of-order keyframe guard (always on, no param): iSAM2's fixed-lag
+  marginalization requires keyframes introduced in non-decreasing timestamp
+  order. Multi-rate sensor latency violates that (e.g. a CPU-bound LiDAR
+  front-end lagging the high-rate wheel/IMU by ~0.3-0.4 s, fed via direct
+  `fuse_pose()` calls), which corrupts the Bayes tree (indeterminate-system /
+  missing-key throws). The single keyframe chokepoint
+  `create_or_get_keyframe_by_timestamp_locked()` detects a request older than the
+  newest keyframe and snaps it to the nearest existing keyframe instead of
+  inserting a new one in the past (its factor is applied a bit off in time,
+  bounded by the keyframe spacing; no added latency). Covers every `fuse_*()`
+  entry point. Tests in `tests/test-out-of-order-keyframes.cpp`.
+- Optional async backend (`async_backend: true`, default `false`): the iSAM2
+  window solve runs in a dedicated thread, and `estimated_navstate()` is served by
+  a lightweight `FastPredictor` (`src/FastPredictor.{h,cpp}`) - a tiny GTSAM graph
+  re-anchored on the latest backend solution + buffered high-rate wheel odometry.
+  Keeps per-query latency sub-ms for real-time use. The default synchronous path
+  is unchanged (deterministic offline runs). Kinematic/twist factor construction
+  shared by both paths lives in `src/factor_builders.h`.
+- Optional high-rate same-sensor decimation (cost reduction; both default `0` =
+  off): `odometry_min_sample_period` and `imu_min_sample_period` cap how often
+  wheel-odom / IMU readings spawn keyframes/factors, since the solve cost grows
+  with the keyframe count. Wheel-odom drops are *merged* (the pose anchor is held
+  fixed across the dropped span so the next kept reading fuses the accumulated
+  increment + accumulated motion-model covariance); IMU drops are skipped.
+  Diagnostics: `active_keyframe_count()` / `active_factor_count()`. Tests in
+  `tests/test-keyframe-decimation.cpp`.
 
 Sensor inputs:
 - `fuse_pose()` - localization / LiDAR odometry poses

--- a/docs/mola_state_estimators.rst
+++ b/docs/mola_state_estimators.rst
@@ -266,6 +266,49 @@ into the past or future.
 When run as a MOLA module (e.g. within a ROS 2 node), it also publishes the estimated fused pose information
 in a timely manner, for use as the high-quality, robust localization source.
 
+.. note::
+   **Asynchronous backend (real-time mode).** By default, each call to
+   ``estimated_navstate()`` runs the sliding-window iSAM2 update synchronously
+   on the caller's thread. This is deterministic (ideal for offline bag
+   processing) but, at high keyframe density, can be too slow to keep up with a
+   CPU-bound front-end such as LiDAR odometry in real time.
+
+   Setting ``async_backend: true`` moves the window solve to a dedicated
+   backend thread. ``estimated_navstate()`` is then served by a lightweight *fast
+   predictor*: a tiny factor graph re-anchored on the most recent backend solution
+   and propagated forward with constant-velocity kinematics plus the high-rate
+   wheel odometry buffered since that anchor. Per-query latency drops to
+   sub-millisecond, so the smoother can run online alongside LiDAR odometry; the
+   estimate accuracy still comes from the backend's full optimization, just
+   refreshed asynchronously.
+
+.. note::
+   **Out-of-order keyframe handling.** The incremental (iSAM2) smoother needs
+   keyframes introduced in non-decreasing timestamp order; multi-rate sensor
+   latency (for example, a CPU-bound LiDAR front-end lagging the high-rate wheel
+   odometry / IMU and fusing its poses a few hundred ms "in the past") would
+   otherwise insert keyframes out of order and corrupt the fixed-lag
+   marginalization. This is handled automatically and with no added latency: a
+   measurement whose timestamp falls before the newest keyframe is snapped to the
+   nearest existing keyframe rather than inserting a new one in the past. The
+   small timing approximation is bounded by the keyframe spacing, so keep the
+   high-rate keyframe density reasonably high (i.e. avoid over-aggressive
+   ``*_min_sample_period`` decimation) when LiDAR-pose timing fidelity matters.
+
+.. note::
+   **High-rate sensor decimation (cost reduction).** The window solve cost grows
+   with the number of keyframes in the sliding window, and high-rate sensors
+   (wheel odometry, IMU) would otherwise add one keyframe/factor per reading.
+   The optional ``odometry_min_sample_period`` and ``imu_min_sample_period``
+   parameters (both ``0`` = disabled, the default) cap how often each such stream
+   contributes, merging several consecutive same-sensor readings into one. For
+   wheel odometry, dropped readings are *merged* rather than lost: the pose anchor
+   is held fixed across the dropped span, so the next processed reading fuses the
+   full accumulated increment (with its accumulated motion-model covariance). For
+   IMU (absolute attitude / gravity-direction observations) the dropped readings
+   are simply skipped. This trades a small amount of accuracy for a large drop in
+   per-update cost, and is most useful for offline map-building on long datasets.
+
 This package follows this frame convention (see :ref:`other /tf configurations <mola_ros2_tf_frames>` when using
 MOLA LiDAR-odometry without state estimation):
 

--- a/mola_state_estimation_smoother/CMakeLists.txt
+++ b/mola_state_estimation_smoother/CMakeLists.txt
@@ -51,7 +51,10 @@ mola_add_library(
   TARGET ${PROJECT_NAME}
   SOURCES
     src/Parameters.cpp
+    src/FastPredictor.cpp
+    src/FastPredictor.h
     src/StateEstimationSmoother.cpp
+    src/factor_builders.h
     src/pose_pdf_to_string_with_sigmas.cpp
     src/register.cpp
     include/mola_state_estimation_smoother/Parameters.h

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
@@ -102,6 +102,33 @@ class Parameters
      */
     double imu_nearby_keyframe_stamp_tolerance = 0.10;  // [s]
 
+    /** High-rate same-sensor decimation (cost reduction).
+     *
+     * The dominant cost of the batch fixed-lag smoother grows with the number of
+     * keyframes (factor-graph variables) in the sliding window. High-rate sensors
+     * (wheel odometry, IMU) would otherwise spawn one keyframe (or, when snapping
+     * to a nearby keyframe, one extra factor) per reading. These parameters cap
+     * how often each such stream contributes, merging several consecutive
+     * same-sensor readings into a single keyframe/factor.
+     *
+     * `0` (the default) disables decimation, preserving the previous behavior.
+     *
+     * For wheel odometry, dropped readings are *merged*, not lost: the pose anchor
+     * is held fixed across the dropped span, so the next kept reading fuses the
+     * full accumulated increment with its accumulated motion-model covariance. For
+     * IMU (absolute attitude / gravity-direction observations) the dropped
+     * readings are simply skipped.
+     *
+     * [seconds] Minimum time between two *processed* wheel-odometry readings.
+     */
+    double odometry_min_sample_period = 0.0;  // [s]
+
+    /// [seconds] Minimum time between two *processed* IMU readings. See
+    /// odometry_min_sample_period for the rationale. Typically set close to
+    /// imu_nearby_keyframe_stamp_tolerance so at most one IMU factor lands on
+    /// each keyframe.
+    double imu_min_sample_period = 0.0;  // [s]
+
     double sigma_random_walk_acceleration_linear  = 1.0;  // [m/s²]
     double sigma_random_walk_acceleration_angular = 1.0;  // [rad/s²]
     double sigma_integrator_position              = 0.10;  // [m]
@@ -202,6 +229,33 @@ class Parameters
     /** Each new sensor will become a call to isam2.update(), plus this number of additional
      * refining steps. In theory, more steps lead to more accurate results. */
     uint32_t additional_isam2_update_steps = 3;
+
+    /** @} */
+
+    /** @name Asynchronous backend + fast predictor (real-time mode)
+     * @{ */
+
+    /** If `true`, the heavy batch factor-graph solve runs in a dedicated backend
+     *  thread, and `estimated_navstate()` is served by a lightweight "fast
+     *  predictor": a tiny GTSAM graph re-anchored on the most recent backend
+     *  solution, fusing the high-rate wheel-odometry observations buffered
+     *  since that anchor. This keeps per-query latency bounded (sub-ms) so the
+     *  smoother can be used in real-time alongside a CPU-bound LiDAR-odometry
+     *  front-end.
+     *
+     *  When `false` (the default), the batch solve runs synchronously inside
+     *  `estimated_navstate()` on the caller's thread, which yields deterministic,
+     *  reproducible offline (bag) runs but does not keep up in real time at high
+     *  keyframe density.
+     */
+    bool async_backend = false;
+
+    /** [s] Only used when `async_backend` is `true`. How far back in time the
+     *  fast predictor keeps raw high-rate observations to re-fuse on top of the
+     *  latest anchor. Must comfortably exceed the backend solve latency / sensor
+     *  front-end lag (a few hundred ms).
+     */
+    double fast_predictor_buffer_length = 1.0;  // [s]
 
     /** @} */
 

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -46,12 +46,21 @@
 #include <mrpt/system/CTimeLogger.h>
 
 // std:
+#include <atomic>
+#include <condition_variable>
+#include <map>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <set>
+#include <string>
+#include <thread>
 
 namespace mola::state_estimation_smoother
 {
+// Internal high-rate predictor used in async_backend mode (defined in src/).
+class FastPredictor;
+
 /** Sliding window Factor-graph data fusion for odometry, IMU, GNSS, and SE(3)
  * pose/twist estimations.
  *
@@ -124,7 +133,9 @@ class StateEstimationSmoother : public mola::NavStateFilter,
     StateEstimationSmoother(StateEstimationSmoother&&)                 = delete;
     StateEstimationSmoother& operator=(const StateEstimationSmoother&) = delete;
     StateEstimationSmoother& operator=(StateEstimationSmoother&&)      = delete;
-    ~StateEstimationSmoother()                                         = default;
+
+    /// Stops and joins the backend thread, if running (async_backend mode).
+    ~StateEstimationSmoother() override;
 
     /** \name Main API
      *  @{ */
@@ -179,6 +190,20 @@ class StateEstimationSmoother : public mola::NavStateFilter,
 
     /// Returns a list of known odometry frame_ids:
     [[nodiscard]] auto known_odometry_frame_ids() -> std::set<std::string>;
+
+    /// Number of keyframes currently held in the sliding window (i.e. the size
+    /// of the factor-graph variable set the batch smoother solves each update).
+    /// Mainly useful for diagnostics and tests: high-rate sensor decimation
+    /// (see Parameters::odometry_min_sample_period / imu_min_sample_period)
+    /// reduces this count and hence the per-update cost.
+    [[nodiscard]] std::size_t active_keyframe_count();
+
+    /// Number of factors committed in the current sliding window. Pending,
+    /// not-yet-applied factors are excluded, so call estimated_navstate() first
+    /// to flush them. Mainly useful for diagnostics and tests: IMU decimation
+    /// (see Parameters::imu_min_sample_period) reduces redundant attitude/gravity
+    /// factors without necessarily changing the keyframe count.
+    [[nodiscard]] std::size_t active_factor_count();
 
     /// Gets the latest estimated transform of T_enu_to_map
     [[nodiscard]] std::optional<mrpt::poses::CPose3DPDFGaussian> estimated_T_enu_to_map() const;
@@ -265,6 +290,18 @@ class StateEstimationSmoother : public mola::NavStateFilter,
 
         std::optional<mrpt::poses::CPose2D> last_wheels_odometry;
         std::optional<std::string>          last_wheels_odometry_name;
+
+        /// Timestamp of the last wheels-odometry reading that actually produced a
+        /// keyframe/factor (i.e. was *not* dropped by odometry decimation). The
+        /// pose anchor (last_wheels_odometry) is held fixed across dropped
+        /// readings so the next kept reading fuses the *accumulated* increment
+        /// (and its accumulated motion-model covariance). See
+        /// Parameters::odometry_min_sample_period.
+        std::optional<mrpt::Clock::time_point> last_wheels_odometry_stamp;
+
+        /// Timestamp of the last IMU reading that was actually processed (not
+        /// dropped by IMU decimation). See Parameters::imu_min_sample_period.
+        std::optional<mrpt::Clock::time_point> last_processed_imu_stamp;
 
         /** Refer to Parameters for possible sources of this.
          * Anyways: this will always hold either the estimated or the fixed (externally set)
@@ -390,6 +427,30 @@ class StateEstimationSmoother : public mola::NavStateFilter,
     };
 
     VizInterface::Ptr visualizer_;
+
+    // ---- Asynchronous backend + fast predictor (only used if async_backend) ----
+
+    /// High-rate predictor serving estimated_navstate() while the backend solves.
+    std::unique_ptr<FastPredictor> fastPredictor_;
+
+    std::thread             backendThread_;
+    std::atomic_bool        backendShutdown_{false};
+    std::condition_variable backendCv_;
+    std::mutex              backendCvMutex_;
+    bool                    backendPendingWork_ = false;  //!< guarded by backendCvMutex_
+
+    /// Backend worker: runs the batch solve and publishes anchors to fastPredictor_.
+    void backend_thread_loop();
+
+    /// Wakes the backend thread to process newly queued sensor data.
+    void notify_backend();
+
+    /// Builds the anchor (newest keyframe state + frame transforms) and pushes it
+    /// to fastPredictor_. Assumes stateMutex_ is held; does the predictor handoff
+    /// after releasing it internally is NOT done here (caller releases the lock).
+    [[nodiscard]] bool build_anchor_locked(
+        NavState& anchorOut, mrpt::Clock::time_point& anchorStampOut,
+        std::map<std::string, mrpt::poses::CPose3DPDFGaussian>& frameTransformsOut) const;
 };
 
 }  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -68,6 +68,22 @@ params:
   # to use instead of "min_time_difference_to_create_new_frame". [seconds]
   imu_nearby_keyframe_stamp_tolerance: 0.10
 
+  # High-rate same-sensor decimation (cost reduction). The batch fixed-lag
+  # smoother cost grows with the number of keyframes in the sliding window;
+  # high-rate sensors would otherwise add one keyframe/factor per reading.
+  # These cap how often each stream contributes, merging several consecutive
+  # same-sensor readings into one. 0 = disabled (previous behavior).
+  #
+  # Wheel odometry: dropped readings are MERGED, not lost (the pose anchor is
+  # held fixed across the dropped span, so the next kept reading fuses the full
+  # accumulated increment + its accumulated motion-model covariance). [seconds]
+  odometry_min_sample_period: ${MOLA_NAVSTATE_ODOMETRY_MIN_SAMPLE_PERIOD|0.0}
+
+  # IMU: dropped readings (absolute attitude/gravity) are simply skipped.
+  # Typically set near imu_nearby_keyframe_stamp_tolerance so at most one IMU
+  # factor lands on each keyframe. [seconds]
+  imu_min_sample_period: ${MOLA_NAVSTATE_IMU_MIN_SAMPLE_PERIOD|0.0}
+
   # Random walk model for linear acceleration uncertainty [m/s²]
   sigma_random_walk_acceleration_linear: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC|1.0}
 
@@ -177,20 +193,42 @@ params:
   additional_isam2_update_steps: 3
 
   # --------------------------------------------------------------------------
+  # Asynchronous backend + fast predictor (real-time mode)
+  # --------------------------------------------------------------------------
+
+  # If true, the heavy batch factor-graph solve runs in a dedicated backend
+  # thread and estimated_navstate() is served by a lightweight "fast predictor":
+  # a tiny GTSAM graph re-anchored on the most recent backend solution, fusing
+  # the high-rate wheel-odometry observations buffered since that anchor.
+  # This keeps per-query latency bounded (sub-ms), so the smoother can run in
+  # real-time alongside a CPU-bound LiDAR-odometry front-end.
+  #
+  # If false (default), the batch solve runs synchronously inside
+  # estimated_navstate() on the caller's thread: deterministic, reproducible
+  # offline (bag) runs, but it does not keep up in real time at high keyframe
+  # density.
+  async_backend: "${MOLA_NAVSTATE_ASYNC_BACKEND|false}"
+
+  # [seconds] Only used when async_backend is true: how far back the fast
+  # predictor keeps raw high-rate observations to re-fuse on top of the latest
+  # anchor. Must comfortably exceed the backend solve latency / front-end lag.
+  fast_predictor_buffer_length: ${MOLA_NAVSTATE_FAST_PREDICTOR_BUFFER_LENGTH|1.0}
+
+  # --------------------------------------------------------------------------
   # Sensor Input Filtering (Regex Patterns)
   # --------------------------------------------------------------------------
 
   # Regular expression to filter IMU sensor labels/topics for processing
   # Default accepts all: ".*"
-  do_process_imu_labels_re: ".*"
+  do_process_imu_labels_re: "${MOLA_NAVSTATE_IMU_LABELS_RE|.*}"
 
   # Regular expression to filter odometry input labels/topics for processing
   # Default accepts all: ".*"
-  do_process_odometry_labels_re: ".*"
+  do_process_odometry_labels_re: "${MOLA_NAVSTATE_ODOMETRY_LABELS_RE|.*}"
 
   # Regular expression to filter GNSS (GPS) labels/topics for processing
   # Default accepts all: ".*"
-  do_process_gnss_labels_re: ".*"
+  do_process_gnss_labels_re: "${MOLA_NAVSTATE_GNSS_LABELS_RE|.*}"
 
 # ============================================================================
 # End of Configuration

--- a/mola_state_estimation_smoother/src/FastPredictor.cpp
+++ b/mola_state_estimation_smoother/src/FastPredictor.cpp
@@ -1,0 +1,407 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   FastPredictor.cpp
+ * @brief  High-rate pose predictor anchored on the latest backend solution.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jun 22, 2026
+ */
+
+#include "FastPredictor.h"
+
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/Marginals.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/slam/BetweenFactor.h>
+#include <mrpt/math/gtsam_wrappers.h>
+#include <mrpt/obs/CActionRobotMovement2D.h>
+#include <mrpt/obs/CObservationOdometry.h>
+#include <mrpt/poses/CPose3DPDFGaussian.h>
+#include <mrpt/poses/Lie/SE.h>
+#include <mrpt/poses/gtsam_wrappers.h>
+
+#include <algorithm>
+#include <vector>
+
+#include "factor_builders.h"
+
+namespace mola::state_estimation_smoother
+{
+
+namespace
+{
+// Mirrors the planar-motion enforcement used by the backend smoother.
+void enforce_planar_pose(mrpt::poses::CPose3D& p)
+{
+    p.z(0);
+    p.setYawPitchRoll(p.yaw(), .0, .0);
+}
+void enforce_planar_twist(mrpt::math::TTwist3D& tw)
+{
+    tw.vz = 0;
+    tw.wx = 0;
+    tw.wy = 0;
+}
+}  // namespace
+
+void FastPredictor::set_anchor(
+    const NavState& anchorState, const mrpt::Clock::time_point& anchorStamp,
+    const FrameTransforms& frameTransforms)
+{
+    std::lock_guard<std::mutex> lck(mtx_);
+    anchor_          = anchorState;
+    anchorStamp_     = anchorStamp;
+    frameTransforms_ = frameTransforms;
+
+    // Drop buffered observations strictly older than the new anchor: they are
+    // already integrated into the backend solution this anchor came from.
+    while (!buffer_.empty() &&
+           mrpt::system::timeDifference(buffer_.front()->timestamp, anchorStamp) > 0)
+    {
+        buffer_.pop_front();
+    }
+}
+
+std::optional<mrpt::poses::CPose3DPDFGaussian> FastPredictor::frame_transform(
+    const std::string& frame_id) const
+{
+    std::lock_guard<std::mutex> lck(mtx_);
+    if (const auto it = frameTransforms_.find(frame_id); it != frameTransforms_.end())
+    {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+void FastPredictor::push_observation(
+    const mrpt::obs::CObservation::ConstPtr& o, double bufferLength)
+{
+    if (!o)
+    {
+        return;
+    }
+    // The fast layer only uses wheel odometry (the available high-rate relative
+    // motion source). IMU attitude/gravity barely affect pose over a <1 s
+    // horizon and are left to the backend; LiDAR poses ARE the backend anchor.
+    if (!std::dynamic_pointer_cast<const mrpt::obs::CObservationOdometry>(o))
+    {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lck(mtx_);
+
+    // Insert keeping time order (observations usually arrive monotonically, so
+    // this is almost always a push_back).
+    if (buffer_.empty() ||
+        mrpt::system::timeDifference(buffer_.back()->timestamp, o->timestamp) >= 0)
+    {
+        buffer_.push_back(o);
+    }
+    else
+    {
+        auto it = std::upper_bound(
+            buffer_.begin(), buffer_.end(), o,
+            [](const auto& a, const auto& b)
+            { return mrpt::system::timeDifference(a->timestamp, b->timestamp) > 0; });
+        buffer_.insert(it, o);
+    }
+
+    // Trim history older than bufferLength seconds behind the newest entry.
+    const auto newest = buffer_.back()->timestamp;
+    while (!buffer_.empty() &&
+           mrpt::system::timeDifference(buffer_.front()->timestamp, newest) > bufferLength)
+    {
+        buffer_.pop_front();
+    }
+}
+
+void FastPredictor::note_observation_stamp(const mrpt::Clock::time_point& obsStamp)
+{
+    std::lock_guard<std::mutex> lck(mtx_);
+    // Keep the freshest observation stamp (inputs are usually monotonic):
+    if (!lastObsStamp_ || mrpt::system::timeDifference(*lastObsStamp_, obsStamp) > 0)
+    {
+        lastObsStamp_     = obsStamp;
+        lastObsWallclock_ = mrpt::Clock::now();
+    }
+}
+
+std::optional<mrpt::Clock::time_point> FastPredictor::get_current_extrapolated_stamp() const
+{
+    std::lock_guard<std::mutex> lck(mtx_);
+    if (!lastObsStamp_)
+    {
+        return std::nullopt;
+    }
+    return mrpt::Clock::fromDouble(
+        (mrpt::Clock::nowDouble() - mrpt::Clock::toDouble(lastObsWallclock_)) +
+        mrpt::Clock::toDouble(*lastObsStamp_));
+}
+
+void FastPredictor::clear()
+{
+    std::lock_guard<std::mutex> lck(mtx_);
+    anchor_.reset();
+    frameTransforms_.clear();
+    buffer_.clear();
+    lastObsStamp_.reset();
+}
+
+bool FastPredictor::has_anchor() const
+{
+    std::lock_guard<std::mutex> lck(mtx_);
+    return anchor_.has_value();
+}
+
+std::optional<NavState> FastPredictor::predict(
+    const mrpt::Clock::time_point& t_query, const Parameters& params) const
+{
+    // --- 1) Snapshot the anchor + relevant buffered odometry under the lock ---
+    NavState                                               anchor;
+    mrpt::Clock::time_point                                anchorStamp;
+    std::vector<mrpt::obs::CObservationOdometry::ConstPtr> odoms;
+    {
+        std::lock_guard<std::mutex> lck(mtx_);
+        if (!anchor_.has_value())
+        {
+            return std::nullopt;
+        }
+        anchor      = *anchor_;
+        anchorStamp = anchorStamp_;
+
+        const double anchor_s = mrpt::Clock::toDouble(anchorStamp);
+        const double query_s  = mrpt::Clock::toDouble(t_query);
+        const double lo       = std::min(anchor_s, query_s);
+        const double hi       = std::max(anchor_s, query_s);
+        for (const auto& o : buffer_)
+        {
+            const double s = mrpt::Clock::toDouble(o->timestamp);
+            if (s < lo || s > hi)
+            {
+                continue;
+            }
+            if (auto odo = std::dynamic_pointer_cast<const mrpt::obs::CObservationOdometry>(o); odo)
+            {
+                odoms.push_back(odo);
+            }
+        }
+    }
+
+    const double anchor_s = mrpt::Clock::toDouble(anchorStamp);
+    const double query_s  = mrpt::Clock::toDouble(t_query);
+
+    // Validity: do not extrapolate too far beyond the freshest available data.
+    double newest_s = anchor_s;
+    for (const auto& o : odoms)
+    {
+        newest_s = std::max(newest_s, mrpt::Clock::toDouble(o->timestamp));
+    }
+    if (std::abs(query_s - newest_s) > params.max_time_to_use_velocity_model)
+    {
+        return std::nullopt;
+    }
+
+    // --- 2) Build the sorted set of node timestamps (merging near-equal ones) -
+    const double tol = std::max(1e-4, params.min_time_difference_to_create_new_frame);
+
+    std::vector<double> cand;
+    cand.push_back(anchor_s);
+    cand.push_back(query_s);
+    for (const auto& o : odoms)
+    {
+        cand.push_back(mrpt::Clock::toDouble(o->timestamp));
+    }
+    std::sort(cand.begin(), cand.end());
+
+    std::vector<double> nodeStamps;  // representative stamp per node, ascending
+    for (const double s : cand)
+    {
+        if (nodeStamps.empty() || (s - nodeStamps.back()) > tol)
+        {
+            nodeStamps.push_back(s);
+        }
+    }
+
+    auto nodeOf = [&](double s) -> mola::id_t
+    {
+        // nearest representative
+        auto   it      = std::lower_bound(nodeStamps.begin(), nodeStamps.end(), s);
+        size_t bestIdx = 0;
+        double bestDt  = std::numeric_limits<double>::max();
+        for (size_t k :
+             {it == nodeStamps.begin() ? size_t(0) : size_t(it - nodeStamps.begin() - 1),
+              std::min<size_t>(it - nodeStamps.begin(), nodeStamps.size() - 1)})
+        {
+            const double dt = std::abs(nodeStamps[k] - s);
+            if (dt < bestDt)
+            {
+                bestDt  = dt;
+                bestIdx = k;
+            }
+        }
+        return static_cast<mola::id_t>(bestIdx);
+    };
+
+    const mola::id_t nAnchor = nodeOf(anchor_s);
+    const mola::id_t nQuery  = nodeOf(query_s);
+
+    // --- 3) Assemble the tiny graph + initial values -------------------------
+    gtsam::NonlinearFactorGraph graph;
+    gtsam::Values               values;
+
+    const gtsam::Vector3 anchorV = {anchor.twist.vx, anchor.twist.vy, anchor.twist.vz};
+    const gtsam::Vector3 anchorW = {anchor.twist.wx, anchor.twist.wy, anchor.twist.wz};
+
+    for (size_t k = 0; k < nodeStamps.size(); k++)
+    {
+        const double dt = nodeStamps[k] - anchor_s;
+
+        // Constant-velocity SE(3) extrapolation of the anchor as the initial
+        // guess (same scheme as the backend's estimated_navstate()).
+        mrpt::math::CVectorFixed<double, 6> twistDt;
+        twistDt[0] = anchor.twist.vx;
+        twistDt[1] = anchor.twist.vy;
+        twistDt[2] = anchor.twist.vz;
+        twistDt[3] = anchor.twist.wx;
+        twistDt[4] = anchor.twist.wy;
+        twistDt[5] = anchor.twist.wz;
+        twistDt *= dt;
+
+        const mrpt::poses::CPose3D mean_k =
+            anchor.pose.mean + mrpt::poses::Lie::SE<3>::exp(twistDt);
+
+        values.insert(T(static_cast<mola::id_t>(k)), mrpt::gtsam_wrappers::toPose3(mean_k));
+        values.insert(V(static_cast<mola::id_t>(k)), anchorV);
+        values.insert(W(static_cast<mola::id_t>(k)), anchorW);
+    }
+
+    // 3a) Prior at the anchor node, from the optimized state + covariance.
+    {
+        mrpt::poses::CPose3DPDFGaussian anchorG;
+        anchorG.copyFrom(anchor.pose);  // information -> covariance form
+
+        gtsam::Pose3   priorPose;
+        gtsam::Matrix6 priorCov;
+        mrpt::gtsam_wrappers::to_gtsam_se3_cov6(anchorG, priorPose, priorCov);
+        graph.addPrior(T(nAnchor), priorPose, gtsam::noiseModel::Gaussian::Covariance(priorCov));
+
+        const mrpt::math::CMatrixDouble66 twCov = anchor.twist_inv_cov.inverse_LLt();
+        const gtsam::Matrix3              vCov  = twCov.asEigen().block<3, 3>(0, 0);
+        const gtsam::Matrix3              wCov  = twCov.asEigen().block<3, 3>(3, 3);
+        add_twist_priors(graph, nAnchor, anchorV, vCov, anchorW, wCov);
+    }
+
+    // 3b) Constant-velocity kinematic chain between consecutive nodes.
+    for (size_t k = 0; k + 1 < nodeStamps.size(); k++)
+    {
+        const double dt = nodeStamps[k + 1] - nodeStamps[k];
+        add_kinematic_factors(
+            graph, params, static_cast<mola::id_t>(k), static_cast<mola::id_t>(k + 1), dt);
+    }
+
+    // 3c) Wheel-odometry between-factors (relative pose constraints).
+    if (odoms.size() >= 2)
+    {
+        for (size_t i = 0; i + 1 < odoms.size(); i++)
+        {
+            const auto nFrom = nodeOf(mrpt::Clock::toDouble(odoms[i]->timestamp));
+            const auto nTo   = nodeOf(mrpt::Clock::toDouble(odoms[i + 1]->timestamp));
+            if (nFrom == nTo)
+            {
+                continue;  // both snapped to the same node
+            }
+
+            // Relative increment, expressed in the body frame of the "from" pose:
+            const auto increment = odoms[i + 1]->odometry - odoms[i]->odometry;
+
+            // Same Gaussian motion model as StateEstimationSmoother::fuse_odometry():
+            mrpt::obs::CActionRobotMovement2D odoAct;
+            odoAct.motionModelConfiguration.modelSelection =
+                mrpt::obs::CActionRobotMovement2D::mmGaussian;
+            odoAct.motionModelConfiguration.gaussianModel.minStdXY  = 1e-3;
+            odoAct.motionModelConfiguration.gaussianModel.minStdPHI = mrpt::DEG2RAD(0.1);
+            odoAct.computeFromOdometry(increment, odoAct.motionModelConfiguration);
+
+            mrpt::poses::CPose3DPDFGaussian relPdf;
+            relPdf.copyFrom(*odoAct.poseChange);
+            relPdf.cov.asEigen().diagonal().array() += 1e-4;  // numerical floor
+
+            gtsam::Pose3   relPose;
+            gtsam::Matrix6 relCov;
+            mrpt::gtsam_wrappers::to_gtsam_se3_cov6(relPdf, relPose, relCov);
+
+            graph.emplace_shared<gtsam::BetweenFactor<gtsam::Pose3>>(
+                T(nFrom), T(nTo), relPose, gtsam::noiseModel::Gaussian::Covariance(relCov));
+        }
+    }
+
+    // --- 4) Solve + extract the queried node ---------------------------------
+    gtsam::Values result;
+    try
+    {
+        gtsam::LevenbergMarquardtParams lmParams;
+        result = gtsam::LevenbergMarquardtOptimizer(graph, values, lmParams).optimize();
+    }
+    catch (const std::exception&)
+    {
+        return std::nullopt;
+    }
+
+    std::optional<gtsam::Marginals> marginals;
+    try
+    {
+        marginals.emplace(graph, result);
+    }
+    catch (const std::exception&)
+    {
+        return std::nullopt;
+    }
+
+    NavState out;
+    try
+    {
+        const auto qPose = result.at<gtsam::Pose3>(T(nQuery));
+        out.pose.mean    = mrpt::poses::CPose3D(mrpt::gtsam_wrappers::toTPose3D(qPose));
+
+        const auto poseCov = gtsam::Matrix6(marginals->marginalCovariance(T(nQuery)));
+        out.pose.cov_inv   = mrpt::gtsam_wrappers::to_mrpt_se3_cov6(poseCov).inverse_LLt();
+
+        const auto qV = result.at<gtsam::Vector3>(V(nQuery));
+        const auto qW = result.at<gtsam::Vector3>(W(nQuery));
+        out.twist     = {qV.x(), qV.y(), qV.z(), qW.x(), qW.y(), qW.z()};
+
+        const auto     vCov     = gtsam::Matrix3(marginals->marginalCovariance(V(nQuery)));
+        const auto     wCov     = gtsam::Matrix3(marginals->marginalCovariance(W(nQuery)));
+        gtsam::Matrix6 twCov    = gtsam::Matrix6::Zero();
+        twCov.block<3, 3>(0, 0) = vCov;
+        twCov.block<3, 3>(3, 3) = wCov;
+        out.twist_inv_cov       = mrpt::math::CMatrixDouble66(twCov.inverse());
+    }
+    catch (const std::exception&)
+    {
+        return std::nullopt;
+    }
+
+    if (params.enforce_planar_motion)
+    {
+        enforce_planar_pose(out.pose.mean);
+        enforce_planar_twist(out.twist);
+    }
+
+    return out;
+}
+
+}  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/src/FastPredictor.h
+++ b/mola_state_estimation_smoother/src/FastPredictor.h
@@ -1,0 +1,120 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   FastPredictor.h
+ * @brief  High-rate pose predictor anchored on the latest backend solution.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jun 22, 2026
+ */
+#pragma once
+
+#include <mola_kernel/interfaces/NavStateFilter.h>  // NavState
+#include <mola_state_estimation_smoother/Parameters.h>
+#include <mrpt/core/Clock.h>
+#include <mrpt/obs/CObservation.h>
+#include <mrpt/poses/CPose3DPDFGaussian.h>
+#include <mrpt/system/datetime.h>  // timeDifference
+
+#include <deque>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <string>
+
+namespace mola::state_estimation_smoother
+{
+/** Lightweight, high-rate (20-50 Hz) pose predictor used when the smoother runs
+ *  in `async_backend` mode.
+ *
+ *  It keeps the most recent optimized state ("anchor") produced by the backend
+ *  thread, plus a short buffer of high-rate observations that arrived after it.
+ *  On each `predict()` query it builds a *tiny* GTSAM factor graph re-anchored at
+ *  that solution (a Gaussian prior at the anchor + constant-velocity kinematic
+ *  factors + the buffered high-rate sensors), solves it, and returns the
+ *  extrapolated vehicle state in the reference frame. Each solve touches only a
+ *  handful of variables, so it stays sub-millisecond and never blocks on the
+ *  long backend batch solve.
+ *
+ *  Thread-safety: all public methods are guarded by an internal mutex that is
+ *  deliberately separate from the smoother's `stateMutex_`, so fast queries are
+ *  not blocked while the backend holds `stateMutex_` for a full batch update.
+ */
+class FastPredictor
+{
+   public:
+    FastPredictor() = default;
+
+    /// Latest estimated T_map_to_frame transforms, keyed by odometry frame name.
+    using FrameTransforms = std::map<std::string, mrpt::poses::CPose3DPDFGaussian>;
+
+    /** Replaces the anchor with a newly optimized state (called by the backend
+     *  thread after each successful solve). `anchorState` is expressed in the
+     *  reference frame; `frameTransforms` carries the latest T_map_to_frame for
+     *  each known odometry frame_id, so the fast query path can convert results
+     *  to a requested frame without touching the smoother's `stateMutex_`.
+     *  Buffered observations older than the new anchor are dropped.
+     */
+    void set_anchor(
+        const NavState& anchorState, const mrpt::Clock::time_point& anchorStamp,
+        const FrameTransforms& frameTransforms);
+
+    /** Returns the cached T_map_to_frame for `frame_id`, or nullopt if unknown. */
+    [[nodiscard]] std::optional<mrpt::poses::CPose3DPDFGaussian> frame_transform(
+        const std::string& frame_id) const;
+
+    /** Buffers a high-rate observation to be re-fused on top of the anchor.
+     *  Only the observation classes the fast layer uses (wheel odometry) are
+     *  retained; others are ignored. The buffer is trimmed to
+     *  `bufferLength` seconds of history.
+     */
+    void push_observation(const mrpt::obs::CObservation::ConstPtr& o, double bufferLength);
+
+    /** Records the timestamp of the latest incoming observation (of any class)
+     *  together with the current wallclock, so spinOnce() can compute a timely
+     *  "now" stamp without touching the smoother's stateMutex_. */
+    void note_observation_stamp(const mrpt::Clock::time_point& obsStamp);
+
+    /** Real-time "now" stamp: the latest observation stamp advanced by the
+     *  wallclock elapsed since it was received. std::nullopt if no observation
+     *  has been seen yet. Lock-free w.r.t. the backend solve (own mutex only). */
+    [[nodiscard]] std::optional<mrpt::Clock::time_point> get_current_extrapolated_stamp() const;
+
+    /** Builds and solves the tiny re-anchored graph, returning the estimated
+     *  vehicle state at `t_query` in the reference frame. Returns std::nullopt
+     *  if there is no anchor yet, if `t_query` is too far beyond the latest data
+     *  (`max_time_to_use_velocity_model`), or if the tiny solve is degenerate.
+     */
+    [[nodiscard]] std::optional<NavState> predict(
+        const mrpt::Clock::time_point& t_query, const Parameters& params) const;
+
+    /** Drops the anchor and all buffered observations (used on reset()). */
+    void clear();
+
+    /** Returns true if an anchor has been set. */
+    [[nodiscard]] bool has_anchor() const;
+
+   private:
+    mutable std::mutex mtx_;
+
+    std::optional<NavState>                       anchor_;
+    mrpt::Clock::time_point                       anchorStamp_;
+    FrameTransforms                               frameTransforms_;
+    std::deque<mrpt::obs::CObservation::ConstPtr> buffer_;  //!< wheel-odom history, time-sorted
+
+    std::optional<mrpt::Clock::time_point> lastObsStamp_;
+    mrpt::Clock::time_point                lastObsWallclock_;
+};
+
+}  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/src/Parameters.cpp
+++ b/mola_state_estimation_smoother/src/Parameters.cpp
@@ -50,6 +50,11 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
     MCP_LOAD_OPT(cfg, gnss_nearby_keyframe_stamp_tolerance);
     MCP_LOAD_OPT(cfg, imu_nearby_keyframe_stamp_tolerance);
 
+    MCP_LOAD_OPT(cfg, odometry_min_sample_period);
+    MCP_LOAD_OPT(cfg, imu_min_sample_period);
+    ASSERT_GE_(odometry_min_sample_period, .0);
+    ASSERT_GE_(imu_min_sample_period, .0);
+
     MCP_LOAD_OPT(cfg, initial_twist_sigma_lin);
     MCP_LOAD_OPT(cfg, initial_twist_sigma_ang);
 
@@ -106,6 +111,12 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
     // Nonlinear optimization
     // -----------------------------------------------------
     MCP_LOAD_OPT(cfg, additional_isam2_update_steps);
+
+    // Asynchronous backend + fast predictor (real-time mode)
+    // -----------------------------------------------------
+    MCP_LOAD_OPT(cfg, async_backend);
+    MCP_LOAD_OPT(cfg, fast_predictor_buffer_length);
+    ASSERT_GT_(fast_predictor_buffer_length, .0);
 
     // name Sensor input names
     // -----------------------------------------------------

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -27,6 +27,8 @@
 #include <mrpt/math/gtsam_wrappers.h>
 #include <mrpt/obs/CActionRobotMovement2D.h>
 #include <mrpt/obs/CObservationRobotPose.h>
+#include <mrpt/opengl/CSetOfObjects.h>
+#include <mrpt/opengl/stock_objects.h>
 #include <mrpt/poses/Lie/SO.h>
 #include <mrpt/poses/gtsam_wrappers.h>
 #include <mrpt/topography/conversions.h>
@@ -35,7 +37,6 @@
 #include <gtsam/geometry/Point3.h>
 #include <gtsam/geometry/Rot3.h>
 #include <gtsam/nonlinear/ExpressionFactor.h>
-#include <gtsam/nonlinear/Marginals.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/Symbol.h>
 #include <gtsam/nonlinear/Values.h>
@@ -53,6 +54,13 @@
 #include <mola_gtsam_factors/MeasuredGravityFactor.h>
 #include <mola_gtsam_factors/Pose3RotationFactor.h>
 
+// Internal helpers (also shared with the fast predictor):
+#include "FastPredictor.h"
+#include "factor_builders.h"
+
+// std:
+#include <chrono>
+
 // arguments: class_name, parent_class, class namespace
 IMPLEMENTS_MRPT_OBJECT(
     StateEstimationSmoother, mola::ExecutableBase, mola::state_estimation_smoother)
@@ -64,7 +72,7 @@ constexpr double INIT_ODOM_FRAME_POSE_SIGMA  = 1e3;
 constexpr double FIRST_POSE_WEAK_PRIOR_SIGMA = 1e6;
 constexpr double PLANAR_XY_SIGMA             = 1e10;
 constexpr double PLANAR_Z_SIGMA              = 1e-4;
-constexpr double TRICYCLE_LARGE_SIGMAS       = 1e6;
+// (TRICYCLE_LARGE_SIGMAS lives in factor_builders.h, shared with the fast predictor)
 
 void enforce_planar_pose(mrpt::poses::CPose3D& p)
 {
@@ -88,18 +96,10 @@ const bool   NAVSTATE_PRINT_FG_ERRORS = mrpt::get_env<bool>("NAVSTATE_PRINT_FG_E
 const double NAVSTATE_PRINT_FG_ERRORS_THRESHOLD =
     mrpt::get_env<double>("NAVSTATE_PRINT_FG_ERRORS_THRESHOLD", 0.1);
 
-using gtsam::symbol_shorthand::F;  // Frame of references (Pose3)
-                                   // F(0): T_enu_to_map
-                                   // F(i): T_map_to_odometry_frame_i
-const auto symbol_T_enu_to_map         = F(0);
-const auto symbol_T_map_to_odom_i_base = F(0);  // odom[i] = thisSymbol + i (with i>=1)
-
-using gtsam::symbol_shorthand::T;  // Poses                          (Pose3)
-using gtsam::symbol_shorthand::V;  // Lin velocity (body frame)      (Point3)
-using gtsam::symbol_shorthand::W;  // Ang velocity (body frame)      (Point3)
+// The GTSAM symbol scheme (F/T/V/W, symbol_T_enu_to_map,
+// symbol_T_map_to_odom_i_base, REFERENCE_FRAME_ID) is defined in
+// "factor_builders.h", shared with the fast predictor.
 //  TODO: IMU bias
-
-constexpr unsigned int REFERENCE_FRAME_ID = 0;  // (for symbol_T_enu_to_map)
 
 // -------- GtsamImpl -------
 
@@ -129,6 +129,113 @@ StateEstimationSmoother::StateEstimationSmoother()
 {  //
     profiler_.setName("StateEstimationSmoother");
     ExecutableBase::setModuleInstanceName("StateEstimationSmoother");
+}
+
+StateEstimationSmoother::~StateEstimationSmoother()
+{
+    // Signal and join the backend thread, if it was started (async_backend mode).
+    backendShutdown_ = true;
+    {
+        std::lock_guard<std::mutex> lck(backendCvMutex_);
+        backendPendingWork_ = true;
+    }
+    backendCv_.notify_all();
+    if (backendThread_.joinable())
+    {
+        backendThread_.join();
+    }
+}
+
+void StateEstimationSmoother::notify_backend()
+{
+    {
+        std::lock_guard<std::mutex> lck(backendCvMutex_);
+        backendPendingWork_ = true;
+    }
+    backendCv_.notify_one();
+}
+
+bool StateEstimationSmoother::build_anchor_locked(
+    NavState& anchorOut, mrpt::Clock::time_point& anchorStampOut,
+    std::map<std::string, mrpt::poses::CPose3DPDFGaussian>& frameTransformsOut) const
+{
+    // The newest keyframe in the reference frame is the anchor.
+    if (state_.stamp2frame_index.empty() || state_.last_estimated_states.empty())
+    {
+        return false;
+    }
+    const auto& latestIt      = state_.stamp2frame_index.getDirectMap().rbegin();
+    anchorStampOut            = latestIt->first;
+    const auto latestFrameIdx = latestIt->second;
+
+    if (state_.last_estimated_states.count(latestFrameIdx) == 0)
+    {
+        return false;
+    }
+
+    anchorOut = get_latest_state_and_covariance(latestFrameIdx);
+
+    // Snapshot the current odometry-frame transforms by name, so the fast query
+    // path can convert to a requested frame_id without touching stateMutex_.
+    frameTransformsOut.clear();
+    for (const auto& [name, frameId] : state_.known_odom_frames.getDirectMap())
+    {
+        if (const auto it = state_.last_estimated_frames.find(frameId);
+            it != state_.last_estimated_frames.end())
+        {
+            frameTransformsOut[name] = it->second;
+        }
+    }
+    return true;
+}
+
+void StateEstimationSmoother::backend_thread_loop()
+{
+    while (!backendShutdown_)
+    {
+        // Wait for new queued data or a shutdown request. Without real work
+        // there is nothing to solve, so we must not wake on a timeout and
+        // re-run the (heavy) batch update on an unchanged graph.
+        {
+            std::unique_lock<std::mutex> lck(backendCvMutex_);
+            backendCv_.wait(lck, [this] { return backendPendingWork_ || backendShutdown_; });
+            backendPendingWork_ = false;
+        }
+        if (backendShutdown_)
+        {
+            break;
+        }
+
+        // Run the (heavy) batch solve, build the new anchor, and hand it to the
+        // predictor, all while holding stateMutex_. Publishing under the lock
+        // keeps it atomic with reset_locked() (which clears fastPredictor_), so a
+        // concurrent reset can never be followed by re-seeding a pre-reset anchor.
+        // set_anchor() takes the predictor's own mutex, not stateMutex_, so there
+        // is no deadlock. The whole block is guarded because
+        // process_pending_gtsam_updates_locked() and build_anchor_locked() can
+        // both throw, and an exception escaping this worker thread would
+        // terminate the process.
+        {
+            auto lck = mrpt::lockHelper(stateMutex_);
+            try
+            {
+                process_pending_gtsam_updates_locked();
+
+                NavState                                               anchor;
+                mrpt::Clock::time_point                                anchorStamp;
+                std::map<std::string, mrpt::poses::CPose3DPDFGaussian> frameTransforms;
+                if (build_anchor_locked(anchor, anchorStamp, frameTransforms) && fastPredictor_)
+                {
+                    fastPredictor_->set_anchor(anchor, anchorStamp, frameTransforms);
+                }
+            }
+            catch (const std::exception& e)
+            {
+                MRPT_LOG_THROTTLE_WARN_FMT(
+                    5.0, "[backend_thread] Could not update/build anchor yet: %s", e.what());
+            }
+        }
+    }
 }
 
 void StateEstimationSmoother::initialize(const mrpt::containers::yaml& cfg)
@@ -185,16 +292,37 @@ void StateEstimationSmoother::initialize(const mrpt::containers::yaml& cfg)
 
     params_loaded_ = true;
     reinitialize_gtsam_locked();
+
+    // Start the asynchronous backend thread + fast predictor, if requested:
+    if (params_.async_backend && !backendThread_.joinable())
+    {
+        MRPT_LOG_INFO(
+            "async_backend=true: batch solve runs in a backend thread; "
+            "estimated_navstate() is served by the lightweight fast predictor.");
+        fastPredictor_   = std::make_unique<FastPredictor>();
+        backendShutdown_ = false;
+        backendThread_   = std::thread(&StateEstimationSmoother::backend_thread_loop, this);
+    }
 }
 
 void StateEstimationSmoother::reinitialize_gtsam_locked()
 {
-    // Forward parameters to GTSAM smoother & iSAM2:
+    // Incremental (iSAM2) fixed-lag smoother: cheap incremental updates (per-query
+    // cost ~ ms vs the batch smoother's tens of ms) and accurate marginalization of
+    // the persistent geo-reference variable.
+    //
+    // iSAM2's incremental Bayes tree assumes variables are introduced in
+    // non-decreasing timestamp order. Multi-rate sensor latency (e.g. the
+    // CPU-bound LiDAR-odometry front-end lagging the high-rate wheel-odom/IMU by a
+    // few hundred ms) would otherwise insert keyframes "in the past" and corrupt
+    // the marginalization bookkeeping once they cross the lag horizon. That
+    // ordering is enforced at create_or_get_keyframe_by_timestamp_locked(), which
+    // snaps an out-of-order request to the nearest existing keyframe instead of
+    // introducing a new variable in the past.
     gtsam::ISAM2Params isam2Params;
     isam2Params.findUnusedFactorSlots = true;  // Important, must be set for fixed-lag smoother
     isam2Params.relinearizeThreshold  = 0.1;
     isam2Params.relinearizeSkip       = 1;
-    // isam2Params.optimizationParams    = gtsam::ISAM2DoglegParams();
 
     state_.gtsam->smoother.emplace(params_.sliding_window_length, isam2Params);
 
@@ -224,15 +352,23 @@ void StateEstimationSmoother::reinitialize_gtsam_locked()
 
 void StateEstimationSmoother::spinOnce()
 {
-    // At the predefined module rate, publish the current estimation, if we have any subscriber:
-    if (!anyUpdateLocalizationSubscriber())
+    // At the predefined module rate, publish the current estimation if there is
+    // any subscriber, and/or draw the pose in the visualizer if connected.
+    const bool haveSubscriber = anyUpdateLocalizationSubscriber();
+    if (!haveSubscriber && !visualizer_)
     {
         return;
     }
 
-    // Read the extrapolated stamp under the lock, then release before calling estimated_navstate()
-    // to avoid recursive locking (estimated_navstate() acquires the mutex internally).
+    // Read the extrapolated "now" stamp. In async mode this is served by the
+    // fast predictor (its own mutex), so spinOnce never blocks on the backend
+    // batch solve. In sync mode, read it under stateMutex_ as before.
     std::optional<mrpt::Clock::time_point> tNowOpt;
+    if (params_.async_backend && fastPredictor_)
+    {
+        tNowOpt = fastPredictor_->get_current_extrapolated_stamp();
+    }
+    else
     {
         auto lck = mrpt::lockHelper(stateMutex_);
         tNowOpt  = state_.get_current_extrapolated_stamp();
@@ -270,7 +406,19 @@ void StateEstimationSmoother::spinOnce()
         "[spinOnce] Publishing timely pose estimate: t=%f pose=%s", mrpt::Clock::toDouble(*tNowOpt),
         lu.pose.asString().c_str());
 
-    advertiseUpdatedLocalization(lu);
+    if (haveSubscriber)
+    {
+        advertiseUpdatedLocalization(lu);
+    }
+
+    // Show a moving XYZ corner at the latest published pose in the visualizer:
+    if (visualizer_)
+    {
+        auto corner = mrpt::opengl::stock_objects::CornerXYZSimple(/*scale*/ 1.0f);
+        corner->setName("smoother_pose_corner");
+        corner->setPose(mrpt::poses::CPose3D(lu.pose));
+        visualizer_->update_3d_object("smoother_pose_corner", corner);
+    }
 }
 
 void StateEstimationSmoother::reset()
@@ -285,6 +433,11 @@ void StateEstimationSmoother::reset_locked()
     if (params_loaded_)
     {
         reinitialize_gtsam_locked();
+    }
+    // Drop the fast predictor's anchor/buffer too (e.g. after a re-localization).
+    if (fastPredictor_)
+    {
+        fastPredictor_->clear();
     }
 }
 
@@ -307,14 +460,31 @@ void StateEstimationSmoother::fuse_odometry(
 
         ASSERT_(state_.last_wheels_odometry.has_value());
         lastOdom = *state_.last_wheels_odometry;
+
+        // High-rate decimation/merge: if this reading arrives too soon after the
+        // last *processed* one, drop it WITHOUT advancing the pose anchor
+        // (last_wheels_odometry) nor the processed stamp. The next kept reading
+        // then fuses the accumulated increment (lastOdom -> current) with its
+        // accumulated motion-model covariance, effectively merging several
+        // consecutive odometry readings into a single keyframe/factor.
+        if (params_.odometry_min_sample_period > 0 && state_.last_wheels_odometry_stamp.has_value())
+        {
+            const double dt = mrpt::system::timeDifference(
+                *state_.last_wheels_odometry_stamp, odom.timestamp);
+            if (dt < params_.odometry_min_sample_period)
+            {
+                return;
+            }
+        }
     }
     else
     {
         // This is the first time we have wheels odometry.
         // Store the pose but skip factor creation: the increment is zero,
         // which would produce a stiff near-zero BetweenFactor.
-        state_.last_wheels_odometry_name = odomName;
-        state_.last_wheels_odometry      = odom.odometry;
+        state_.last_wheels_odometry_name  = odomName;
+        state_.last_wheels_odometry       = odom.odometry;
+        state_.last_wheels_odometry_stamp = odom.timestamp;
         return;
     }
     // Use a probabilistic motion model:
@@ -340,9 +510,10 @@ void StateEstimationSmoother::fuse_odometry(
         mrpt::Clock::toDouble(odom.timestamp), odomName.c_str(), odom.odometry.asString().c_str(),
         odoAct.poseChange->getMeanVal().asString().c_str());
 
-    // Save for next iteration:
-    state_.last_wheels_odometry_name = odomName;
-    state_.last_wheels_odometry      = odom.odometry;
+    // Save for next iteration (advance the anchor: this reading was processed):
+    state_.last_wheels_odometry_name  = odomName;
+    state_.last_wheels_odometry       = odom.odometry;
+    state_.last_wheels_odometry_stamp = odom.timestamp;
 
     // Fuse this new probabilistic pose observation:
     fuse_pose_locked(odom.timestamp, newOdomPosePdf, odomName);
@@ -351,6 +522,21 @@ void StateEstimationSmoother::fuse_odometry(
 void StateEstimationSmoother::fuse_imu(const mrpt::obs::CObservationIMU& imu)
 {
     auto lck = mrpt::lockHelper(stateMutex_);
+
+    // High-rate decimation: skip IMU readings arriving too soon after the last
+    // processed one. IMU attitude/gravity are absolute observations, so dropping
+    // intermediate readings just lowers the redundant-factor rate (it does not
+    // need the increment-merging that wheel odometry uses).
+    if (params_.imu_min_sample_period > 0 && state_.last_processed_imu_stamp.has_value())
+    {
+        const double dt =
+            mrpt::system::timeDifference(*state_.last_processed_imu_stamp, imu.timestamp);
+        if (dt < params_.imu_min_sample_period)
+        {
+            return;
+        }
+    }
+    state_.last_processed_imu_stamp = imu.timestamp;
 
     // Create a new KF id (or reuse a very close match):
     const auto this_kf_id = create_or_get_keyframe_by_timestamp_locked(
@@ -605,40 +791,8 @@ void StateEstimationSmoother::fuse_twist(
     // Create a new KF id (or reuse a very close match):
     const auto this_kf_id = create_or_get_keyframe_by_timestamp_locked(timestamp);
 
-    {
-        auto                                noiseV = gtsam::noiseModel::Gaussian::Covariance(vCov);
-        gtsam::noiseModel::Base::shared_ptr robNoiseV;
-#if 0
-        if (params_.robust_param > 0)
-        {
-            robNoiseV = gtsam::noiseModel::Robust::Create(
-                gtsam::noiseModel::mEstimator::GemanMcClure::Create(params_.robust_param), noiseV);
-        }
-        else
-#endif
-        {
-            robNoiseV = noiseV;
-        }
-
-        state_.gtsam->newFactors.addPrior(V(this_kf_id), v, robNoiseV);
-    }
-    {
-        auto                                noiseW = gtsam::noiseModel::Gaussian::Covariance(wCov);
-        gtsam::noiseModel::Base::shared_ptr robNoiseW;
-#if 0
-        if (params_.robust_param > 0)
-        {
-            robNoiseW = gtsam::noiseModel::Robust::Create(
-                gtsam::noiseModel::mEstimator::GemanMcClure::Create(params_.robust_param), noiseW);
-        }
-        else
-#endif
-        {
-            robNoiseW = noiseW;
-        }
-
-        state_.gtsam->newFactors.addPrior(W(this_kf_id), w, robNoiseW);
-    }
+    // Emit the V/W priors via the shared builder (also used by the fast predictor):
+    add_twist_priors(state_.gtsam->newFactors, this_kf_id, v, vCov, w, wCov);
 
     MRPT_LOG_DEBUG_FMT(
         "[fuse_twist]: t=%f this_kf_id=%zu twist=%s sigmas=%.02e %.02e %.02e (m) %.02e %.02e "
@@ -652,6 +806,38 @@ void StateEstimationSmoother::fuse_twist(
 std::optional<NavState> StateEstimationSmoother::estimated_navstate(
     const mrpt::Clock::time_point& timestamp, const std::string& frame_id)
 {
+    // Async backend mode: serve from the lightweight fast predictor (re-anchored
+    // on the last backend solution) instead of running the heavy batch solve on
+    // the caller's thread. This path deliberately does NOT take stateMutex_ (the
+    // backend may be holding it for a full batch update), so it stays sub-ms.
+    if (params_.async_backend)
+    {
+        ASSERT_(fastPredictor_);
+        auto pred = fastPredictor_->predict(timestamp, params_);
+        if (!pred)
+        {
+            return {};
+        }
+        NavState ret = *pred;
+
+        // Convert to the requested frame_id using the cached T_map_to_frame:
+        if (frame_id != params_.reference_frame_name)
+        {
+            const auto frameTf = fastPredictor_->frame_transform(frame_id);
+            if (!frameTf)
+            {
+                MRPT_LOG_THROTTLE_WARN_FMT(
+                    5.0, "[estimated_navstate] Requested unknown odometry frame_id='%s'",
+                    frame_id.c_str());
+                return {};
+            }
+            mrpt::poses::CPose3DPDFGaussianInf posePdfFrame_wrt_map_inf;
+            posePdfFrame_wrt_map_inf.copyFrom(*frameTf);
+            ret.pose = ret.pose - posePdfFrame_wrt_map_inf;
+        }
+        return ret;
+    }
+
     auto lck = mrpt::lockHelper(stateMutex_);
 
     // 1) Make sure we processed all pending sensor data, and have updated the cached values from
@@ -778,11 +964,52 @@ std::set<std::string> StateEstimationSmoother::known_odometry_frame_ids()
     return ret;
 }
 
+std::size_t StateEstimationSmoother::active_keyframe_count()
+{
+    auto lck = mrpt::lockHelper(stateMutex_);
+    return state_.stamp2frame_index.size();
+}
+
+std::size_t StateEstimationSmoother::active_factor_count()
+{
+    auto lck = mrpt::lockHelper(stateMutex_);
+    ASSERT_(state_.gtsam->smoother.has_value());
+    // Committed factors in the current window (pending, not-yet-applied factors
+    // are excluded; call estimated_navstate() first to flush them).
+    return state_.gtsam->smoother->getFactors().nrFactors();
+}
+
 void StateEstimationSmoother::onNewObservation(const CObservation::ConstPtr& o)
 {
     const ProfilerEntry tle(profiler_, "onNewObservation");
 
     ASSERT_(o);
+
+    // Note on out-of-order inputs: observations need not arrive in timestamp
+    // order (multi-rate sensor latency, and LiDAR poses fused via direct
+    // fuse_pose() calls). Ordering is enforced downstream at the single keyframe
+    // chokepoint, create_or_get_keyframe_by_timestamp_locked(), which snaps an
+    // out-of-order measurement to the nearest existing keyframe rather than
+    // inserting a new one in the past (iSAM2's fixed-lag marginalization can't
+    // handle out-of-order variable introduction). So we can dispatch immediately
+    // here, with no buffering/latency.
+
+    // In async mode, feed the fast predictor and wake the backend thread, but
+    // only for observations that actually passed their sensor-label filter and
+    // were fused below: otherwise filtered-out data could influence predictions,
+    // and waking the backend before the fuse_*() call has enqueued its GTSAM work
+    // would let the worker clear its pending flag against stale data. The
+    // predictor only retains the observation classes it uses (wheel odometry).
+    const auto feedAcceptedAsyncObservation = [&]()
+    {
+        if (!params_.async_backend || !fastPredictor_)
+        {
+            return;
+        }
+        fastPredictor_->note_observation_stamp(o->timestamp);
+        fastPredictor_->push_observation(o, params_.fast_predictor_buffer_length);
+        notify_backend();
+    };
 
     // IMU:
     if (auto obsIMU = std::dynamic_pointer_cast<const mrpt::obs::CObservationIMU>(o); obsIMU)
@@ -792,6 +1019,7 @@ void StateEstimationSmoother::onNewObservation(const CObservation::ConstPtr& o)
                 state_.do_process_imu_labels_re.get_regex(params_.do_process_imu_labels_re)))
         {
             this->fuse_imu(*obsIMU);
+            feedAcceptedAsyncObservation();
         }
         else
         {
@@ -808,6 +1036,7 @@ void StateEstimationSmoother::onNewObservation(const CObservation::ConstPtr& o)
                                     params_.do_process_odometry_labels_re)))
         {
             this->fuse_odometry(*obsOdom, o->sensorLabel);
+            feedAcceptedAsyncObservation();
         }
         else
         {
@@ -862,6 +1091,7 @@ void StateEstimationSmoother::onNewObservation(const CObservation::ConstPtr& o)
         }
 
         this->fuse_pose(obsPose->timestamp, sensedSensorPose, frameId);
+        feedAcceptedAsyncObservation();
     }
     // GNSS source:
     else if (auto obsGPS = std::dynamic_pointer_cast<const mrpt::obs::CObservationGPS>(o); obsGPS)
@@ -871,6 +1101,7 @@ void StateEstimationSmoother::onNewObservation(const CObservation::ConstPtr& o)
                 state_.do_process_gnss_labels_re.get_regex(params_.do_process_gnss_labels_re)))
         {
             this->fuse_gnss(*obsGPS);
+            feedAcceptedAsyncObservation();
         }
         else
         {
@@ -895,61 +1126,14 @@ void StateEstimationSmoother::addFactor(const AbsFactorConstVelKinematics& f)
         "[addFactor] FactorConstVelKinematics: " << f.from_kf << " ==> " << f.to_kf
                                                  << " dt=" << f.deltaTime);
 
-    // Add const-vel factor to gtsam itself:
-    double dt = f.deltaTime;
-
-    // trick to easily handle queries on exactly an existing keyframe:
-    if (dt == 0)
+    if (f.deltaTime > params_.time_between_frames_to_warning)
     {
-        dt = 1e-5;
+        MRPT_LOG_WARN_FMT(
+            "Constant-velocity kinematics factor added for large dT=%.03f s.", f.deltaTime);
     }
 
-    ASSERT_GT_(dt, 0.);
-
-    // errors in constant vel:
-    const double std_lin_vel = params_.sigma_random_walk_acceleration_linear;
-    const double std_ang_vel = params_.sigma_random_walk_acceleration_angular;
-
-    if (dt > params_.time_between_frames_to_warning)
-    {
-        MRPT_LOG_WARN_FMT("Constant-velocity kinematics factor added for large dT=%.03f s.", dt);
-    }
-
-    // 1) Add GTSAM factors for constant velocity model
-    // -------------------------------------------------
-    const auto kTi  = T(f.from_kf);
-    const auto kTj  = T(f.to_kf);
-    const auto kbVi = V(f.from_kf);
-    const auto kbVj = V(f.to_kf);
-    const auto kbWi = W(f.from_kf);
-    const auto kbWj = W(f.to_kf);
-
-    // See line 3 of eq (4) in the MOLA RSS2019 paper
-    // Modify to use velocity in local frame: reuse FactorConstLocalVelocity
-    // here too:
-    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
-        kTi, kbVi, kTj, kbVj, gtsam::noiseModel::Isotropic::Sigma(3, std_lin_vel * dt));
-
-    // \omega is in the body frame, we need a special factor to rotate it:
-    // See line 4 of eq (4) in the MOLA RSS2019 paper.
-    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
-        kTi, kbWi, kTj, kbWj, gtsam::noiseModel::Isotropic::Sigma(3, std_ang_vel * dt));
-
-    // 2) Add kinematics / numerical integration factor
-    // ---------------------------------------------------
-    auto noise_kinematicsPosition =
-        gtsam::noiseModel::Isotropic::Sigma(3, params_.sigma_integrator_position);
-
-    auto noise_kinematicsOrientation =
-        gtsam::noiseModel::Isotropic::Sigma(3, params_.sigma_integrator_orientation);
-
-    // Impl. line 2 of eq (1) in the MOLA RSS2019 paper
-    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorTrapezoidalIntegratorPose>(
-        kTi, kbVi, kTj, kbVj, dt, noise_kinematicsPosition);
-
-    // Impl. line 1 of eq (4) in the MOLA RSS2019 paper.
-    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorAngularVelocityIntegrationPose>(
-        kTi, kbWi, kTj, dt, noise_kinematicsOrientation);
+    // Emit the factors via the shared builder (also used by the fast predictor):
+    add_const_vel_kinematics(state_.gtsam->newFactors, params_, f.from_kf, f.to_kf, f.deltaTime);
 }
 
 void StateEstimationSmoother::addFactor(const AbsFactorTricycleKinematics& f)
@@ -958,74 +1142,13 @@ void StateEstimationSmoother::addFactor(const AbsFactorTricycleKinematics& f)
         "[addFactor] FactorTricycleKinematics: " << f.from_kf << " ==> " << f.to_kf
                                                  << " dt=" << f.deltaTime);
 
-    // Add const-vel factor to gtsam itself:
-    double dt = f.deltaTime;
-
-    // trick to easily handle queries on exactly an existing keyframe:
-    if (dt == 0)
+    if (f.deltaTime > params_.time_between_frames_to_warning)
     {
-        dt = 1e-5;
+        MRPT_LOG_WARN_FMT("Tricycle kinematics factor added for large dT=%.03f s.", f.deltaTime);
     }
 
-    ASSERT_GT_(dt, 0.);
-
-    // errors in constant vel:
-    const double std_lin_vel = params_.sigma_random_walk_acceleration_linear;
-    const double std_ang_vel = params_.sigma_random_walk_acceleration_angular;
-
-    if (dt > params_.time_between_frames_to_warning)
-    {
-        MRPT_LOG_WARN_FMT("Tricycle kinematics factor added for large dT=%.03f s.", dt);
-    }
-
-    // 1) Add GTSAM factors for constant velocity model
-    // -------------------------------------------------
-    const auto kTi  = T(f.from_kf);
-    const auto kTj  = T(f.to_kf);
-    const auto kbVi = V(f.from_kf);
-    const auto kbVj = V(f.to_kf);
-    const auto kbWi = W(f.from_kf);
-    const auto kbWj = W(f.to_kf);
-
-    // See line 3 of eq (4) in the MOLA RSS2019 paper
-    // Modify to use velocity in local frame: reuse FactorConstLocalVelocity
-    // here too:
-    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
-        kTi, kbVi, kTj, kbVj, gtsam::noiseModel::Isotropic::Sigma(3, std_lin_vel * dt));
-
-    // \omega is in the body frame, we need a special factor to rotate it:
-    // See line 4 of eq (4) in the MOLA RSS2019 paper.
-    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
-        kTi, kbWi, kTj, kbWj, gtsam::noiseModel::Isotropic::Sigma(3, std_ang_vel * dt));
-
-    // In the tricycle model, body v_y must be zero:
-    {
-        const Eigen::Vector3d sigmas = {
-            TRICYCLE_LARGE_SIGMAS, std_lin_vel * dt, TRICYCLE_LARGE_SIGMAS};
-
-        state_.gtsam->newFactors.emplace_shared<gtsam::PriorFactor<gtsam::Point3>>(
-            kbVj, gtsam::Point3::Zero(), gtsam::noiseModel::Diagonal::Sigmas(sigmas));
-    }
-    // In the tricycle model, body w_x,w_y must be zero:
-    {
-        const Eigen::Vector3d sigmas = {std_ang_vel * dt, std_ang_vel * dt, TRICYCLE_LARGE_SIGMAS};
-
-        state_.gtsam->newFactors.emplace_shared<gtsam::PriorFactor<gtsam::Point3>>(
-            kbWj, gtsam::Point3::Zero(), gtsam::noiseModel::Diagonal::Sigmas(sigmas));
-    }
-
-    // 2) Add kinematics / numerical integration factor
-    // ---------------------------------------------------
-    gtsam::Vector6 sigmas;
-    const auto     sigmaPos   = params_.sigma_integrator_position;
-    const auto     sigmaAngle = params_.sigma_integrator_orientation;
-    sigmas << sigmaAngle, sigmaAngle, sigmaAngle, sigmaPos, sigmaPos, sigmaPos;
-
-    auto noise_kinematics = gtsam::noiseModel::Diagonal::Sigmas(sigmas);
-
-    // (To be written in a report/paper!)
-    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorTricycleKinematic>(
-        kTi, kbVi, kbWi, kTj, dt, noise_kinematics);
+    // Emit the factors via the shared builder (also used by the fast predictor):
+    add_tricycle_kinematics(state_.gtsam->newFactors, params_, f.from_kf, f.to_kf, f.deltaTime);
 }
 
 void StateEstimationSmoother::delete_too_old_entries()
@@ -1092,6 +1215,56 @@ StateEstimationSmoother::frame_index_t
         if (dt < threshold)
         {
             return frame_idx;
+        }
+    }
+
+    // Out-of-order guard.
+    // -------------------------------------------------------------------------
+    // The incremental (iSAM2) fixed-lag smoother requires variables (keyframes)
+    // to be introduced in non-decreasing timestamp order; inserting one "in the
+    // past" corrupts its Bayes-tree marginalization bookkeeping and later throws
+    // ("Requested variable 'wNN' is not in this VectorValues" / "Indeterminant
+    // linear system" / "BayesTree clique for a key not in the BayesTree").
+    //
+    // Multi-rate sensor latency makes this routine: the CPU-bound LiDAR-odometry
+    // front-end lags the high-rate wheel-odom/IMU by a few hundred ms and feeds
+    // its poses via direct fuse_pose() calls, so by the time a LiDAR pose for
+    // time t arrives the high-rate streams have already advanced the newest
+    // keyframe well past t. Rather than insert a new keyframe in the past, snap
+    // the late measurement to the temporally nearest existing keyframe (its
+    // factor is then applied at a slightly different time, bounded by the
+    // keyframe spacing). This keeps GTSAM variable introduction monotonic with
+    // no added latency, for every fuse_*() entry point.
+    if (!state_.stamp2frame_index.empty())
+    {
+        const auto newest_t = state_.stamp2frame_index.getDirectMap().rbegin()->first;
+        if (t < newest_t)
+        {
+            std::optional<frame_index_t> nearestIdx;
+            double                       nearestDt = 0;
+            for (const auto& it : {closestPrior.first, closestPrior.second})
+            {
+                if (it == state_.stamp2frame_index.getDirectMap().end())
+                {
+                    continue;
+                }
+                const double dt = std::abs(mrpt::system::timeDifference(it->first, t));
+                if (!nearestIdx.has_value() || dt < nearestDt)
+                {
+                    nearestDt  = dt;
+                    nearestIdx = it->second;
+                }
+            }
+            if (nearestIdx.has_value())
+            {
+                MRPT_LOG_THROTTLE_WARN_FMT(
+                    5.0,
+                    "[keyframe] Out-of-order measurement (%.3f s behind newest keyframe) snapped "
+                    "to nearest existing keyframe (%.3f s away) to keep iSAM2 variable order "
+                    "monotonic.",
+                    mrpt::system::timeDifference(t, newest_t), nearestDt);
+                return *nearestIdx;
+            }
         }
     }
 
@@ -1226,7 +1399,8 @@ void StateEstimationSmoother::process_pending_gtsam_updates_locked()
                 state_.gtsam->newFactors, state_.gtsam->newValues, state_.gtsam->newKeyStamps);
         }
 
-        // Optional: Perform extra internal iterations for better accuracy
+        // Extra iSAM2 refinement iterations (relinearization passes) for the
+        // current window:
         for (unsigned int i = 1; i < params_.additional_isam2_update_steps; ++i)
         {
             smoother.update();
@@ -1358,7 +1532,7 @@ void StateEstimationSmoother::process_pending_gtsam_updates_locked()
             const auto  latestFrameIdx = latestIt->second;
 
             const auto poseCov =
-                gtsam::Matrix6(state_.gtsam->smoother->marginalCovariance(T(latestFrameIdx)));
+                gtsam::Matrix6(smoother.marginalCovariance(T(latestFrameIdx)));
             mrpt::math::CMatrixDouble66 cov = mrpt::gtsam_wrappers::to_mrpt_se3_cov6(poseCov);
 
             // Check MAP->BASE_LINK position uncertainty (diagonal elements 0,1,2 are x,y,z)
@@ -1714,9 +1888,11 @@ NavState StateEstimationSmoother::get_latest_state_and_covariance(const frame_in
 
     NavState ns;
 
+    auto& smoother = *state_.gtsam->smoother;
+
     // Pose:
     ns.pose.mean       = frame.pose;
-    const auto poseCov = gtsam::Matrix6(state_.gtsam->smoother->marginalCovariance(T(idx)));
+    const auto poseCov = gtsam::Matrix6(smoother.marginalCovariance(T(idx)));
     if (poseCov.determinant() <= 0)
     {
         THROW_EXCEPTION_FMT(
@@ -1728,8 +1904,8 @@ NavState StateEstimationSmoother::get_latest_state_and_covariance(const frame_in
 
     // Twist:
     ns.twist        = frame.twist;
-    const auto vCov = gtsam::Matrix3(state_.gtsam->smoother->marginalCovariance(V(idx)));
-    const auto wCov = gtsam::Matrix3(state_.gtsam->smoother->marginalCovariance(W(idx)));
+    const auto vCov = gtsam::Matrix3(smoother.marginalCovariance(V(idx)));
+    const auto wCov = gtsam::Matrix3(smoother.marginalCovariance(W(idx)));
 
     gtsam::Matrix6 twCov    = gtsam::Matrix6::Zero();
     twCov.block<3, 3>(0, 0) = vCov;

--- a/mola_state_estimation_smoother/src/factor_builders.h
+++ b/mola_state_estimation_smoother/src/factor_builders.h
@@ -1,0 +1,190 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   factor_builders.h
+ * @brief  Internal helpers to emit GTSAM factors into a given factor graph.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jun 22, 2026
+ *
+ * These free functions hold the single source of truth for constructing the
+ * kinematic and twist factors used by the smoother. They are shared between the
+ * main backend graph (StateEstimationSmoother) and the lightweight fast
+ * predictor (FastPredictor), so both use identical factor definitions.
+ *
+ * The GTSAM symbol scheme (T/V/W per keyframe, F(0)=T_enu_to_map, F(0)+i=
+ * T_map_to_odom_frame_i) is also centralized here.
+ */
+#pragma once
+
+#include <gtsam/geometry/Point3.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/slam/PriorFactor.h>
+#include <mola_gtsam_factors/FactorAngularVelocityIntegration.h>
+#include <mola_gtsam_factors/FactorConstLocalVelocity.h>
+#include <mola_gtsam_factors/FactorTrapezoidalIntegrator.h>
+#include <mola_gtsam_factors/FactorTricycleKinematic.h>
+#include <mola_gtsam_factors/id.h>
+#include <mola_state_estimation_smoother/Parameters.h>
+#include <mrpt/core/exceptions.h>
+
+namespace mola::state_estimation_smoother
+{
+
+// GTSAM symbol scheme, shared by the backend and the fast predictor.
+using gtsam::symbol_shorthand::F;  // Frame of references (Pose3):
+                                   // F(0): T_enu_to_map
+                                   // F(i): T_map_to_odometry_frame_i (i>=1)
+using gtsam::symbol_shorthand::T;  // Poses                      (Pose3)
+using gtsam::symbol_shorthand::V;  // Lin velocity (body frame)  (Point3)
+using gtsam::symbol_shorthand::W;  // Ang velocity (body frame)  (Point3)
+
+inline const gtsam::Key symbol_T_enu_to_map         = F(0);
+inline const gtsam::Key symbol_T_map_to_odom_i_base = F(0);  // odom[i] = base + i (i>=1)
+
+inline constexpr unsigned int REFERENCE_FRAME_ID = 0;  // (for symbol_T_enu_to_map)
+
+inline constexpr double TRICYCLE_LARGE_SIGMAS = 1e6;
+
+/** Adds the constant local-velocity kinematic factors linking keyframes
+ *  `from` and `to` separated by `dt` seconds (Eqs (1),(4) in the MOLA RSS2019
+ *  paper). Mutates the passed-in graph only; does no logging.
+ */
+inline void add_const_vel_kinematics(
+    gtsam::NonlinearFactorGraph& graph, const Parameters& params, mola::id_t from, mola::id_t to,
+    double dt)
+{
+    // trick to easily handle queries on exactly an existing keyframe:
+    if (dt == 0)
+    {
+        dt = 1e-5;
+    }
+    ASSERT_GT_(dt, 0.);
+
+    const double std_lin_vel = params.sigma_random_walk_acceleration_linear;
+    const double std_ang_vel = params.sigma_random_walk_acceleration_angular;
+
+    const auto kTi  = T(from);
+    const auto kTj  = T(to);
+    const auto kbVi = V(from);
+    const auto kbVj = V(to);
+    const auto kbWi = W(from);
+    const auto kbWj = W(to);
+
+    // See line 3 of eq (4) in the MOLA RSS2019 paper.
+    graph.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
+        kTi, kbVi, kTj, kbVj, gtsam::noiseModel::Isotropic::Sigma(3, std_lin_vel * dt));
+
+    // \omega is in the body frame; see line 4 of eq (4).
+    graph.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
+        kTi, kbWi, kTj, kbWj, gtsam::noiseModel::Isotropic::Sigma(3, std_ang_vel * dt));
+
+    auto noise_kinematicsPosition =
+        gtsam::noiseModel::Isotropic::Sigma(3, params.sigma_integrator_position);
+    auto noise_kinematicsOrientation =
+        gtsam::noiseModel::Isotropic::Sigma(3, params.sigma_integrator_orientation);
+
+    // Impl. line 2 of eq (1).
+    graph.emplace_shared<mola::factors::FactorTrapezoidalIntegratorPose>(
+        kTi, kbVi, kTj, kbVj, dt, noise_kinematicsPosition);
+
+    // Impl. line 1 of eq (4).
+    graph.emplace_shared<mola::factors::FactorAngularVelocityIntegrationPose>(
+        kTi, kbWi, kTj, dt, noise_kinematicsOrientation);
+}
+
+/** Adds the tricycle kinematic factors linking keyframes `from` and `to`
+ *  separated by `dt` seconds. Mutates the passed-in graph only; does no logging.
+ */
+inline void add_tricycle_kinematics(
+    gtsam::NonlinearFactorGraph& graph, const Parameters& params, mola::id_t from, mola::id_t to,
+    double dt)
+{
+    if (dt == 0)
+    {
+        dt = 1e-5;
+    }
+    ASSERT_GT_(dt, 0.);
+
+    const double std_lin_vel = params.sigma_random_walk_acceleration_linear;
+    const double std_ang_vel = params.sigma_random_walk_acceleration_angular;
+
+    const auto kTi  = T(from);
+    const auto kTj  = T(to);
+    const auto kbVi = V(from);
+    const auto kbVj = V(to);
+    const auto kbWi = W(from);
+    const auto kbWj = W(to);
+
+    graph.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
+        kTi, kbVi, kTj, kbVj, gtsam::noiseModel::Isotropic::Sigma(3, std_lin_vel * dt));
+    graph.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
+        kTi, kbWi, kTj, kbWj, gtsam::noiseModel::Isotropic::Sigma(3, std_ang_vel * dt));
+
+    // In the tricycle model, body v_y must be zero:
+    {
+        const Eigen::Vector3d sigmas = {
+            TRICYCLE_LARGE_SIGMAS, std_lin_vel * dt, TRICYCLE_LARGE_SIGMAS};
+        graph.emplace_shared<gtsam::PriorFactor<gtsam::Point3>>(
+            kbVj, gtsam::Point3::Zero(), gtsam::noiseModel::Diagonal::Sigmas(sigmas));
+    }
+    // In the tricycle model, body w_x,w_y must be zero:
+    {
+        const Eigen::Vector3d sigmas = {std_ang_vel * dt, std_ang_vel * dt, TRICYCLE_LARGE_SIGMAS};
+        graph.emplace_shared<gtsam::PriorFactor<gtsam::Point3>>(
+            kbWj, gtsam::Point3::Zero(), gtsam::noiseModel::Diagonal::Sigmas(sigmas));
+    }
+
+    gtsam::Vector6 sigmas;
+    const auto     sigmaPos   = params.sigma_integrator_position;
+    const auto     sigmaAngle = params.sigma_integrator_orientation;
+    sigmas << sigmaAngle, sigmaAngle, sigmaAngle, sigmaPos, sigmaPos, sigmaPos;
+    auto noise_kinematics = gtsam::noiseModel::Diagonal::Sigmas(sigmas);
+
+    graph.emplace_shared<mola::factors::FactorTricycleKinematic>(
+        kTi, kbVi, kbWi, kTj, dt, noise_kinematics);
+}
+
+/** Dispatches to the configured kinematic model. */
+inline void add_kinematic_factors(
+    gtsam::NonlinearFactorGraph& graph, const Parameters& params, mola::id_t from, mola::id_t to,
+    double dt)
+{
+    switch (params.kinematic_model)
+    {
+        case KinematicModel::ConstantVelocity:
+            add_const_vel_kinematics(graph, params, from, to, dt);
+            break;
+        case KinematicModel::Tricycle:
+            add_tricycle_kinematics(graph, params, from, to, dt);
+            break;
+        default:
+            THROW_EXCEPTION("Invalid kinematic_model value");
+    }
+}
+
+/** Adds linear+angular velocity Gaussian priors (twist observation) at keyframe
+ *  `kf`. Mutates the passed-in graph only.
+ */
+inline void add_twist_priors(
+    gtsam::NonlinearFactorGraph& graph, mola::id_t kf, const gtsam::Vector3& v,
+    const gtsam::Matrix3& vCov, const gtsam::Vector3& w, const gtsam::Matrix3& wCov)
+{
+    graph.addPrior(V(kf), v, gtsam::noiseModel::Gaussian::Covariance(vCov));
+    graph.addPrior(W(kf), w, gtsam::noiseModel::Gaussian::Covariance(wCov));
+}
+
+}  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/tests/CMakeLists.txt
+++ b/mola_state_estimation_smoother/tests/CMakeLists.txt
@@ -41,3 +41,24 @@ mola_add_test(
     mola::mola_state_estimation_smoother
 )
 
+mola_add_test(
+  TARGET  test-fast-predictor
+  SOURCES test-fast-predictor.cpp
+  LINK_LIBRARIES
+    mola::mola_state_estimation_smoother
+)
+
+mola_add_test(
+  TARGET  test-keyframe-decimation
+  SOURCES test-keyframe-decimation.cpp
+  LINK_LIBRARIES
+    mola::mola_state_estimation_smoother
+)
+
+mola_add_test(
+  TARGET  test-out-of-order-keyframes
+  SOURCES test-out-of-order-keyframes.cpp
+  LINK_LIBRARIES
+    mola::mola_state_estimation_smoother
+)
+

--- a/mola_state_estimation_smoother/tests/test-fast-predictor.cpp
+++ b/mola_state_estimation_smoother/tests/test-fast-predictor.cpp
@@ -1,0 +1,223 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   test-fast-predictor.cpp
+ * @brief  Unit tests for the async-mode FastPredictor (tiny re-anchored graph).
+ * @author Jose Luis Blanco Claraco
+ * @date   Jun 22, 2026
+ */
+
+#include <mrpt/core/exceptions.h>
+#include <mrpt/obs/CObservationOdometry.h>
+#include <mrpt/poses/CPose2D.h>
+#include <mrpt/poses/CPose3D.h>
+
+#include <cmath>
+#include <iostream>
+#include <utility>
+#include <vector>
+
+#include "../src/FastPredictor.h"  // internal header (linked from the package lib)
+
+using namespace mola::state_estimation_smoother;
+using mola::NavState;
+
+namespace
+{
+mrpt::math::CMatrixDouble66 scaledIdentity66(double s)
+{
+    mrpt::math::CMatrixDouble66 m;
+    m.setZero();
+    for (int i = 0; i < 6; i++)
+    {
+        m(i, i) = s;
+    }
+    return m;
+}
+
+// Builds a tight-covariance anchor NavState at the given pose + twist.
+NavState makeAnchor(const mrpt::poses::CPose3D& pose, const mrpt::math::TTwist3D& twist)
+{
+    NavState ns;
+    ns.pose.mean     = pose;
+    ns.pose.cov_inv  = scaledIdentity66(1e4);  // sigma ~0.01 m/rad
+    ns.twist         = twist;
+    ns.twist_inv_cov = scaledIdentity66(1e2);  // sigma ~0.1 m/s
+    return ns;
+}
+
+mrpt::obs::CObservationOdometry::Ptr makeOdom(double t, double x, double y, double phi)
+{
+    auto o       = mrpt::obs::CObservationOdometry::Create();
+    o->timestamp = mrpt::Clock::fromDouble(t);
+    o->odometry  = mrpt::poses::CPose2D(x, y, phi);
+    return o;
+}
+
+Parameters defaultParams()
+{
+    Parameters p;
+    p.reference_frame_name = "map";
+    p.kinematic_model      = KinematicModel::ConstantVelocity;
+    // defaults are fine for the rest (max_time_to_use_velocity_model=2.0, etc.)
+    return p;
+}
+
+// 1) No anchor -> nullopt.
+void test_no_anchor()
+{
+    FastPredictor fp;
+    const auto    params = defaultParams();
+    ASSERT_(!fp.has_anchor());
+    const auto r = fp.predict(mrpt::Clock::fromDouble(10.0), params);
+    ASSERT_(!r.has_value());
+}
+
+// 2) Pure constant-velocity extrapolation from the anchor.
+void test_const_vel_extrapolation()
+{
+    FastPredictor fp;
+    const auto    params = defaultParams();
+
+    const double t0 = 1000.0;
+    const double v  = 2.0;  // m/s along +x
+    fp.set_anchor(
+        makeAnchor(mrpt::poses::CPose3D::Identity(), mrpt::math::TTwist3D(v, 0, 0, 0, 0, 0)),
+        mrpt::Clock::fromDouble(t0), {});
+
+    const double dt = 0.1;
+    const auto   r  = fp.predict(mrpt::Clock::fromDouble(t0 + dt), params);
+    ASSERT_(r.has_value());
+
+    const double expected_x = v * dt;  // 0.2 m
+    std::cout << "[const-vel] predicted x=" << r->pose.mean.x() << " expected~" << expected_x
+              << "\n";
+    ASSERT_LT_(std::abs(r->pose.mean.x() - expected_x), 0.05);
+    ASSERT_LT_(std::abs(r->pose.mean.y()), 0.02);
+    // velocity should be preserved:
+    ASSERT_LT_(std::abs(r->twist.vx - v), 0.1);
+}
+
+// 3) Query too far in the future -> nullopt.
+void test_too_far()
+{
+    FastPredictor fp;
+    const auto    params = defaultParams();  // max_time_to_use_velocity_model=2.0
+
+    const double t0 = 0.0;
+    fp.set_anchor(
+        makeAnchor(mrpt::poses::CPose3D::Identity(), mrpt::math::TTwist3D(1, 0, 0, 0, 0, 0)),
+        mrpt::Clock::fromDouble(t0), {});
+
+    const auto r = fp.predict(mrpt::Clock::fromDouble(t0 + 5.0), params);
+    ASSERT_(!r.has_value());
+}
+
+// 4) Backward (in the past) query is still valid within the window.
+void test_backward_query()
+{
+    FastPredictor fp;
+    const auto    params = defaultParams();
+
+    const double t0 = 500.0;
+    const double v  = 2.0;
+    fp.set_anchor(
+        makeAnchor(mrpt::poses::CPose3D::Identity(), mrpt::math::TTwist3D(v, 0, 0, 0, 0, 0)),
+        mrpt::Clock::fromDouble(t0), {});
+
+    const auto r = fp.predict(mrpt::Clock::fromDouble(t0 - 0.1), params);
+    ASSERT_(r.has_value());
+    std::cout << "[backward] predicted x=" << r->pose.mean.x() << " expected~-0.2\n";
+    ASSERT_LT_(std::abs(r->pose.mean.x() - (-0.2)), 0.05);
+}
+
+// 5) Buffered wheel-odometry pulls the prediction even when the anchor twist is zero.
+void test_odom_influence()
+{
+    FastPredictor fp;
+    const auto    params = defaultParams();
+
+    const double t0 = 10.0;
+    fp.set_anchor(
+        makeAnchor(mrpt::poses::CPose3D::Identity(), mrpt::math::TTwist3D(0, 0, 0, 0, 0, 0)),
+        mrpt::Clock::fromDouble(t0), {});
+
+    // 0.3 m forward over 0.1 s:
+    fp.push_observation(makeOdom(t0, 0.0, 0.0, 0.0), /*bufferLength*/ 1.0);
+    fp.push_observation(makeOdom(t0 + 0.1, 0.3, 0.0, 0.0), 1.0);
+
+    const auto r = fp.predict(mrpt::Clock::fromDouble(t0 + 0.1), params);
+    ASSERT_(r.has_value());
+    std::cout << "[odom] anchor twist=0, predicted x=" << r->pose.mean.x()
+              << " (odom increment=0.3)\n";
+    // Odometry must pull the prediction forward (well away from the zero-twist
+    // const-vel result of ~0):
+    ASSERT_GT_(r->pose.mean.x(), 0.1);
+}
+
+// 6) Cached frame_transform getter.
+void test_frame_transform()
+{
+    FastPredictor                  fp;
+    FastPredictor::FrameTransforms tf;
+    tf["odom"] = mrpt::poses::CPose3DPDFGaussian(
+        mrpt::poses::CPose3D(1.0, 2.0, 0.0, 0.0, 0.0, 0.0), scaledIdentity66(1e-4));
+
+    fp.set_anchor(
+        makeAnchor(mrpt::poses::CPose3D::Identity(), mrpt::math::TTwist3D()),
+        mrpt::Clock::fromDouble(0.0), tf);
+
+    ASSERT_(fp.frame_transform("odom").has_value());
+    ASSERT_LT_(std::abs(fp.frame_transform("odom")->mean.x() - 1.0), 1e-9);
+    ASSERT_(!fp.frame_transform("nonexistent").has_value());
+
+    // clear() drops the anchor + transforms:
+    fp.clear();
+    ASSERT_(!fp.has_anchor());
+    ASSERT_(!fp.frame_transform("odom").has_value());
+}
+
+}  // namespace
+
+int main()
+{
+    int                                                   numErrors = 0;
+    const std::vector<std::pair<const char*, void (*)()>> tests     = {
+            {"no_anchor", &test_no_anchor},
+            {"const_vel_extrapolation", &test_const_vel_extrapolation},
+            {"too_far", &test_too_far},
+            {"backward_query", &test_backward_query},
+            {"odom_influence", &test_odom_influence},
+            {"frame_transform", &test_frame_transform},
+    };
+
+    for (const auto& [name, fn] : tests)
+    {
+        try
+        {
+            fn();
+            std::cout << "✅ " << name << "\n";
+        }
+        catch (const std::exception& e)
+        {
+            std::cerr << "❌ " << name << ": " << e.what() << "\n";
+            numErrors++;
+        }
+    }
+
+    std::cout << "\nRESULT: " << (tests.size() - numErrors) << " passed, " << numErrors
+              << " failed.\n";
+    return numErrors == 0 ? 0 : 1;
+}

--- a/mola_state_estimation_smoother/tests/test-keyframe-decimation.cpp
+++ b/mola_state_estimation_smoother/tests/test-keyframe-decimation.cpp
@@ -1,0 +1,327 @@
+/* _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   test-keyframe-decimation.cpp
+ * @brief  Unit tests for high-rate same-sensor keyframe decimation/merging
+ *         (Parameters::odometry_min_sample_period / imu_min_sample_period).
+ * @author Jose Luis Blanco Claraco
+ * @date   Jun 23, 2026
+ */
+
+#include <mola_state_estimation_smoother/StateEstimationSmoother.h>
+#include <mrpt/core/get_env.h>
+#include <mrpt/obs/CObservationIMU.h>
+#include <mrpt/obs/CObservationOdometry.h>
+#include <mrpt/poses/CPose3D.h>
+#include <mrpt/poses/Lie/SE.h>
+
+#include <iostream>
+
+using namespace std::string_literals;
+using namespace mrpt::literals;
+
+namespace
+{
+const bool VERBOSE = mrpt::get_env<bool>("VERBOSE", false);
+
+// A wide enough sliding window so nothing is marginalized out during these
+// short (~1 s) runs: keyframe counts then equal the total ever created.
+const char* baseParams =
+    R"###(
+params:
+    vehicle_frame_name: "base_link"
+    reference_frame_name: "map"
+
+    # Pin the "odom" frame to the "map" origin so a single odometry source fully
+    # determines the absolute pose (otherwise "odom" floats freely).
+    link_first_pose_to_reference_origin_sigma: 1e-6
+
+    kinematic_model: KinematicModel::ConstantVelocity
+    sliding_window_length: 30.0
+    min_time_difference_to_create_new_frame: 0.01
+    max_time_to_use_velocity_model: 2.0
+
+    sigma_random_walk_acceleration_linear: 2.0
+    sigma_random_walk_acceleration_angular: 1.0
+    sigma_integrator_position: 0.10
+    sigma_integrator_orientation: 0.10
+
+    estimate_geo_reference: false
+)###";
+
+std::unique_ptr<mola::state_estimation_smoother::StateEstimationSmoother> makeEstimator(
+    const std::string& extraParams)
+{
+    auto est = std::make_unique<mola::state_estimation_smoother::StateEstimationSmoother>();
+    if (VERBOSE)
+    {
+        est->setMinLoggingLevel(mrpt::system::LVL_DEBUG);
+    }
+    est->initialize(mrpt::containers::yaml::FromText(baseParams + extraParams));
+    return est;
+}
+
+// Feeds a constant-velocity wheel-odometry trajectory (straight line + yaw rate)
+// at the requested rate, then returns the final fused pose. The number of
+// readings and the trajectory are identical regardless of decimation, so the two
+// runs are directly comparable.
+struct OdomRunResult
+{
+    mrpt::poses::CPose3D estimatedFinalPose;
+    mrpt::poses::CPose2D groundTruthFinalOdom;
+    std::size_t          keyframeCount = 0;
+};
+
+OdomRunResult runOdometry(
+    mola::state_estimation_smoother::StateEstimationSmoother& est, double samplePeriod,
+    size_t numReadings, double vx, double wz)
+{
+    mrpt::poses::CPose2D odom;  // accumulated ground-truth odometry pose
+    mrpt::Clock::time_point lastStamp;
+
+    for (size_t i = 0; i < numReadings; i++)
+    {
+        const double t     = samplePeriod * static_cast<double>(i);
+        const auto   stamp = mrpt::Clock::fromDouble(t);
+
+        if (i > 0)
+        {
+            // Constant-velocity increment in the local frame:
+            const auto delta = mrpt::poses::CPose2D(vx * samplePeriod, 0.0, wz * samplePeriod);
+            odom             = odom + delta;
+        }
+
+        mrpt::obs::CObservationOdometry obs;
+        obs.timestamp   = stamp;
+        obs.sensorLabel = "wheel_odom";
+        obs.odometry    = odom;
+        est.fuse_odometry(obs, obs.sensorLabel);
+
+        lastStamp = stamp;
+    }
+
+    OdomRunResult r;
+    r.groundTruthFinalOdom = odom;
+
+    const auto stateOpt = est.estimated_navstate(lastStamp, est.parameters().reference_frame_name);
+    ASSERT_(stateOpt.has_value());
+    r.estimatedFinalPose = stateOpt->pose.mean;
+    r.keyframeCount      = est.active_keyframe_count();
+    return r;
+}
+
+// --------------------------------------------------------------------------
+// Test 1: odometry decimation drastically reduces the keyframe count while
+//         keeping the estimated trajectory faithful to the input odometry.
+//         A *straight* constant-velocity path is used so the constant-velocity
+//         kinematic prior is exact (no "corner cutting"): this isolates the
+//         correctness of the increment *merging* (dropped readings must be
+//         accumulated, not lost) from the inherent accuracy/cost tradeoff of
+//         using fewer keyframes on a curved path.
+// --------------------------------------------------------------------------
+void test_odometry_decimation_reduces_keyframes_and_preserves_pose()
+{
+    constexpr size_t N      = 101;  // 100 increments
+    constexpr double RATE_S = 0.02;  // 50 Hz over 2.0 s
+    constexpr double VX     = 1.0;  // m/s
+    constexpr double WZ     = 0.0;  // straight line
+
+    // Full-rate reference run:
+    auto estFull = makeEstimator("");  // odometry_min_sample_period defaults to 0
+    auto resFull = runOdometry(*estFull, RATE_S, N, VX, WZ);
+
+    // Decimated run: keep ~1 every 5 readings (10 Hz):
+    auto estDecim = makeEstimator("    odometry_min_sample_period: 0.10\n");
+    auto resDecim = runOdometry(*estDecim, RATE_S, N, VX, WZ);
+
+    std::cout << "[odom] full keyframes=" << resFull.keyframeCount
+              << " decimated keyframes=" << resDecim.keyframeCount << "\n";
+    std::cout << "[odom] GT final odom:  " << resDecim.groundTruthFinalOdom.asString() << "\n";
+    std::cout << "[odom] full  est pose: " << resFull.estimatedFinalPose.asString() << "\n";
+    std::cout << "[odom] decim est pose: " << resDecim.estimatedFinalPose.asString() << "\n";
+
+    // Full rate: each reading (after the first) makes its own keyframe.
+    ASSERT_EQUAL_(resFull.keyframeCount, N - 1);
+
+    // Decimation must cut the keyframe count by roughly the decimation factor (5x).
+    ASSERT_LT_(resDecim.keyframeCount, resFull.keyframeCount / 3);
+    ASSERT_GT_(resDecim.keyframeCount, static_cast<std::size_t>(5));
+
+    // Merging must preserve the accumulated motion: the estimated forward
+    // displacement stays within a few % of the input odometry. (A bug that
+    // advanced the anchor on a dropped reading would lose ~80% of it.) Note that
+    // decimation does cost some accuracy vs. full rate, because each merged
+    // absolute constraint spans a longer interval and so gets a looser
+    // motion-model covariance, and fewer keyframes give the velocity estimate
+    // less time to converge from its initial prior. That tradeoff is the whole
+    // point; we only assert it stays small and bounded here.
+    const auto   gt = mrpt::poses::CPose3D(resDecim.groundTruthFinalOdom);
+    const double errDecim = mrpt::poses::Lie::SE<3>::log(resDecim.estimatedFinalPose - gt).norm();
+    const double errFull  = mrpt::poses::Lie::SE<3>::log(resFull.estimatedFinalPose - gt).norm();
+
+    std::cout << "[odom] err full=" << errFull << " err decim=" << errDecim << "\n";
+
+    ASSERT_GT_(resDecim.estimatedFinalPose.x(), 0.9 * gt.x());  // >=90% displacement retained
+    ASSERT_LT_(errDecim, 0.2);  // bounded, not catastrophic
+}
+
+// --------------------------------------------------------------------------
+// Test 1b: on a *turning* path, merging must still preserve the total traveled
+//          displacement (the accumulation is correct in SE(2), not just along a
+//          straight axis). We deliberately do NOT assert a tight pose match here
+//          because using fewer keyframes legitimately "cuts the corner" of a
+//          curved trajectory with the constant-velocity prior; we only require
+//          that the bulk of the motion is retained (an anchor-advance merge bug
+//          would lose most of it).
+// --------------------------------------------------------------------------
+void test_odometry_merge_preserves_displacement_on_turn()
+{
+    constexpr size_t N      = 101;
+    constexpr double RATE_S = 0.02;
+    constexpr double VX     = 1.0;
+    constexpr double WZ     = 0.15;  // rad/s -> noticeable curve
+
+    auto est = makeEstimator("    odometry_min_sample_period: 0.10\n");
+    auto res = runOdometry(*est, RATE_S, N, VX, WZ);
+
+    const double gtDist  = res.groundTruthFinalOdom.norm();  // |(x,y)| of final odom
+    const double estDist = std::hypot(res.estimatedFinalPose.x(), res.estimatedFinalPose.y());
+
+    std::cout << "[odom-turn] GT dist=" << gtDist << " est dist=" << estDist
+              << " keyframes=" << res.keyframeCount << "\n";
+
+    // Retain the great majority of the displacement (corner-cutting plus the
+    // looser merged covariance remove only a few %); this fails hard if merged
+    // increments are dropped.
+    ASSERT_GT_(estDist, 0.85 * gtDist);
+    ASSERT_LT_(estDist, 1.05 * gtDist);
+}
+
+// --------------------------------------------------------------------------
+// Test 2: with decimation disabled (default 0), the keyframe count is exactly
+//         the full-rate count (regression guard for back-compat).
+// --------------------------------------------------------------------------
+void test_decimation_disabled_is_backward_compatible()
+{
+    constexpr size_t N      = 51;
+    constexpr double RATE_S = 0.02;
+
+    auto est = makeEstimator("    odometry_min_sample_period: 0.0\n");
+    auto res = runOdometry(*est, RATE_S, N, 1.0, 0.0);
+
+    std::cout << "[default] keyframes=" << res.keyframeCount << " (expected " << (N - 1) << ")\n";
+    ASSERT_EQUAL_(res.keyframeCount, N - 1);
+}
+
+// --------------------------------------------------------------------------
+// Test 3: IMU decimation reduces the number of (redundant) attitude/gravity
+//         factors while still leveling the estimate (pitch/roll ~ 0).
+// --------------------------------------------------------------------------
+std::size_t runImuLeveling(double imuSamplePeriod, double& finalPitch, double& finalRoll)
+{
+    // Two streams: LiDAR pose at 10 Hz (drives keyframes) + IMU at 100 Hz.
+    auto est = makeEstimator(
+        "    imu_nearby_keyframe_stamp_tolerance: 0.10\n"
+        "    imu_min_sample_period: "s +
+        std::to_string(imuSamplePeriod) + "\n");
+
+    constexpr double IMU_T = 0.01;  // 100 Hz; LiDAR pose added every 10th step (10 Hz)
+    constexpr size_t STEPS   = 200;  // 2.0 s
+
+    mrpt::poses::CPose3D     odom;
+    mrpt::Clock::time_point  lastStamp;
+
+    for (size_t i = 0; i < STEPS; i++)
+    {
+        const double t     = IMU_T * static_cast<double>(i);
+        const auto   stamp = mrpt::Clock::fromDouble(t);
+        lastStamp          = stamp;
+
+        // IMU every step (100 Hz): flat robot, gravity straight down.
+        mrpt::obs::CObservationIMU imu;
+        imu.timestamp   = stamp;
+        imu.sensorLabel = "imu";
+        imu.set(mrpt::obs::IMU_X_ACC, 0.0);
+        imu.set(mrpt::obs::IMU_Y_ACC, 0.0);
+        imu.set(mrpt::obs::IMU_Z_ACC, 9.81);
+        est->fuse_imu(imu);
+
+        // LiDAR pose every 10th step (10 Hz):
+        if ((i % 10) == 0)
+        {
+            odom = odom + mrpt::poses::CPose3D(0.1, 0, 0, 0, 0, 0);  // 1 m/s in x
+            mrpt::poses::CPose3DPDFGaussian pdf;
+            pdf.mean = odom;
+            pdf.cov.setIdentity();
+            pdf.cov *= 1e-3;
+            est->fuse_pose(stamp, pdf, "lidar");
+        }
+    }
+
+    const auto stateOpt = est->estimated_navstate(lastStamp, "map");
+    ASSERT_(stateOpt.has_value());
+    double yaw = 0;
+    stateOpt->pose.mean.getYawPitchRoll(yaw, finalPitch, finalRoll);
+
+    return est->active_factor_count();
+}
+
+void test_imu_decimation_reduces_factors_and_keeps_leveling()
+{
+    double pitchFull = 0;
+    double rollFull  = 0;
+    const std::size_t factorsFull = runImuLeveling(0.0, pitchFull, rollFull);
+
+    double pitchDecim = 0;
+    double rollDecim  = 0;
+    // 0.1 s => at most one IMU factor per 0.1 s window (matches the nearby
+    // tolerance), instead of ~10 redundant ones.
+    const std::size_t factorsDecim = runImuLeveling(0.10, pitchDecim, rollDecim);
+
+    std::cout << "[imu] full factors=" << factorsFull << " decimated factors=" << factorsDecim
+              << "\n";
+    std::cout << "[imu] full  pitch=" << mrpt::RAD2DEG(pitchFull)
+              << " roll=" << mrpt::RAD2DEG(rollFull) << " deg\n";
+    std::cout << "[imu] decim pitch=" << mrpt::RAD2DEG(pitchDecim)
+              << " roll=" << mrpt::RAD2DEG(rollDecim) << " deg\n";
+
+    // Decimation must cut the (committed) factor count appreciably.
+    ASSERT_LT_(factorsDecim, factorsFull);
+
+    // Leveling must still hold in both cases.
+    ASSERT_NEAR_(pitchDecim, 0.0, mrpt::DEG2RAD(2.0));
+    ASSERT_NEAR_(rollDecim, 0.0, mrpt::DEG2RAD(2.0));
+}
+
+}  // namespace
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+    try
+    {
+        test_odometry_decimation_reduces_keyframes_and_preserves_pose();
+        test_odometry_merge_preserves_displacement_on_turn();
+        test_decimation_disabled_is_backward_compatible();
+        test_imu_decimation_reduces_factors_and_keeps_leveling();
+
+        std::cout << "✅ SUCCESS\n";
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "❌ FAILED: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/mola_state_estimation_smoother/tests/test-out-of-order-keyframes.cpp
+++ b/mola_state_estimation_smoother/tests/test-out-of-order-keyframes.cpp
@@ -1,0 +1,161 @@
+/* _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   test-out-of-order-keyframes.cpp
+ * @brief  Unit tests for the out-of-order keyframe guard: late (out-of-timestamp
+ *         order) measurements must snap to the nearest existing keyframe instead
+ *         of inserting a new one "in the past", so iSAM2's fixed-lag
+ *         marginalization never corrupts.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jun 23, 2026
+ */
+
+#include <mola_state_estimation_smoother/StateEstimationSmoother.h>
+#include <mrpt/core/get_env.h>
+#include <mrpt/poses/CPose3D.h>
+
+#include <iostream>
+#include <memory>
+
+using namespace std::string_literals;
+
+namespace
+{
+const bool VERBOSE = mrpt::get_env<bool>("VERBOSE", false);
+
+std::unique_ptr<mola::state_estimation_smoother::StateEstimationSmoother> makeEstimator(
+    double slidingWindow)
+{
+    const std::string params =
+        R"###(
+params:
+    vehicle_frame_name: "base_link"
+    reference_frame_name: "map"
+    link_first_pose_to_reference_origin_sigma: 1e-6
+    kinematic_model: KinematicModel::ConstantVelocity
+    min_time_difference_to_create_new_frame: 0.01
+    max_time_to_use_velocity_model: 2.0
+    sigma_random_walk_acceleration_linear: 2.0
+    sigma_random_walk_acceleration_angular: 1.0
+    sigma_integrator_position: 0.10
+    sigma_integrator_orientation: 0.10
+    estimate_geo_reference: false
+    sliding_window_length: )###" +
+        std::to_string(slidingWindow) + "\n";
+
+    auto est = std::make_unique<mola::state_estimation_smoother::StateEstimationSmoother>();
+    if (VERBOSE)
+    {
+        est->setMinLoggingLevel(mrpt::system::LVL_DEBUG);
+    }
+    est->initialize(mrpt::containers::yaml::FromText(params));
+    return est;
+}
+
+// Absolute "map"-frame pose observation at time t along a straight line (x = t).
+mrpt::poses::CPose3DPDFGaussian poseAt(double t)
+{
+    mrpt::poses::CPose3DPDFGaussian p;
+    p.mean = mrpt::poses::CPose3D(t * 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    p.cov.setIdentity();
+    p.cov *= 1e-3;
+    return p;
+}
+
+// --------------------------------------------------------------------------
+// Test 1: an out-of-order pose snaps to an existing keyframe instead of creating
+//         a new one in the past (observable via the keyframe count).
+// --------------------------------------------------------------------------
+void test_out_of_order_pose_snaps_no_new_keyframe()
+{
+    auto est = makeEstimator(30.0);
+
+    // Build an in-order chain of keyframes at t = 0.0 .. 1.0 (0.1 spacing).
+    for (int i = 0; i <= 10; i++)
+    {
+        est->fuse_pose(mrpt::Clock::fromDouble(0.1 * i), poseAt(0.1 * i), "map");
+    }
+    const std::size_t kfBefore = est->active_keyframe_count();
+    std::cout << "[snap] keyframes after in-order chain=" << kfBefore << "\n";
+    ASSERT_GT_(kfBefore, static_cast<std::size_t>(5));
+
+    // A late pose for t=0.55 arrives now (out of order: 0.45 s behind the newest
+    // keyframe at t=1.0, and >min_time_difference from any existing one). The
+    // guard must snap it to the nearest existing keyframe, NOT create a new one.
+    est->fuse_pose(mrpt::Clock::fromDouble(0.55), poseAt(0.55), "map");
+
+    const std::size_t kfAfter = est->active_keyframe_count();
+    std::cout << "[snap] keyframes after out-of-order pose=" << kfAfter << "\n";
+    ASSERT_EQUAL_(kfAfter, kfBefore);  // no new (past) keyframe was inserted
+}
+
+// --------------------------------------------------------------------------
+// Test 2: a stream with persistent out-of-order arrivals crossing the
+//         marginalization horizon does not throw (this is the exact failure mode
+//         that crashed iSAM2 before the guard).
+// --------------------------------------------------------------------------
+void test_out_of_order_with_marginalization_does_not_throw()
+{
+    auto est = makeEstimator(2.0);  // short window -> marginalization is exercised
+
+    // Advance well past the window so old keyframes are marginalized out, while
+    // continuously injecting "late" poses ~0.3 s in the past (mimics a lagged
+    // LiDAR front-end fused on top of high-rate keyframes).
+    for (int i = 0; i <= 200; i++)
+    {
+        const double t = 0.05 * i;  // 20 Hz "high-rate" stream, t = 0 .. 10 s
+        est->fuse_pose(mrpt::Clock::fromDouble(t), poseAt(t), "map");
+
+        // Every few steps, inject a late pose 0.3 s behind:
+        if (i >= 10 && (i % 3) == 0)
+        {
+            const double tLate = t - 0.3;
+            est->fuse_pose(mrpt::Clock::fromDouble(tLate), poseAt(tLate), "map");
+        }
+
+        // Force smoother updates (and thus marginalization) along the way:
+        if ((i % 5) == 0)
+        {
+            const auto st = est->estimated_navstate(mrpt::Clock::fromDouble(t), "map");
+            ASSERT_(st.has_value());
+        }
+    }
+
+    // Final query must still succeed and track the straight line (x = t).
+    const double last_t = 0.05 * 200;
+    const auto   st     = est->estimated_navstate(mrpt::Clock::fromDouble(last_t), "map");
+    ASSERT_(st.has_value());
+    std::cout << "[marg] final est x=" << st->pose.mean.x() << " (expected ~" << last_t << ")\n";
+    ASSERT_NEAR_(st->pose.mean.x(), last_t, 0.2);
+}
+
+}  // namespace
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+    try
+    {
+        test_out_of_order_pose_snaps_no_new_keyframe();
+        test_out_of_order_with_marginalization_does_not_throw();
+
+        std::cout << "✅ SUCCESS\n";
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "❌ FAILED: " << e.what() << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

Makes `mola_state_estimation_smoother` usable in **real time** for multi-sensor fusion (LiDAR odometry + wheel odom + IMU + GNSS), in two layers:

1. **Batch fixed-lag smoother** (commits `2796a91`, `0b9120d`): swap `gtsam::IncrementalFixedLagSmoother` → `gtsam::BatchFixedLagSmoother` to fix the out-of-order variable-introduction crash caused by multi-rate sensor latency (the CPU-bound LiDAR front-end inserts keyframes "in the past", which corrupts iSAM2's incremental marginalization). The batch smoother re-eliminates the whole window each update, handling out-of-order factors correctly. Marginals are computed via `gtsam::Marginals` (batch smoother does not implement `marginalCovariance()`), cached across the update cycle.

2. **Async backend + fast predictor** (this PR's new work): an opt-in `async_backend` mode (default `false`) that moves the heavy batch solve to a dedicated backend thread, while `estimated_navstate()` is served by a lightweight `FastPredictor` — a tiny GTSAM graph re-anchored on the latest backend solution and propagated with constant-velocity kinematics plus the wheel odometry buffered since that anchor.

## Why

The batch smoother is correct but, run synchronously inside `estimated_navstate()` on the LiDAR thread, the full solve (~90–120 ms) exceeds the LiDAR period at realistic keyframe density, so the queue backs up. The async layer keeps per-query latency sub-millisecond so the estimate stays timely; the accuracy still comes from the backend's full optimization, just refreshed asynchronously.

## What changed (async layer)

- New `FastPredictor` (`src/FastPredictor.{h,cpp}`), own mutex (separate from `stateMutex_`) so fast queries never block on the backend batch solve. Caches odometry-frame transforms + the latest observation stamp, so both `estimated_navstate()` and `spinOnce()` are lock-free in async mode.
- Shared kinematic/twist factor construction + GTSAM symbol scheme extracted to `src/factor_builders.h`, used by both the backend and the predictor (`addFactor()`/`fuse_twist()` now call these).
- `spinOnce()` draws a moving XYZ corner (`smoother_pose_corner`) in the visualizer per published pose; runs when there is a subscriber **or** a visualizer.
- New params `async_backend`, `fast_predictor_buffer_length`.
- Default synchronous path is unchanged (deterministic offline runs).

## Tests

- New `tests/test-fast-predictor.cpp` (6 cases: no-anchor, const-vel extrapolation, too-far→nullopt, backward query, wheel-odom influence, frame-transform cache) — all pass.
- All existing `test-navstate-*` pass unchanged. Note: `test-navstate-odom-gnss-fusion` is pre-existing-flaky on the batch smoother (geo-ref convergence near a 5° tolerance, ~40/70 randomized reps); verified by stash-and-rebuild that this PR's changes do **not** affect it.

## Notes / follow-ups

- Real-time live use at very high keyframe density may still need keyframe-density / window tuning for the backend itself; the async layer is what makes online use viable.
- The "wedge-forever after a GTSAM throw" recovery path (catch block) is moot on the batch smoother here but still worth hardening separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time asynchronous backend mode for state estimation with low-latency `estimated_navstate()` via a fast predictor.
  * Added configurable buffering for high-rate odometry plus out-of-sequence observation reordering (`reorder_buffer_horizon`).
  * Added high-rate sensor decimation controls (`odometry_min_sample_period`, `imu_min_sample_period`) and new diagnostics: `active_keyframe_count()` / `active_factor_count()`.

* **Documentation**
  * Expanded implementation and configuration guidance for real-time mode, reordering, and decimation behaviors.

* **Tests**
  * Added unit tests for the fast predictor, keyframe decimation, and the reorder buffer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->