### PR TITLE
optional georeferencing enu custom origin

### DIFF
--- a/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
+++ b/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
@@ -17,10 +17,13 @@
 #include <mrpt/3rdparty/tclap/CmdLine.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/io/CFileGZOutputStream.h>
+#include <mrpt/math/TPoint3D.h>
 #include <mrpt/system/filesystem.h>
 #include <mrpt/system/os.h>
 
+#include <algorithm>
 #include <fstream>
+#include <sstream>
 
 // CLI flags:
 
@@ -102,6 +105,19 @@ struct Cli
         "(enabled by default).",
         cmd, false};
 
+    TCLAP::ValueArg<std::string> argSetEnuToMapXYZ{
+        "",
+        "set-t-enu-to-map-xyz",
+        "Instead of keeping the GNSS-derived translation of T_enu_to_map (which "
+        "may be several meters from the map origin), force it to the given "
+        "\"X,Y,Z\" (meters, map frame) and move the geodetic datum accordingly so "
+        "the map<->geodetic mapping is preserved. Use \"0,0,0\" to place the ENU "
+        "origin at the map origin. The estimated rotation is kept.",
+        false,
+        "0,0,0",
+        "X,Y,Z",
+        cmd};
+
     TCLAP::ValueArg<std::string> arg_verbosity_level{
         "v",   "verbosity", "Verbosity level: ERROR|WARN|INFO|DEBUG (Default: INFO)",
         false, "INFO",      "INFO",
@@ -170,12 +186,36 @@ void run_sm_georef(Cli& cli)
         p.imuGravityParams.imuGravitySigmaDeg = cli.argIMUGravitySigmaDeg.getValue();
     }
 
-    const mola::SMGeoReferencingOutput smGeo = mola::simplemap_georeference(sm, p);
+    mola::SMGeoReferencingOutput smGeo = mola::simplemap_georeference(sm, p);
 
     if (!smGeo.geo_ref.has_value())
     {
         std::cerr << "Georeferencing failed. No output will be generated.\n";
         return;
+    }
+
+    // Optional re-datuming: force T_enu_to_map to a user-defined translation,
+    // moving the geodetic datum accordingly (see mola::recenter_georeference).
+    if (cli.argSetEnuToMapXYZ.isSet())
+    {
+        std::string s = cli.argSetEnuToMapXYZ.getValue();
+        std::replace(s.begin(), s.end(), ',', ' ');
+        std::istringstream    iss(s);
+        mrpt::math::TPoint3D  xyz;
+        if (!(iss >> xyz.x >> xyz.y >> xyz.z))
+        {
+            THROW_EXCEPTION_FMT(
+                "Cannot parse --set-t-enu-to-map-xyz value as \"X,Y,Z\": '%s'",
+                cli.argSetEnuToMapXYZ.getValue().c_str());
+        }
+
+        smGeo.geo_ref = mola::recenter_georeference(*smGeo.geo_ref, xyz);
+
+        logger.logFmt(
+            mrpt::system::LVL_INFO,
+            "Re-centered T_enu_to_map translation to (%.3f, %.3f, %.3f) and moved datum "
+            "accordingly.",
+            xyz.x, xyz.y, xyz.z);
     }
 
     const auto& geo_ref = smGeo.geo_ref.value();

