### PR TITLE
Add MapGravityFactor: unary gravity-leveling in a z-up map frame

### DIFF
--- a/mola_gtsam_factors/CMakeLists.txt
+++ b/mola_gtsam_factors/CMakeLists.txt
@@ -51,6 +51,7 @@ mola_add_library(
     include/mola_gtsam_factors/FactorTricycleKinematic.h
     include/mola_gtsam_factors/gtsam_detect_version.h
     include/mola_gtsam_factors/id.h
+    include/mola_gtsam_factors/MapGravityFactor.h
     include/mola_gtsam_factors/MeasuredGravityFactor.h
     include/mola_gtsam_factors/Pose3RotationFactor.h
     src/FactorAngularVelocityIntegration.cpp
@@ -59,6 +60,7 @@ mola_add_library(
     src/FactorGnssMapEnu.cpp
     src/FactorTrapezoidalIntegrator.cpp
     src/FactorTricycleKinematic.cpp
+    src/MapGravityFactor.cpp
     src/MeasuredGravityFactor.cpp
     src/Pose3RotationFactor.cpp
     src/register.cpp

--- a/mola_gtsam_factors/include/mola_gtsam_factors/MapGravityFactor.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/MapGravityFactor.h
@@ -1,0 +1,98 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   MapGravityFactor.h
+ * @brief  Unary GTSAM factor for IMU gravity-leveling in a z-up map frame
+ * @author Jose Luis Blanco Claraco
+ * @date   Jun 30, 2026
+ */
+
+#pragma once
+
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/nonlinear/ExpressionFactor.h>
+#include <gtsam/nonlinear/expressions.h>
+#include <gtsam/slam/expressions.h>
+#include <mola_gtsam_factors/gtsam_detect_version.h>
+
+namespace mola::factors
+{
+/**
+ * Unary GTSAM factor for IMU observations of gravity-aligned orientation,
+ * imposing leveling directly in the (assumed gravity-aligned, z-up) map frame.
+ *
+ * Unlike MeasuredGravityFactor, this factor does NOT depend on the
+ * enu-to-map geo-reference node: it asserts that the measured up-vector,
+ * carried from the body frame into the MAP frame through Pi, points along the
+ * map +Z axis. This requires the map frame to be defined gravity-aligned
+ * (z-up). It is the right tool when vertical (gravity) and horizontal
+ * (azimuth/geo-reference) are decoupled, so gravity-leveling works even with
+ * geo-referencing/GNSS disabled.
+ *
+ */
+class MapGravityFactor : public gtsam::ExpressionFactorN<
+                             gtsam::Vector3 /*return type*/, gtsam::Pose3 /*Pi*/
+                             >
+{
+   private:
+    using This = MapGravityFactor;
+    using Base = gtsam::ExpressionFactorN<gtsam::Vector3 /*return type*/, gtsam::Pose3 /*Pi*/>;
+
+    gtsam::Pose3  sensorPoseOnVehicle_ = gtsam::Pose3::Identity();
+    gtsam::Point3 observedNormalizedAcc_b_;
+
+   public:
+    /// default constructor
+    MapGravityFactor();
+
+    MapGravityFactor(
+        gtsam::Key kPi, const gtsam::Pose3& sensorPoseOnVehicle,
+        const gtsam::Vector3& observedNormalizedAcc_b, const gtsam::SharedNoiseModel& model);
+
+    /// @return a deep copy of this factor
+    gtsam::NonlinearFactor::shared_ptr clone() const override;
+
+    // Return measurement expression
+    gtsam::Expression<gtsam::Point3> expression(
+        const std::array<gtsam::Key, NARY_EXPRESSION_SIZE>& keys) const override;
+
+    /** implement functions needed for Testable */
+
+    /** print */
+    void print(
+        const std::string&         s,
+        const gtsam::KeyFormatter& keyFormatter = gtsam::DefaultKeyFormatter) const override;
+
+    /** equals */
+    bool equals(const gtsam::NonlinearFactor& expected, double tol = 1e-9) const override;
+
+   private:
+#if GTSAM_USES_BOOST
+    /** Serialization function */
+    friend class boost::serialization::access;
+    template <class ARCHIVE>
+    void serialize(ARCHIVE& ar, const unsigned int /*version*/)
+    {
+        // **IMPORTANT** We need to deserialize parameters before the base
+        // class, since it calls expression() and we need all parameters ready
+        // at that point.
+        ar& BOOST_SERIALIZATION_NVP(measured_);
+        ar& boost::serialization::make_nvp(
+            "MapGravityFactor", boost::serialization::base_object<Base>(*this));
+    }
+#endif
+};
+
+}  // namespace mola::factors

--- a/mola_gtsam_factors/src/MapGravityFactor.cpp
+++ b/mola_gtsam_factors/src/MapGravityFactor.cpp
@@ -1,0 +1,74 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   MapGravityFactor.cpp
+ * @brief  Unary GTSAM factor for IMU gravity-leveling in a z-up map frame.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jun 30, 2026
+ */
+
+#include <mola_gtsam_factors/MapGravityFactor.h>
+
+namespace mola::factors
+{
+
+MapGravityFactor::MapGravityFactor() = default;
+
+MapGravityFactor::MapGravityFactor(
+    gtsam::Key kPi, const gtsam::Pose3& sensorPoseOnVehicle,
+    const gtsam::Vector3& observedNormalizedAcc_b, const gtsam::SharedNoiseModel& model)
+    : Base({kPi}, model, /* error */ {.0, .0, 1.}),
+      sensorPoseOnVehicle_(sensorPoseOnVehicle),
+      observedNormalizedAcc_b_(observedNormalizedAcc_b)
+{
+    this->initialize(This::expression({kPi}));
+}
+
+gtsam::NonlinearFactor::shared_ptr MapGravityFactor::clone() const
+{
+#if GTSAM_USES_BOOST
+    return boost::static_pointer_cast<This>(gtsam::NonlinearFactor::shared_ptr(new This(*this)));
+#else
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(std::make_shared<This>(*this));
+#endif
+}
+
+gtsam::Expression<gtsam::Point3> MapGravityFactor::expression(
+    const std::array<gtsam::Key, NARY_EXPRESSION_SIZE>& keys) const
+{
+    const gtsam::Expression<gtsam::Pose3> Pi_(keys[0]);
+    const gtsam::Expression<gtsam::Pose3> p(sensorPoseOnVehicle_);
+
+    const gtsam::Expression<gtsam::Point3> measuredUp(observedNormalizedAcc_b_);
+
+    // Carry the measured body up-vector into the (z-up) map frame; it must
+    // point along map +Z. No geo-reference node involved.
+    return {gtsam::rotate(gtsam::rotation(gtsam::compose(Pi_, p)), measuredUp)};
+}
+
+void MapGravityFactor::print(const std::string& s, const gtsam::KeyFormatter& keyFormatter) const
+{
+    std::cout << s << "MapGravityFactor(" << keyFormatter(Factor::keys_[0]) << ")\n";
+    gtsam::traits<gtsam::Point3>::Print(measured_, "  measured: ");
+    this->noiseModel_->print("  noise model: ");
+}
+
+bool MapGravityFactor::equals(const gtsam::NonlinearFactor& expected, double tol) const
+{
+    const This* e = dynamic_cast<const This*>(&expected);
+    return e != nullptr && Base::equals(*e, tol);
+}
+
+}  // namespace mola::factors


### PR DESCRIPTION
## Summary

Adds `MapGravityFactor`, a **unary** GTSAM `ExpressionFactor` on a single pose `Pi`.

It imposes that the measured body up-vector, carried into the map frame through `Pi`, points along the map +Z axis:

```
rotate( rotation( Pi ∘ sensorPose ), measuredUp_body ) == (0,0,1)
```

## Motivation

`MeasuredGravityFactor` is binary on `(T_enu_to_map, Pi)`, routing every gravity sample through the geo-reference node. `MapGravityFactor` instead asserts leveling **directly in a gravity-aligned (z-up) map frame**, with no dependency on the geo-reference node. This:

- lets gravity-leveling work even with geo-referencing/GNSS disabled;
- decouples vertical (gravity) from horizontal (azimuth/geo-reference) estimation;
- removes a path by which gravity perturbs the geo-reference roll/pitch.

It is the right tool when the map frame is defined gravity-aligned (z-up) and `T_enu_to_map` roll/pitch are pinned.

## Changes

- New `MapGravityFactor.h` / `MapGravityFactor.cpp`
- Registered both in `CMakeLists.txt`

`MeasuredGravityFactor` is left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new gravity-alignment factor for IMU-related pose estimation in a map frame.
  * The factor supports combining a vehicle-mounted sensor pose with a measured up-vector to improve gravity-consistent optimization.

* **Bug Fixes**
  * Improved internal integration so the new factor is included in the main build and available at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->