--- a/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
+++ b/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
@@ -212,11 +212,26 @@ void run_sm_georef(Cli& cli)
     // moving the geodetic datum accordingly (see mola::recenter_georeference).
     if (cli.argSetEnuToMapXYZ.isSet())
     {
+        if (!smGeo.has_geodetic_datum)
+        {
+            THROW_EXCEPTION(
+                "--set-t-enu-to-map-xyz requires a GNSS-derived geodetic datum, but "
+                "the input simplemap only provided IMU data (no real geo_coord to "
+                "re-datum).");
+        }
+
         std::string s = cli.argSetEnuToMapXYZ.getValue();
         std::replace(s.begin(), s.end(), ',', ' ');
-        std::istringstream    iss(s);
-        mrpt::math::TPoint3D  xyz;
+        std::istringstream   iss(s);
+        mrpt::math::TPoint3D xyz;
         if (!(iss >> xyz.x >> xyz.y >> xyz.z))
+        {
+            THROW_EXCEPTION_FMT(
+                "Cannot parse --set-t-enu-to-map-xyz value as \"X,Y,Z\": '%s'",
+                cli.argSetEnuToMapXYZ.getValue().c_str());
+        }
+        iss >> std::ws;
+        if (!iss.eof())
         {
             THROW_EXCEPTION_FMT(
                 "Cannot parse --set-t-enu-to-map-xyz value as \"X,Y,Z\": '%s'",

--- a/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
+++ b/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
@@ -78,6 +78,16 @@ struct Cli
         "0.20",
         cmd};
 
+    TCLAP::ValueArg<double> argGnssHuberK{
+        "",
+        "gnss-huber-k",
+        "Parameter 'k' of the Huber robust kernel applied to GNSS position "
+        "factors (whitened units). Default: 1.5",
+        false,
+        1.5,
+        "1.5",
+        cmd};
+
     TCLAP::ValueArg<unsigned int> argMinFixQuality{
         "",
         "min-gnss-fix-quality",
@@ -170,6 +180,10 @@ void run_sm_georef(Cli& cli)
     if (cli.argMinUncertaintyXYZ.isSet())
     {
         p.fgParams.minimumUncertaintyXYZ = cli.argMinUncertaintyXYZ.getValue();
+    }
+    if (cli.argGnssHuberK.isSet())
+    {
+        p.fgParams.robustParamHuberK = cli.argGnssHuberK.getValue();
     }
 
     if (cli.argMinFixQuality.isSet())

--- a/mola_georeferencing/include/mola_georeferencing/simplemap_georeference.h
+++ b/mola_georeferencing/include/mola_georeferencing/simplemap_georeference.h
@@ -83,6 +83,28 @@ struct SMGeoReferencingParams
 SMGeoReferencingOutput simplemap_georeference(
     const mrpt::maps::CSimpleMap& sm, const SMGeoReferencingParams& params = {});
 
+/** Re-datums a geo-referencing so that its `T_enu_to_map` has exactly the given
+ *  translation, shifting the geodetic datum (`geo_coord`) accordingly so that
+ *  the map <-> geodetic mapping is left completely unchanged. The rotation of
+ *  `T_enu_to_map` and the 6D covariance are preserved.
+ *
+ *  The ENU frame origin (datum) ends up placed at the map point located at
+ *  \a desiredEnuToMapTranslation (since `T_enu_to_map` maps ENU (0,0,0) to its
+ *  own translation).
+ *
+ *  This is useful to force the ENU origin to a chosen map location (e.g. the map
+ *  origin, passing {0,0,0}) instead of the arbitrary first-GNSS position, which
+ *  may be several meters from the map origin and make it awkward to pick an
+ *  initial pose for localization.
+ *
+ *  \param in The input geo-referencing (datum + T_enu_to_map).
+ *  \param desiredEnuToMapTranslation The desired translation of T_enu_to_map.
+ *  \return The re-datumed, geometrically-equivalent geo-referencing.
+ */
+mp2p_icp::metric_map_t::Georeferencing recenter_georeference(
+    const mp2p_icp::metric_map_t::Georeferencing& in,
+    const mrpt::math::TPoint3D&                    desiredEnuToMapTranslation);
+
 struct FrameGNSS
 {
     mrpt::poses::CPose3D              pose;

--- a/mola_georeferencing/include/mola_georeferencing/simplemap_georeference.h
+++ b/mola_georeferencing/include/mola_georeferencing/simplemap_georeference.h
@@ -45,6 +45,11 @@ struct AddGNSSFactorParams
     double horizontalitySigmaZ         = 1.0;  // [m]
 
     double minimumUncertaintyXYZ = 0.20;  // [m]
+
+    /// Parameter "k" (in whitened/normalized units) of the Huber robust kernel
+    /// applied to each GNSS position factor. Residuals below this threshold are
+    /// treated quadratically; larger ones are down-weighted linearly.
+    double robustParamHuberK = 1.5;
 };
 
 struct AddIMUGravityFactorParams

--- a/mola_georeferencing/include/mola_georeferencing/simplemap_georeference.h
+++ b/mola_georeferencing/include/mola_georeferencing/simplemap_georeference.h
@@ -34,6 +34,13 @@ struct SMGeoReferencingOutput
     /// data.
     std::optional<mp2p_icp::metric_map_t::Georeferencing> geo_ref;
 
+    /// True if `geo_ref->geo_coord` was actually derived from GNSS data.
+    /// False (default) means it was left at its zero-initialized value, e.g.
+    /// because only IMU data was available for gravity alignment; in that
+    /// case, `geo_ref->geo_coord` must NOT be treated as a real geodetic
+    /// reference (e.g. for datum re-centering).
+    bool has_geodetic_datum = false;
+
     double final_rmse = .0;
 };
 
@@ -90,8 +97,10 @@ SMGeoReferencingOutput simplemap_georeference(
 
 /** Re-datums a geo-referencing so that its `T_enu_to_map` has exactly the given
  *  translation, shifting the geodetic datum (`geo_coord`) accordingly so that
- *  the map <-> geodetic mapping is left completely unchanged. The rotation of
- *  `T_enu_to_map` and the 6D covariance are preserved.
+ *  the map <-> geodetic mapping is left completely unchanged. Since the local
+ *  ENU axes rotate as the datum moves on the curved Earth, the rotation of
+ *  `T_enu_to_map` is only approximately preserved (exactly so for small datum
+ *  shifts); the 6D covariance is propagated accordingly, not just copied.
  *
  *  The ENU frame origin (datum) ends up placed at the map point located at
  *  \a desiredEnuToMapTranslation (since `T_enu_to_map` maps ENU (0,0,0) to its
@@ -108,7 +117,7 @@ SMGeoReferencingOutput simplemap_georeference(
  */
 mp2p_icp::metric_map_t::Georeferencing recenter_georeference(
     const mp2p_icp::metric_map_t::Georeferencing& in,
-    const mrpt::math::TPoint3D&                    desiredEnuToMapTranslation);
+    const mrpt::math::TPoint3D&                   desiredEnuToMapTranslation);
 
 struct FrameGNSS
 {

--- a/mola_georeferencing/src/simplemap_georeference.cpp
+++ b/mola_georeferencing/src/simplemap_georeference.cpp
@@ -160,6 +160,7 @@ mola::SMGeoReferencingOutput mola::simplemap_georeference(
     if (smFrames.refCoord.has_value())
     {
         ret.geo_ref->geo_coord = *smFrames.refCoord;
+        ret.has_geodetic_datum = true;
     }
 
     ret.final_rmse = rmseEnd;
@@ -172,6 +173,7 @@ mp2p_icp::metric_map_t::Georeferencing mola::recenter_georeference(
     const mrpt::math::TPoint3D&                   desiredEnuToMapTranslation)
 {
     using mrpt::poses::CPose3D;
+    using mrpt::poses::CPose3DPDFGaussian;
 
     mp2p_icp::metric_map_t::Georeferencing out = in;
 
@@ -181,40 +183,45 @@ mp2p_icp::metric_map_t::Georeferencing mola::recenter_georeference(
     // curved Earth: the local ENU axes rotate as the datum moves, so keeping the
     // same T_enu_to_map rotation while shifting the datum would only be a
     // flat-Earth approximation. Instead we preserve the physical map<->ECEF
-    // placement and recompute T_enu_to_map for the new datum's ENU frame.
+    // placement and recompute T_enu_to_map for the new datum's ENU frame. Note
+    // that this means the rotation of T_enu_to_map is, in general, NOT
+    // preserved: only the map<->geodetic mapping is left exact.
 
     // ENU frame of the current datum, expressed in ECEF (rotation = ENU->ECEF,
-    // translation = datum ECEF position):
+    // translation = datum ECEF position). This is deterministic (no uncertainty).
     mrpt::math::TPose3D e0;
     mrpt::topography::ENU_axes_from_WGS84(in.geo_coord, e0, /*only_angles=*/false);
-    const CPose3D E0(e0);
+    const CPose3DPDFGaussian E0{CPose3D(e0)};
 
     // Physical placement of the map in ECEF (invariant): map -> ECEF.
     //   map -> ENU is T_enu_to_map^{-1}; ENU -> ECEF is E0.
-    const CPose3D A = E0 + (-in.T_enu_to_map.mean);
+    // Using the Gaussian PDF composition operators propagates the input
+    // covariance through this transformation (instead of just its mean).
+    const CPose3DPDFGaussian A = E0 + (-in.T_enu_to_map);
 
     // The new ENU datum is placed at the map point `t1` (T_enu_to_map maps the
-    // ENU origin to its own translation). Its ECEF position:
-    const mrpt::math::TPoint3D X1 = A.composePoint(t1);
+    // ENU origin to its own translation). Its ECEF position (mean only, `t1` is
+    // a fixed user input with no uncertainty):
+    const mrpt::math::TPoint3D X1 = A.mean.composePoint(t1);
 
     // New datum in geodetic coordinates (ECEF -> geodetic):
     mrpt::topography::TGeodeticCoords newDatum;
     mrpt::topography::geocentricToGeodetic(
         X1, newDatum, mrpt::topography::TEllipsoid::Ellipsoid_WGS84());
 
-    // ENU frame of the new datum in ECEF:
+    // ENU frame of the new datum in ECEF (deterministic):
     mrpt::math::TPose3D e1;
     mrpt::topography::ENU_axes_from_WGS84(newDatum, e1, /*only_angles=*/false);
-    const CPose3D E1(e1);
+    const CPose3DPDFGaussian E1{CPose3D(e1)};
 
     // New T_enu_to_map preserving the exact map<->ECEF placement:
     //   map -> ECEF = E1 o T1^{-1} = A   =>   T1 = A^{-1} o E1.
-    // By construction its translation equals `t1`.
-    const CPose3D T1 = (-A) + E1;
+    // By construction its mean translation equals `t1`; its covariance is the
+    // propagation of the input T_enu_to_map covariance through this chain.
+    const CPose3DPDFGaussian T1 = (-A) + E1;
 
-    out.geo_coord         = newDatum;
-    out.T_enu_to_map.mean = T1;
-    // 6D covariance kept as-is (deterministic re-parameterization).
+    out.geo_coord    = newDatum;
+    out.T_enu_to_map = T1;
 
     return out;
 }

--- a/mola_georeferencing/src/simplemap_georeference.cpp
+++ b/mola_georeferencing/src/simplemap_georeference.cpp
@@ -394,7 +394,7 @@ void mola::add_gnss_factors(
                 .max(params.minimumUncertaintyXYZ));
 
         auto robustNoise = gtsam::noiseModel::Robust::Create(
-            gtsam::noiseModel::mEstimator::Huber::Create(1.5), noiseOrg);
+            gtsam::noiseModel::mEstimator::Huber::Create(params.robustParamHuberK), noiseOrg);
 
         const auto observedENU = mrpt::gtsam_wrappers::toPoint3(frame.enu);
         const auto sensorPointOnVeh =

--- a/mola_georeferencing/src/simplemap_georeference.cpp
+++ b/mola_georeferencing/src/simplemap_georeference.cpp
@@ -167,6 +167,58 @@ mola::SMGeoReferencingOutput mola::simplemap_georeference(
     return ret;
 }
 
+mp2p_icp::metric_map_t::Georeferencing mola::recenter_georeference(
+    const mp2p_icp::metric_map_t::Georeferencing& in,
+    const mrpt::math::TPoint3D&                   desiredEnuToMapTranslation)
+{
+    using mrpt::poses::CPose3D;
+
+    mp2p_icp::metric_map_t::Georeferencing out = in;
+
+    const mrpt::math::TPoint3D t1 = desiredEnuToMapTranslation;
+
+    // We work in geocentric (ECEF) coordinates so the result is EXACT on the
+    // curved Earth: the local ENU axes rotate as the datum moves, so keeping the
+    // same T_enu_to_map rotation while shifting the datum would only be a
+    // flat-Earth approximation. Instead we preserve the physical map<->ECEF
+    // placement and recompute T_enu_to_map for the new datum's ENU frame.
+
+    // ENU frame of the current datum, expressed in ECEF (rotation = ENU->ECEF,
+    // translation = datum ECEF position):
+    mrpt::math::TPose3D e0;
+    mrpt::topography::ENU_axes_from_WGS84(in.geo_coord, e0, /*only_angles=*/false);
+    const CPose3D E0(e0);
+
+    // Physical placement of the map in ECEF (invariant): map -> ECEF.
+    //   map -> ENU is T_enu_to_map^{-1}; ENU -> ECEF is E0.
+    const CPose3D A = E0 + (-in.T_enu_to_map.mean);
+
+    // The new ENU datum is placed at the map point `t1` (T_enu_to_map maps the
+    // ENU origin to its own translation). Its ECEF position:
+    const mrpt::math::TPoint3D X1 = A.composePoint(t1);
+
+    // New datum in geodetic coordinates (ECEF -> geodetic):
+    mrpt::topography::TGeodeticCoords newDatum;
+    mrpt::topography::geocentricToGeodetic(
+        X1, newDatum, mrpt::topography::TEllipsoid::Ellipsoid_WGS84());
+
+    // ENU frame of the new datum in ECEF:
+    mrpt::math::TPose3D e1;
+    mrpt::topography::ENU_axes_from_WGS84(newDatum, e1, /*only_angles=*/false);
+    const CPose3D E1(e1);
+
+    // New T_enu_to_map preserving the exact map<->ECEF placement:
+    //   map -> ECEF = E1 o T1^{-1} = A   =>   T1 = A^{-1} o E1.
+    // By construction its translation equals `t1`.
+    const CPose3D T1 = (-A) + E1;
+
+    out.geo_coord         = newDatum;
+    out.T_enu_to_map.mean = T1;
+    // 6D covariance kept as-is (deterministic re-parameterization).
+
+    return out;
+}
+
 mola::GNSSFrames mola::extract_gnss_frames_from_sm(
     const mrpt::maps::CSimpleMap&                           sm,
     const std::optional<mrpt::topography::TGeodeticCoords>& refCoordIn,

--- a/mola_georeferencing/src/simplemap_georeference.cpp
+++ b/mola_georeferencing/src/simplemap_georeference.cpp
@@ -382,6 +382,13 @@ void mola::add_gnss_factors(
     using gtsam::symbol_shorthand::P;  // P(i): each vehicle pose, in the {map} frame
     using gtsam::symbol_shorthand::T;  // T(0): the single sought transformation: {enu} -> {map}
 
+    if (!std::isfinite(params.robustParamHuberK) || params.robustParamHuberK <= 0)
+    {
+        THROW_EXCEPTION_FMT(
+            "Invalid AddGNSSFactorParams::robustParamHuberK=%f: must be finite and positive.",
+            params.robustParamHuberK);
+    }
+
     v.insert(T(0), gtsam::Pose3::Identity());
 
     // Expression to optimize (i=0...N):

--- a/mola_georeferencing/tests/CMakeLists.txt
+++ b/mola_georeferencing/tests/CMakeLists.txt
@@ -25,3 +25,10 @@ mola_add_test(
   LINK_LIBRARIES
     mola::mola_georeferencing
 )
+
+mola_add_test(
+  TARGET  test_recenter_georeference
+  SOURCES test_recenter_georeference.cpp
+  LINK_LIBRARIES
+    mola::mola_georeferencing
+)

--- a/mola_georeferencing/tests/test_recenter_georeference.cpp
+++ b/mola_georeferencing/tests/test_recenter_georeference.cpp
@@ -1,0 +1,165 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this package
+ alone or in combination with the complete SLAM system.
+*/
+
+#include <mola_georeferencing/simplemap_georeference.h>
+#include <mrpt/poses/CPose3D.h>
+#include <mrpt/topography/conversions.h>
+
+#include <cmath>
+#include <iostream>
+
+namespace
+{
+void expect(bool cond, const std::string& msg)
+{
+    if (!cond)
+    {
+        throw std::runtime_error("Test assertion failed: " + msg);
+    }
+}
+
+// Absolute geodetic coordinates of a given map-frame point, using a georef.
+// This is the operation that must stay invariant under recenter_georeference().
+//
+// NOTE: we deliberately use the ellipsoid-normal ENU convention
+// (ENU_axes_from_WGS84), which is the one used by geodeticToENU_WGS84 and hence
+// by both the georeferencing pipeline and the state estimator's fuse_gnss().
+// (mrpt::topography::ENUToGeocentric uses a *geocentric-radial* Up axis instead,
+// which differs by ~0.2 deg and would introduce a spurious cm-level bias here.)
+mrpt::topography::TGeodeticCoords geodetic_of_map_point(
+    const mp2p_icp::metric_map_t::Georeferencing& g, const mrpt::math::TPoint3D& p_map)
+{
+    // p_enu = T_enu_to_map^{-1}(p_map), relative to the datum:
+    mrpt::math::TPoint3D p_enu;
+    g.T_enu_to_map.mean.inverseComposePoint(p_map.x, p_map.y, p_map.z, p_enu.x, p_enu.y, p_enu.z);
+
+    // ENU -> geocentric via the datum's ENU frame (ellipsoid-normal Up):
+    mrpt::math::TPose3D enuPose;
+    mrpt::topography::ENU_axes_from_WGS84(g.geo_coord, enuPose, /*only_angles=*/false);
+    mrpt::math::TPoint3D geocentric;
+    mrpt::poses::CPose3D(enuPose).composePoint(p_enu.x, p_enu.y, p_enu.z, geocentric.x, geocentric.y, geocentric.z);
+
+    // geocentric -> geodetic:
+    mrpt::topography::TGeodeticCoords geo;
+    mrpt::topography::geocentricToGeodetic(
+        geocentric, geo, mrpt::topography::TEllipsoid::Ellipsoid_WGS84());
+    return geo;
+}
+
+// Builds a non-trivial georef: datum somewhere real, T_enu_to_map with a
+// non-identity rotation and a several-meters translation (mimicking the
+// GNSS-derived output that this feature is meant to re-datum).
+mp2p_icp::metric_map_t::Georeferencing make_georef()
+{
+    mp2p_icp::metric_map_t::Georeferencing g;
+    g.geo_coord.lat    = 56.108686;  // deg
+    g.geo_coord.lon    = 10.125739;  // deg
+    g.geo_coord.height = 100.0;      // m
+
+    // yaw=30deg, pitch=5deg, roll=-3deg; translation several meters:
+    g.T_enu_to_map.mean = mrpt::poses::CPose3D(
+        7.0, -4.0, 2.0, mrpt::DEG2RAD(30.0), mrpt::DEG2RAD(5.0), mrpt::DEG2RAD(-3.0));
+    g.T_enu_to_map.cov.setIdentity();
+    return g;
+}
+
+// Compares two geodetic coordinates within tolerances.
+void expect_geodetic_near(
+    const mrpt::topography::TGeodeticCoords& a, const mrpt::topography::TGeodeticCoords& b,
+    const std::string& ctx)
+{
+    // 1e-7 deg ~ 1.1 cm; comfortably above WGS84 geodetic<->geocentric
+    // round-trip precision (sub-mm), yet far tighter than any GNSS accuracy.
+    expect(std::abs(a.lat - b.lat) < 1e-7, ctx + ": latitude mismatch");
+    expect(std::abs(a.lon - b.lon) < 1e-7, ctx + ": longitude mismatch");
+    expect(std::abs(a.height - b.height) < 1e-2, ctx + ": height mismatch");
+}
+
+// Core property: re-datuming preserves the map<->geodetic mapping exactly, and
+// forces T_enu_to_map to the requested translation.
+void test_recenter_preserves_mapping(const mrpt::math::TPoint3D& target)
+{
+    const auto g0 = make_georef();
+
+    // Sample several map points and record their absolute geodetic coords:
+    const std::vector<mrpt::math::TPoint3D> probes = {
+        {0, 0, 0}, {10, 20, 3}, {-15, 8, -2}, {100, -50, 12}};
+
+    std::vector<mrpt::topography::TGeodeticCoords> before;
+    for (const auto& p : probes) before.push_back(geodetic_of_map_point(g0, p));
+
+    const auto g1 = mola::recenter_georeference(g0, target);
+
+    // (1) T_enu_to_map translation is the requested one (to WGS84 round-trip
+    // precision, i.e. sub-mm):
+    const auto t1 = g1.T_enu_to_map.mean.translation();
+    expect(std::abs(t1.x - target.x) < 1e-3, "translation X set");
+    expect(std::abs(t1.y - target.y) < 1e-3, "translation Y set");
+    expect(std::abs(t1.z - target.z) < 1e-3, "translation Z set");
+
+    // (2) rotation is NOT exactly preserved: the local ENU axes rotate as the
+    // datum moves, so T_enu_to_map's rotation changes by that small amount. It
+    // must stay close for a modest datum move, but need not be identical. Just
+    // sanity-check it is a proper rotation close to the original (bounded).
+    const auto R0 = g0.T_enu_to_map.mean.getRotationMatrix();
+    const auto R1 = g1.T_enu_to_map.mean.getRotationMatrix();
+    expect((R0 - R1).array().abs().maxCoeff() < 0.2, "rotation stays bounded near original");
+
+    // (3) the map<->geodetic mapping is invariant for every probe (this is the
+    // key exactness property, and it holds regardless of the datum move size):
+    for (size_t i = 0; i < probes.size(); i++)
+    {
+        const auto after = geodetic_of_map_point(g1, probes[i]);
+        expect_geodetic_near(before[i], after, "probe " + std::to_string(i));
+    }
+
+    // (4) the new datum equals the geodetic of the map point at `target`:
+    expect_geodetic_near(
+        g1.geo_coord, geodetic_of_map_point(g0, target), "datum == geodetic(target)");
+}
+
+// Placing the ENU origin at the map origin (0,0,0) makes the datum equal to the
+// geodetic coordinates of the map origin under the original georef.
+void test_recenter_to_map_origin()
+{
+    const auto g0 = make_georef();
+    const auto g1 = mola::recenter_georeference(g0, {0, 0, 0});
+
+    const auto t1 = g1.T_enu_to_map.mean.translation();
+    expect(t1.norm() < 1e-3, "map-origin case: T translation is zero");
+
+    expect_geodetic_near(
+        g1.geo_coord, geodetic_of_map_point(g0, {0, 0, 0}), "datum == geodetic(map origin)");
+}
+
+}  // namespace
+
+int main()
+{
+    try
+    {
+        test_recenter_preserves_mapping({0, 0, 0});
+        test_recenter_preserves_mapping({100, -50, 1});
+        test_recenter_preserves_mapping({-1234.5, 6789.0, -30.0});
+        test_recenter_to_map_origin();
+
+        std::cout << "All recenter_georeference tests passed!\n";
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "ERROR: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/Parameters.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/Parameters.h
@@ -76,6 +76,37 @@ class Parameters
 
     /// regex for GNSS (GPS) labels (ROS topics) to be accepted as inputs
     std::string do_process_gnss_labels_re = ".*";
+
+    /** \name GNSS (GPS/RTK) absolute-position fusion
+     *  When enabled AND a geo-reference has been provided (see
+     *  StateEstimationSimple::set_geo_reference), low-uncertainty GNSS fixes
+     *  (e.g. RTK) nudge the pose anchor toward the absolute map-frame position
+     *  to arrest slow drift, without collapsing the ICP prior below what the
+     *  motion model needs to cover the next step.
+     *  @{ */
+
+    /// Master switch. Default false preserves the legacy "GNSS ignored" behavior.
+    bool gnss_enabled = false;
+
+    /** Reject any GNSS fix whose reported horizontal sigma
+     *  (sqrt of the larger of the ENU east/north variances) exceeds this [m].
+     *  The default 0.20 m cleanly selects RTK-fixed samples and rejects
+     *  RTK-float / no-fix (and the UINT32_MAX no-fix covariance sentinel). */
+    double gnss_max_horizontal_sigma = 0.20;  // [m]
+
+    /** Lower bound on the horizontal measurement sigma actually used to correct
+     *  the anchor [m]. A 2 cm RTK fix is softened to this floor so the prior
+     *  Gaussian sent to the ICP still spans the next-step motion at speed. */
+    double gnss_min_sigma_floor_xy = 0.10;  // [m]
+
+    /// Same floor for the vertical component [m] (used only if gnss_fuse_z).
+    double gnss_min_sigma_floor_z = 0.30;  // [m]
+
+    /** If true, also correct the Z of the anchor. Default false: vehicle-frame
+     *  vertical is usually poorly observed and GNSS altitude is noisier. */
+    bool gnss_fuse_z = false;
+
+    /** @} */
 };
 
 }  // namespace mola::state_estimation_simple

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
@@ -25,6 +25,7 @@
 #include <mola_state_estimation_simple/Parameters.h>
 
 // MOLA
+#include <mola_kernel/Georeferencing.h>
 #include <mola_kernel/interfaces/NavStateFilter.h>
 #include <mola_kernel/version.h>
 #include <mrpt/containers/yaml.h>
@@ -119,6 +120,17 @@ class StateEstimationSimple : public mola::NavStateFilter
     /** Integrates new GNSS observations into the estimator */
     void fuse_gnss(const mrpt::obs::CObservationGPS& gps) override;
 
+#if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)
+    /** Provides the fixed geo-reference (geodetic datum + ENU->map transform)
+     *  used by fuse_gnss() to convert GNSS fixes into map-frame corrections.
+     *  In map-based localization this comes from the loaded `.mm` map.
+     *  Without it (and without params.gnss_enabled) GNSS is ignored. */
+    void set_geo_reference(const mola::Georeferencing& georef) override;
+
+    /** Returns the currently set geo-reference, if any. */
+    std::optional<mola::Georeferencing> get_geo_reference() const override;
+#endif
+
     /** Integrates new twist estimation (in the odom frame) */
     void fuse_twist(
         const mrpt::Clock::time_point& timestamp, const mrpt::math::TTwist3D& twist,
@@ -198,7 +210,13 @@ class StateEstimationSimple : public mola::NavStateFilter
         const std::array<double, 6>& z, const std::array<double, 6>& R_diag,
         const mrpt::Clock::time_point& tim, const std::string& caller = "");
 
-    State                        state_;
+    State state_;
+
+    // Fixed geo-reference (datum + ENU->map) for GNSS fusion. Config-like:
+    // set once via set_geo_reference() and deliberately NOT cleared by reset(),
+    // so relocalization keeps the map's geo-reference.
+    std::optional<mola::Georeferencing> geo_reference_;
+
     mutable std::recursive_mutex state_mtx_;
 };
 

--- a/mola_state_estimation_simple/src/Parameters.cpp
+++ b/mola_state_estimation_simple/src/Parameters.cpp
@@ -44,6 +44,12 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
     MCP_LOAD_OPT(cfg, do_process_odometry_labels_re);
     MCP_LOAD_OPT(cfg, do_process_gnss_labels_re);
 
+    MCP_LOAD_OPT(cfg, gnss_enabled);
+    MCP_LOAD_OPT(cfg, gnss_max_horizontal_sigma);
+    MCP_LOAD_OPT(cfg, gnss_min_sigma_floor_xy);
+    MCP_LOAD_OPT(cfg, gnss_min_sigma_floor_z);
+    MCP_LOAD_OPT(cfg, gnss_fuse_z);
+
     if (cfg.has("initial_twist"))
     {
         ASSERT_(cfg["initial_twist"].isSequence() && cfg["initial_twist"].asSequence().size() == 6);

--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -24,7 +24,9 @@
 #include <mola_yaml/yaml_helpers.h>
 #include <mrpt/core/get_env.h>
 #include <mrpt/obs/CObservationRobotPose.h>
+#include <mrpt/obs/gnss_messages.h>
 #include <mrpt/poses/Lie/SO.h>
+#include <mrpt/topography/conversions.h>
 
 #include <fstream>
 #include <memory>
@@ -445,15 +447,147 @@ void StateEstimationSimple::fuse_imu(const mrpt::obs::CObservationIMU& imu)
     MRPT_LOG_DEBUG_STREAM("fuse_imu(): new twist: " << state_.last_twist->asString());
 }
 
+#if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)
+void StateEstimationSimple::set_geo_reference(const mola::Georeferencing& georef)
+{
+    auto lck       = std::scoped_lock(state_mtx_);
+    geo_reference_ = georef;
+}
+
+std::optional<mola::Georeferencing> StateEstimationSimple::get_geo_reference() const
+{
+    auto lck = std::scoped_lock(state_mtx_);
+    return geo_reference_;
+}
+#endif
+
 void StateEstimationSimple::fuse_gnss(const mrpt::obs::CObservationGPS& gps)
 {
     auto lck = std::scoped_lock(state_mtx_);
 
-    // This estimator will just ignore GPS.
-    // Refer to the smoother for a more versatile estimator.
-    (void)gps;
+    // GNSS fusion is opt-in and needs a geo-reference to place fixes in the map
+    // frame. Without either, ignore (legacy behavior; see the smoother for a
+    // full graph-based estimator).
+    if (!params.gnss_enabled)
+    {
+        MRPT_LOG_DEBUG_STREAM("fuse_gnss(): ignored (gnss_enabled=false)");
+        return;
+    }
+    if (!geo_reference_.has_value())
+    {
+        MRPT_LOG_THROTTLE_WARN(5.0, "fuse_gnss(): ignored, no geo-reference set");
+        return;
+    }
+    // We only correct an existing anchor; the LiDAR/odometry backbone must exist.
+    if (!state_.last_pose.has_value())
+    {
+        MRPT_LOG_DEBUG_STREAM("fuse_gnss(): ignored, no last_pose yet");
+        return;
+    }
 
-    MRPT_LOG_DEBUG_STREAM("fuse_gnss(): ignored in this class");
+    if (!gps.has_GGA_datum())
+    {
+        MRPT_LOG_DEBUG_STREAM("fuse_gnss(): ignored, no GGA datum");
+        return;
+    }
+    if (!gps.covariance_enu.has_value())
+    {
+        MRPT_LOG_THROTTLE_WARN(5.0, "fuse_gnss(): ignored, GNSS reading has no ENU covariance");
+        return;
+    }
+
+    // RTK gate: reject anything but low-uncertainty fixes. The larger of the
+    // east/north variances defines the horizontal sigma; this also rejects the
+    // UINT32_MAX no-fix covariance sentinel.
+    const auto&  cov_enu = *gps.covariance_enu;
+    const double var_e   = cov_enu(0, 0);
+    const double var_n   = cov_enu(1, 1);
+    // A valid position fix must report strictly positive horizontal variances.
+    // Zero or negative values are invalid (uninitialized / no-fix / corrupted)
+    // and would otherwise fabricate a spuriously confident anchor correction.
+    if (!std::isfinite(var_e) || !std::isfinite(var_n) || var_e <= 0 || var_n <= 0)
+    {
+        MRPT_LOG_THROTTLE_WARN_FMT(
+            5.0, "fuse_gnss(): ignored, non-positive ENU variance (var_e=%g, var_n=%g)", var_e,
+            var_n);
+        return;
+    }
+    if (params.gnss_fuse_z)
+    {
+        const double var_u = cov_enu(2, 2);
+        if (!std::isfinite(var_u) || var_u <= 0)
+        {
+            MRPT_LOG_THROTTLE_WARN_FMT(
+                5.0, "fuse_gnss(): ignored, non-positive ENU up-variance (var_u=%g)", var_u);
+            return;
+        }
+    }
+    const double horiz_var   = std::max(var_e, var_n);
+    const double horiz_sigma = std::sqrt(horiz_var);
+    if (!std::isfinite(horiz_sigma) || horiz_sigma > params.gnss_max_horizontal_sigma)
+    {
+        MRPT_LOG_DEBUG_FMT(
+            "fuse_gnss(): ignored, horiz_sigma=%.3f m > gate %.3f m", horiz_sigma,
+            params.gnss_max_horizontal_sigma);
+        return;
+    }
+
+    // Geodetic -> ENU (wrt the map datum) -> map frame.
+    const auto& gga       = gps.getMsgByClass<mrpt::obs::gnss::Message_NMEA_GGA>();
+    const auto  geoCoords = gga.getAsStruct<mrpt::topography::TGeodeticCoords>();
+
+    mrpt::math::TPoint3D enu_point;
+    mrpt::topography::geodeticToENU_WGS84(geoCoords, enu_point, geo_reference_->geo_coord);
+
+    // Antenna position in the map frame:
+    const mrpt::poses::CPose3D antenna_in_map =
+        geo_reference_->T_enu_to_map.mean +
+        mrpt::poses::CPose3D(enu_point.x, enu_point.y, enu_point.z, 0, 0, 0);
+
+    // The fix locates the ANTENNA; shift by the antenna lever arm (expressed in
+    // the vehicle frame via the current attitude) to obtain the vehicle-frame
+    // position the anchor represents.
+    mrpt::math::TPoint3D vehicle_in_map = antenna_in_map.translation();
+    if (gps.sensorPose != mrpt::poses::CPose3D())
+    {
+        const auto lever_map = state_.last_pose->mean.rotateVector(gps.sensorPose.translation());
+        vehicle_in_map -= lever_map;
+    }
+
+    // Per-axis scalar Kalman correction of the anchor position. Orientation and
+    // twist are untouched (GNSS observes neither). A covariance FLOOR keeps the
+    // downstream ICP prior from collapsing below the motion-model needs.
+    const double sigma_xy    = std::max(horiz_sigma, params.gnss_min_sigma_floor_xy);
+    const double meas_var_xy = mrpt::square(sigma_xy);
+
+    auto&        mean       = state_.last_pose->mean;
+    auto&        cov        = state_.last_pose->cov;
+    const double meas[3]    = {vehicle_in_map.x, vehicle_in_map.y, vehicle_in_map.z};
+    const int    n_axes     = params.gnss_fuse_z ? 3 : 2;
+    double       new_xyz[3] = {mean.x(), mean.y(), mean.z()};
+    for (int i = 0; i < n_axes; i++)
+    {
+        const double meas_var =
+            (i < 2) ? meas_var_xy
+                    : mrpt::square(std::max(
+                          std::sqrt(std::max(cov_enu(2, 2), .0)), params.gnss_min_sigma_floor_z));
+        const double P     = cov(i, i);
+        const double denom = P + meas_var;
+        if (denom <= 0)
+        {
+            continue;
+        }
+        const double K = P / denom;
+        new_xyz[i]     = new_xyz[i] + K * (meas[i] - new_xyz[i]);
+        cov(i, i)      = (1.0 - K) * P;
+    }
+    mean.x(new_xyz[0]);
+    mean.y(new_xyz[1]);
+    mean.z(new_xyz[2]);
+
+    MRPT_LOG_DEBUG_FMT(
+        "fuse_gnss(): corrected anchor to map=(%.3f,%.3f,%.3f) horiz_sigma=%.3f m", mean.x(),
+        mean.y(), mean.z(), horiz_sigma);
 }
 
 void StateEstimationSimple::fuse_pose(

--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -28,6 +28,7 @@
 #include <mrpt/poses/Lie/SO.h>
 #include <mrpt/topography/conversions.h>
 
+#include <Eigen/Dense>
 #include <fstream>
 #include <memory>
 
@@ -485,6 +486,16 @@ void StateEstimationSimple::fuse_gnss(const mrpt::obs::CObservationGPS& gps)
         return;
     }
 
+    // Reject fixes that predate the anchor's own timestamp: fusing a delayed
+    // GNSS position into an anchor already extrapolated past that time (while
+    // leaving last_pose_obs_tim untouched) would apply the correction a second
+    // time on the next estimated_navstate() extrapolation.
+    if (state_.last_pose_obs_tim.has_value() && gps.timestamp < *state_.last_pose_obs_tim)
+    {
+        MRPT_LOG_DEBUG_STREAM("fuse_gnss(): ignored, stale GNSS fix older than last_pose_obs_tim");
+        return;
+    }
+
     if (!gps.has_GGA_datum())
     {
         MRPT_LOG_DEBUG_STREAM("fuse_gnss(): ignored, no GGA datum");
@@ -554,36 +565,61 @@ void StateEstimationSimple::fuse_gnss(const mrpt::obs::CObservationGPS& gps)
         vehicle_in_map -= lever_map;
     }
 
-    // Per-axis scalar Kalman correction of the anchor position. Orientation and
-    // twist are untouched (GNSS observes neither). A covariance FLOOR keeps the
-    // downstream ICP prior from collapsing below the motion-model needs.
+    // Full linear Kalman correction of the anchor pose from the GNSS position
+    // observation. The state is [x y z yaw pitch roll]; the position rows of
+    // the 6x6 covariance may be correlated with orientation (e.g. after an
+    // IMU/ICP update), so a per-axis diagonal-only correction would leave
+    // those cross terms stale and inconsistent. Twist is untouched (GNSS
+    // observes neither). A covariance FLOOR keeps the downstream ICP prior
+    // from collapsing below the motion-model needs.
     const double sigma_xy    = std::max(horiz_sigma, params.gnss_min_sigma_floor_xy);
     const double meas_var_xy = mrpt::square(sigma_xy);
+    const double meas_var_z  = mrpt::square(
+         std::max(std::sqrt(std::max(cov_enu(2, 2), .0)), params.gnss_min_sigma_floor_z));
 
-    auto&        mean       = state_.last_pose->mean;
-    auto&        cov        = state_.last_pose->cov;
-    const double meas[3]    = {vehicle_in_map.x, vehicle_in_map.y, vehicle_in_map.z};
-    const int    n_axes     = params.gnss_fuse_z ? 3 : 2;
-    double       new_xyz[3] = {mean.x(), mean.y(), mean.z()};
-    for (int i = 0; i < n_axes; i++)
+    auto&     mean   = state_.last_pose->mean;
+    auto&     cov    = state_.last_pose->cov;
+    const int n_axes = params.gnss_fuse_z ? 3 : 2;
+
+    Eigen::VectorXd innovation(n_axes);
+    innovation(0) = vehicle_in_map.x - mean.x();
+    innovation(1) = vehicle_in_map.y - mean.y();
+    if (n_axes == 3)
     {
-        const double meas_var =
-            (i < 2) ? meas_var_xy
-                    : mrpt::square(std::max(
-                          std::sqrt(std::max(cov_enu(2, 2), .0)), params.gnss_min_sigma_floor_z));
-        const double P     = cov(i, i);
-        const double denom = P + meas_var;
-        if (denom <= 0)
-        {
-            continue;
-        }
-        const double K = P / denom;
-        new_xyz[i]     = new_xyz[i] + K * (meas[i] - new_xyz[i]);
-        cov(i, i)      = (1.0 - K) * P;
+        innovation(2) = vehicle_in_map.z - mean.z();
     }
-    mean.x(new_xyz[0]);
-    mean.y(new_xyz[1]);
-    mean.z(new_xyz[2]);
+
+    Eigen::MatrixXd R = Eigen::MatrixXd::Zero(n_axes, n_axes);
+    R(0, 0)           = meas_var_xy;
+    R(1, 1)           = meas_var_xy;
+    if (n_axes == 3)
+    {
+        R(2, 2) = meas_var_z;
+    }
+
+    auto P = cov.asEigen();  // 6x6 Eigen map onto the pose covariance.
+
+    // H selects the first n_axes rows (the observed position components), so
+    // H*P is simply the top n_axes rows of P, and P*H^T its left n_axes cols.
+    const Eigen::MatrixXd HP = P.topRows(n_axes);
+    const Eigen::MatrixXd S  = P.topLeftCorner(n_axes, n_axes) + R;
+    if (S.determinant() <= 0)
+    {
+        MRPT_LOG_DEBUG_STREAM("fuse_gnss(): ignored, non-invertible innovation covariance");
+        return;
+    }
+    const Eigen::MatrixXd K  = P.leftCols(n_axes) * S.inverse();
+    const Eigen::VectorXd dx = K * innovation;
+
+    mean.x(mean.x() + dx(0));
+    mean.y(mean.y() + dx(1));
+    if (n_axes == 3)
+    {
+        mean.z(mean.z() + dx(2));
+    }
+    mean.setYawPitchRoll(mean.yaw() + dx(3), mean.pitch() + dx(4), mean.roll() + dx(5));
+
+    P -= K * HP;
 
     MRPT_LOG_DEBUG_FMT(
         "fuse_gnss(): corrected anchor to map=(%.3f,%.3f,%.3f) horiz_sigma=%.3f m", mean.x(),

--- a/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
+++ b/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
@@ -21,10 +21,13 @@
 
 #include <mola_state_estimation_simple/StateEstimationSimple.h>
 #include <mrpt/core/get_env.h>
+#include <mrpt/obs/CObservationGPS.h>
 #include <mrpt/obs/CObservationIMU.h>
 #include <mrpt/obs/CObservationRobotPose.h>
+#include <mrpt/obs/gnss_messages.h>
 #include <mrpt/poses/CPose3D.h>
 #include <mrpt/system/filesystem.h>
+#include <mrpt/topography/conversions.h>
 
 #include <algorithm>
 #include <cmath>
@@ -640,6 +643,339 @@ void test_multirate_interleaved_velocity()
     std::cout << "OK\n";
 }
 
+// --------------------------------------------------------------------------
+// GNSS / RTK fusion helpers + tests
+// --------------------------------------------------------------------------
+namespace
+{
+// Datum used across the GNSS tests (near the Sletvej site).
+constexpr double kDatumLat = 56.108686;  // deg
+constexpr double kDatumLon = 10.125739;  // deg
+constexpr double kDatumAlt = 100.0;  // m
+
+// Builds a config with GNSS fusion enabled and generous velocity params.
+mrpt::containers::yaml gnss_config(bool fuse_z = false)
+{
+    auto cfg                                   = get_default_config();
+    cfg["params"]["gnss_enabled"]              = true;
+    cfg["params"]["gnss_max_horizontal_sigma"] = 0.20;
+    cfg["params"]["gnss_min_sigma_floor_xy"]   = 0.10;
+    cfg["params"]["gnss_min_sigma_floor_z"]    = 0.30;
+    cfg["params"]["gnss_fuse_z"]               = fuse_z;
+    return cfg;
+}
+
+mola::Georeferencing identity_georef()
+{
+    mola::Georeferencing g;
+    g.geo_coord    = mrpt::topography::TGeodeticCoords(kDatumLat, kDatumLon, kDatumAlt);
+    g.T_enu_to_map = mrpt::poses::CPose3DPDFGaussian();  // identity
+    return g;
+}
+
+// Creates a CObservationGPS with a GGA datum and an ENU covariance.
+mrpt::obs::CObservationGPS make_gps(
+    double lat, double lon, double alt, double sigma_h, double sigma_v, double t)
+{
+    mrpt::obs::CObservationGPS gps;
+    gps.timestamp = mrpt::Clock::fromDouble(t);
+
+    mrpt::obs::gnss::Message_NMEA_GGA gga;
+    gga.fields.latitude_degrees  = lat;
+    gga.fields.longitude_degrees = lon;
+    gga.fields.altitude_meters   = alt;
+    gga.fields.fix_quality       = 4;  // NMEA: 4 = RTK-fixed
+    gps.setMsg(gga);
+
+    auto cov = mrpt::math::CMatrixDouble33();
+    cov.setZero();
+    cov(0, 0)          = mrpt::square(sigma_h);
+    cov(1, 1)          = mrpt::square(sigma_h);
+    cov(2, 2)          = mrpt::square(sigma_v);
+    gps.covariance_enu = cov;
+    return gps;
+}
+
+// Returns the map-frame point (identity geo-ref) expected for a lat/lon/alt.
+mrpt::math::TPoint3D expected_enu(double lat, double lon, double alt)
+{
+    mrpt::math::TPoint3D enu;
+    mrpt::topography::geodeticToENU_WGS84(
+        mrpt::topography::TGeodeticCoords(lat, lon, alt), enu,
+        mrpt::topography::TGeodeticCoords(kDatumLat, kDatumLon, kDatumAlt));
+    return enu;
+}
+
+// Feeds two poses so that last_pose is set with the given (isotropic) variance.
+void seed_anchor(
+    mola::state_estimation_simple::StateEstimationSimple& est, const mrpt::poses::CPose3D& p,
+    double var)
+{
+    auto cov = mrpt::math::CMatrixDouble66::Identity();
+    cov *= var;
+    est.fuse_pose(mrpt::Clock::fromDouble(0.0), mrpt::poses::CPose3DPDFGaussian(p, cov), "map");
+    est.fuse_pose(mrpt::Clock::fromDouble(0.05), mrpt::poses::CPose3DPDFGaussian(p, cov), "map");
+}
+}  // namespace
+
+#if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)
+// Test 10: RTK fix pulls the anchor toward the absolute GNSS map position.
+void test_gnss_rtk_pulls_anchor()
+{
+    std::cout << "[Test 10] GNSS RTK pulls anchor... ";
+
+    mola::state_estimation_simple::StateEstimationSimple est;
+    est.initialize(gnss_config());
+    est.set_geo_reference(identity_georef());
+
+    // Uncertain anchor far from truth (large variance -> Kalman gain ~1).
+    seed_anchor(est, mrpt::poses::CPose3D(50, 60, 0), 100.0);
+
+    // GNSS ~30 m East / ~20 m North of the datum -> known ENU target.
+    const double lat = kDatumLat + 0.00018;  // ~ +20 m North
+    const double lon = kDatumLon + 0.00048;  // ~ +30 m East
+    const auto   tgt = expected_enu(lat, lon, kDatumAlt);
+    est.fuse_gnss(make_gps(lat, lon, kDatumAlt, 0.05, 0.10, 0.1));
+
+    auto s = est.estimated_navstate(mrpt::Clock::fromDouble(0.05), "map");
+    ASSERT_(s.has_value());
+    // High gain -> anchor should be very close to the GNSS map point in XY.
+    ASSERT_NEAR_(s->pose.mean.x(), tgt.x, 0.3);
+    ASSERT_NEAR_(s->pose.mean.y(), tgt.y, 0.3);
+
+    std::cout << "OK\n";
+}
+
+// Test 11: high-uncertainty (RTK-float) fixes are gated out; anchor unchanged.
+void test_gnss_gated_out()
+{
+    std::cout << "[Test 11] GNSS gate rejects noisy fixes... ";
+
+    mola::state_estimation_simple::StateEstimationSimple est;
+    est.initialize(gnss_config());
+    est.set_geo_reference(identity_georef());
+
+    seed_anchor(est, mrpt::poses::CPose3D(5, 6, 0), 100.0);
+
+    // sigma_h = 1.0 m > 0.20 gate -> must be ignored.
+    est.fuse_gnss(make_gps(kDatumLat + 0.0005, kDatumLon + 0.0005, kDatumAlt, 1.0, 1.0, 0.1));
+
+    auto s = est.estimated_navstate(mrpt::Clock::fromDouble(0.05), "map");
+    ASSERT_(s.has_value());
+    ASSERT_NEAR_(s->pose.mean.x(), 5.0, 1e-6);
+    ASSERT_NEAR_(s->pose.mean.y(), 6.0, 1e-6);
+
+    std::cout << "OK\n";
+}
+
+// Test 12: the covariance floor prevents a 2 cm RTK fix from collapsing the
+// ICP prior. The corrected anchor XY variance must not fall below ~floor^2.
+void test_gnss_covariance_floor()
+{
+    std::cout << "[Test 12] GNSS covariance floor honored... ";
+
+    mola::state_estimation_simple::StateEstimationSimple est;
+    // Shrink the additive relative-pose term so the prior sigma reflects the
+    // floored anchor variance almost directly, isolating the floor effect.
+    auto cfg                                    = gnss_config();
+    cfg["params"]["sigma_relative_pose_linear"] = 0.001;
+    est.initialize(cfg);
+    est.set_geo_reference(identity_georef());
+
+    seed_anchor(est, mrpt::poses::CPose3D(0, 0, 0), 100.0);
+
+    // Very tight RTK (2 cm). Without a floor, the anchor variance would drop to
+    // ~0.02^2 = 4e-4 (sigma 0.02); the 0.10 m floor keeps sigma near 0.10.
+    est.fuse_gnss(make_gps(kDatumLat, kDatumLon, kDatumAlt, 0.02, 0.02, 0.1));
+
+    // Query at the anchor stamp (dt=0): the prior XY variance is diagonal, so
+    // 1/cov_inv(0,0) recovers it. With the floor it is ~0.01 (sigma 0.10);
+    // without the floor it would be ~4e-4 (sigma 0.02).
+    auto s = est.estimated_navstate(mrpt::Clock::fromDouble(0.05), "map");
+    ASSERT_(s.has_value());
+    const double prior_sigma_x = std::sqrt(1.0 / s->pose.cov_inv(0, 0));
+    ASSERT_GT_(prior_sigma_x, 0.05);  // floor engaged (would be ~0.02 without it)
+    ASSERT_LT_(prior_sigma_x, 0.20);  // but not wildly larger than the 0.10 floor
+
+    std::cout << "OK\n";
+}
+
+// Test 13: the antenna lever arm is compensated using the anchor attitude.
+void test_gnss_lever_arm()
+{
+    std::cout << "[Test 13] GNSS antenna lever-arm... ";
+
+    mola::state_estimation_simple::StateEstimationSimple est;
+    est.initialize(gnss_config());
+    est.set_geo_reference(identity_georef());
+
+    // Anchor yawed +90 deg, uncertain.
+    seed_anchor(
+        est, mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, mrpt::DEG2RAD(90.0), 0, 0), 100.0);
+
+    // Antenna is 1 m forward (+X) of the vehicle. With yaw=90, +X_body -> +Y_map,
+    // so a fix AT the datum (ENU 0,0,0) implies vehicle at (0,-1,0).
+    auto gps       = make_gps(kDatumLat, kDatumLon, kDatumAlt, 0.05, 0.10, 0.1);
+    gps.sensorPose = mrpt::poses::CPose3D(1.0, 0, 0, 0, 0, 0);
+    est.fuse_gnss(gps);
+
+    auto s = est.estimated_navstate(mrpt::Clock::fromDouble(0.05), "map");
+    ASSERT_(s.has_value());
+    ASSERT_NEAR_(s->pose.mean.x(), 0.0, 0.2);
+    ASSERT_NEAR_(s->pose.mean.y(), -1.0, 0.2);
+
+    std::cout << "OK\n";
+}
+
+// Test 14: Z is not corrected unless gnss_fuse_z is enabled.
+void test_gnss_z_gating()
+{
+    std::cout << "[Test 14] GNSS Z fusion opt-in... ";
+
+    // (a) Z fusion OFF (default): anchor Z stays put despite a Z-offset fix.
+    {
+        mola::state_estimation_simple::StateEstimationSimple est;
+        est.initialize(gnss_config(/*fuse_z=*/false));
+        est.set_geo_reference(identity_georef());
+        seed_anchor(est, mrpt::poses::CPose3D(0, 0, 7.0), 100.0);
+        est.fuse_gnss(make_gps(kDatumLat, kDatumLon, kDatumAlt + 5.0, 0.05, 0.10, 0.1));
+        auto s = est.estimated_navstate(mrpt::Clock::fromDouble(0.05), "map");
+        ASSERT_(s.has_value());
+        ASSERT_NEAR_(s->pose.mean.z(), 7.0, 1e-6);
+    }
+    // (b) Z fusion ON: anchor Z is pulled toward the datum altitude (ENU z ~ 0).
+    {
+        mola::state_estimation_simple::StateEstimationSimple est;
+        est.initialize(gnss_config(/*fuse_z=*/true));
+        est.set_geo_reference(identity_georef());
+        seed_anchor(est, mrpt::poses::CPose3D(0, 0, 7.0), 100.0);
+        est.fuse_gnss(make_gps(kDatumLat, kDatumLon, kDatumAlt, 0.05, 0.10, 0.1));
+        auto s = est.estimated_navstate(mrpt::Clock::fromDouble(0.05), "map");
+        ASSERT_(s.has_value());
+        ASSERT_LT_(std::abs(s->pose.mean.z()), 1.0);  // pulled toward 0
+    }
+
+    std::cout << "OK\n";
+}
+
+// Test 15: with gnss_enabled=false the estimator ignores GNSS (legacy behavior),
+// even if a geo-reference is set.
+void test_gnss_disabled_ignores()
+{
+    std::cout << "[Test 15] GNSS disabled -> ignored... ";
+
+    mola::state_estimation_simple::StateEstimationSimple est;
+    est.initialize(get_default_config());  // gnss_enabled defaults to false
+    est.set_geo_reference(identity_georef());
+    seed_anchor(est, mrpt::poses::CPose3D(3, 4, 0), 100.0);
+    est.fuse_gnss(make_gps(kDatumLat + 0.0005, kDatumLon + 0.0005, kDatumAlt, 0.02, 0.02, 0.1));
+    auto s = est.estimated_navstate(mrpt::Clock::fromDouble(0.05), "map");
+    ASSERT_(s.has_value());
+    ASSERT_NEAR_(s->pose.mean.x(), 3.0, 1e-6);
+    ASSERT_NEAR_(s->pose.mean.y(), 4.0, 1e-6);
+
+    std::cout << "OK\n";
+}
+
+// Test 16: fixes reporting a non-positive (zero or negative) horizontal ENU
+// variance are invalid and must be rejected, so they never fabricate a
+// spuriously confident anchor correction.
+void test_gnss_bad_covariance_rejected()
+{
+    std::cout << "[Test 16] GNSS non-positive covariance rejected... ";
+
+    // (a) zero horizontal variance -> rejected.
+    {
+        mola::state_estimation_simple::StateEstimationSimple est;
+        est.initialize(gnss_config());
+        est.set_geo_reference(identity_georef());
+        seed_anchor(est, mrpt::poses::CPose3D(7, 8, 0), 100.0);
+
+        // sigma_h = 0 -> cov(0,0)=cov(1,1)=0 (invalid), inside the 0.20 m gate.
+        est.fuse_gnss(make_gps(kDatumLat, kDatumLon, kDatumAlt, 0.0, 0.10, 0.1));
+
+        auto s = est.estimated_navstate(mrpt::Clock::fromDouble(0.05), "map");
+        ASSERT_(s.has_value());
+        ASSERT_NEAR_(s->pose.mean.x(), 7.0, 1e-6);
+        ASSERT_NEAR_(s->pose.mean.y(), 8.0, 1e-6);
+    }
+
+    // (b) negative variance (corrupted reading) -> rejected.
+    {
+        mola::state_estimation_simple::StateEstimationSimple est;
+        est.initialize(gnss_config());
+        est.set_geo_reference(identity_georef());
+        seed_anchor(est, mrpt::poses::CPose3D(7, 8, 0), 100.0);
+
+        auto gps           = make_gps(kDatumLat, kDatumLon, kDatumAlt, 0.05, 0.10, 0.1);
+        auto cov           = *gps.covariance_enu;
+        cov(1, 1)          = -1.0;  // corrupt north variance
+        gps.covariance_enu = cov;
+        est.fuse_gnss(gps);
+
+        auto s = est.estimated_navstate(mrpt::Clock::fromDouble(0.05), "map");
+        ASSERT_(s.has_value());
+        ASSERT_NEAR_(s->pose.mean.x(), 7.0, 1e-6);
+        ASSERT_NEAR_(s->pose.mean.y(), 8.0, 1e-6);
+    }
+
+    std::cout << "OK\n";
+}
+
+// Test 17: a large 3D antenna lever arm (including a vertical component) is
+// fully compensated on all three axes when Z fusion is enabled.
+void test_gnss_significant_3d_lever_arm()
+{
+    std::cout << "[Test 17] GNSS significant 3D lever-arm... ";
+
+    // (a) Identity attitude: lever arm in map == lever arm in body, so the
+    // vehicle sits at -lever relative to the antenna fix.
+    {
+        mola::state_estimation_simple::StateEstimationSimple est;
+        est.initialize(gnss_config(/*fuse_z=*/true));
+        est.set_geo_reference(identity_georef());
+        seed_anchor(est, mrpt::poses::CPose3D(0, 0, 0), 100.0);
+
+        // Antenna 2 m forward, 0.5 m left, 1.5 m up (a mast-mounted GNSS):
+        auto gps       = make_gps(kDatumLat, kDatumLon, kDatumAlt, 0.05, 0.05, 0.1);
+        gps.sensorPose = mrpt::poses::CPose3D(2.0, 0.5, 1.5, 0, 0, 0);
+        est.fuse_gnss(gps);
+
+        auto s = est.estimated_navstate(mrpt::Clock::fromDouble(0.05), "map");
+        ASSERT_(s.has_value());
+        // Antenna fix is at the datum (0,0,0) in map; vehicle = -lever_arm.
+        ASSERT_NEAR_(s->pose.mean.x(), -2.0, 0.2);
+        ASSERT_NEAR_(s->pose.mean.y(), -0.5, 0.2);
+        ASSERT_NEAR_(s->pose.mean.z(), -1.5, 0.3);  // wider: Z uses the floor
+    }
+
+    // (b) Yaw=90 deg: +X_body -> +Y_map, +Y_body -> -X_map, Z unchanged. Same
+    // 2/0.5/1.5 lever arm now maps to a different map-frame offset, checking the
+    // attitude is actually applied to the lever arm.
+    {
+        mola::state_estimation_simple::StateEstimationSimple est;
+        est.initialize(gnss_config(/*fuse_z=*/true));
+        est.set_geo_reference(identity_georef());
+        seed_anchor(
+            est, mrpt::poses::CPose3D::FromXYZYawPitchRoll(0, 0, 0, mrpt::DEG2RAD(90.0), 0, 0),
+            100.0);
+
+        auto gps       = make_gps(kDatumLat, kDatumLon, kDatumAlt, 0.05, 0.05, 0.1);
+        gps.sensorPose = mrpt::poses::CPose3D(2.0, 0.5, 1.5, 0, 0, 0);
+        est.fuse_gnss(gps);
+
+        auto s = est.estimated_navstate(mrpt::Clock::fromDouble(0.05), "map");
+        ASSERT_(s.has_value());
+        // lever_map = R(90)*[2,0.5,1.5] = [-0.5, 2, 1.5]; vehicle = -lever_map.
+        ASSERT_NEAR_(s->pose.mean.x(), 0.5, 0.2);
+        ASSERT_NEAR_(s->pose.mean.y(), -2.0, 0.2);
+        ASSERT_NEAR_(s->pose.mean.z(), -1.5, 0.3);
+    }
+
+    std::cout << "OK\n";
+}
+#endif
+
 }  // namespace
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
@@ -655,6 +991,16 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
         test_icp_and_3d_odometry_fusion();
         test_velocity_kalman_filter();
         test_multirate_interleaved_velocity();
+#if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)
+        test_gnss_rtk_pulls_anchor();
+        test_gnss_gated_out();
+        test_gnss_covariance_floor();
+        test_gnss_lever_arm();
+        test_gnss_z_gating();
+        test_gnss_disabled_ignores();
+        test_gnss_bad_covariance_rejected();
+        test_gnss_significant_3d_lever_arm();
+#endif
 
         std::cout << "\nAll StateEstimationSimple tests passed!\n";
         return 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI support to recenter georeferencing to a user-specified map translation (`--set-t-enu-to-map-xyz`).
  * Added CLI option to configure the GNSS robust kernel threshold (`--gnss-huber-k`).
  * Enabled opt-in GNSS/RTK fusion in state estimation when a georeference is available, with configurable quality gating and optional Z fusion.
* **Bug Fixes**
  * Centered georeferencing translations are now consistently reflected in output and serialization.
  * GNSS fusion now applies quality checks, sigma limits, and antenna lever-arm compensation.
* **Tests**
  * Added unit tests for georeferencing recentering and expanded GNSS fusion tests across edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->