### PR TITLE
Fuse IMU absolute attitude into georeferencing and state estimation

### DIFF
--- a/.github/workflows/build-ros.yml
+++ b/.github/workflows/build-ros.yml
@@ -87,6 +87,25 @@ jobs:
             | tee /etc/apt/sources.list.d/ros2-testing.list > /dev/null
           apt-get update
 
+      # setup-ros resolves the ROS apt source package version via an
+      # unauthenticated call to api.github.com, which occasionally hits
+      # GitHub's rate limit and fails the whole job. Pre-configuring the apt
+      # repository here makes setup-ros detect it is already present and
+      # skip that lookup.
+      - name: Pre-configure ROS apt repository
+        if: matrix.docker_image != 'ubuntu:resolute'
+        run: |
+          curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+            -o /usr/share/keyrings/ros-archive-keyring.gpg
+          ros_channel="ros2"
+          if [ "${{ matrix.use_ros_testing }}" = "true" ]; then
+            ros_channel="ros2-testing"
+          fi
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
+            http://packages.ros.org/${ros_channel}/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" \
+            | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+          apt-get update
+
       - name: setup ROS environment
         if: matrix.docker_image != 'ubuntu:resolute'
         uses: ros-tooling/setup-ros@v0.7

--- a/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
+++ b/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
@@ -68,6 +68,36 @@ struct Cli
                                                   "3.0",
                                                   cmd};
 
+    TCLAP::ValueArg<double> argIMUAttitudeSigmaDeg{
+        "",
+        "imu-attitude-sigma-deg",
+        "IMU absolute-attitude roll/pitch uncertainty (degrees).",
+        false,
+        3.0,
+        "3.0",
+        cmd};
+
+    TCLAP::ValueArg<double> argIMUAttitudeYawSigmaDeg{
+        "",
+        "imu-attitude-yaw-sigma-deg",
+        "IMU absolute-attitude yaw (azimuth) uncertainty (degrees). Defaults higher "
+        "than the roll/pitch sigma since fused yaw (often magnetometer-based) is "
+        "typically noisier.",
+        false,
+        15.0,
+        "15.0",
+        cmd};
+
+    TCLAP::ValueArg<double> argIMUAttitudeAzimuthOffsetDeg{
+        "",
+        "imu-attitude-azimuth-offset-deg",
+        "Fixed calibration offset (degrees) between the IMU's zero-yaw reading and "
+        "true azimuth, e.g. due to sensor mounting or magnetic declination.",
+        false,
+        0.0,
+        "0.0",
+        cmd};
+
     TCLAP::ValueArg<double> argMinUncertaintyXYZ{
         "",
         "min-gnss-sigma",
@@ -113,6 +143,12 @@ struct Cli
         "", "no-imu-gravity",
         "Disable using IMU acceleration data for gravity alignment "
         "(enabled by default).",
+        cmd, false};
+
+    TCLAP::SwitchArg argNoIMUAttitude{
+        "", "no-imu-attitude",
+        "Disable using IMU absolute-attitude (orientation) data for full attitude "
+        "alignment, including azimuth (enabled by default).",
         cmd, false};
 
     TCLAP::ValueArg<std::string> argSetEnuToMapXYZ{
@@ -198,6 +234,23 @@ void run_sm_georef(Cli& cli)
     if (cli.argIMUGravitySigmaDeg.isSet())
     {
         p.imuGravityParams.imuGravitySigmaDeg = cli.argIMUGravitySigmaDeg.getValue();
+    }
+
+    if (cli.argNoIMUAttitude.getValue())
+    {
+        p.useIMUAttitudeAlignment = false;
+    }
+    if (cli.argIMUAttitudeSigmaDeg.isSet())
+    {
+        p.imuAttitudeParams.imuAttitudeSigmaDeg = cli.argIMUAttitudeSigmaDeg.getValue();
+    }
+    if (cli.argIMUAttitudeYawSigmaDeg.isSet())
+    {
+        p.imuAttitudeParams.imuAttitudeYawSigmaDeg = cli.argIMUAttitudeYawSigmaDeg.getValue();
+    }
+    if (cli.argIMUAttitudeAzimuthOffsetDeg.isSet())
+    {
+        p.imuAttitudeParams.azimuthOffsetDeg = cli.argIMUAttitudeAzimuthOffsetDeg.getValue();
     }
 
     mola::SMGeoReferencingOutput smGeo = mola::simplemap_georeference(sm, p);

--- a/mola_georeferencing/include/mola_georeferencing/simplemap_georeference.h
+++ b/mola_georeferencing/include/mola_georeferencing/simplemap_georeference.h
@@ -21,6 +21,7 @@
 #include <mrpt/system/COutputLogger.h>
 
 // GTSAM:
+#include <gtsam/geometry/Rot3.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/Values.h>
 
@@ -64,6 +65,22 @@ struct AddIMUGravityFactorParams
     double imuGravitySigmaDeg = 3.0;  // [deg]
 };
 
+struct AddIMUAttitudeFactorParams
+{
+    /// Sigma for the roll/pitch components of the absolute-attitude factor [deg].
+    double imuAttitudeSigmaDeg = 3.0;
+
+    /// Sigma for the yaw (azimuth) component [deg]. IMU-fused yaw (often
+    /// magnetometer-based) is typically much noisier than roll/pitch, hence
+    /// this defaults higher. Set equal to imuAttitudeSigmaDeg for isotropic
+    /// noise.
+    double imuAttitudeYawSigmaDeg = 15.0;
+
+    /// Fixed calibration offset (degrees) between the IMU's zero-yaw reading
+    /// and true azimuth, e.g. due to sensor mounting or magnetic declination.
+    double azimuthOffsetDeg = 0.0;
+};
+
 struct SMGeoReferencingParams
 {
     SMGeoReferencingParams() = default;
@@ -84,6 +101,14 @@ struct SMGeoReferencingParams
     /// optimization. This helps in cases with poor Z data in GPS.
     bool                      useIMUGravityAlignment = true;
     AddIMUGravityFactorParams imuGravityParams;
+
+    /// If true, use IMU absolute-orientation data (e.g. quaternion fields
+    /// filled in by an onboard AHRS) found in the simplemap to add full
+    /// attitude constraints (Pose3RotationFactor) to the optimization. Unlike
+    /// gravity-only alignment, this also observes azimuth (yaw), so it can
+    /// remove the need for GNSS to solve for it.
+    bool                       useIMUAttitudeAlignment = true;
+    AddIMUAttitudeFactorParams imuAttitudeParams;
 
     mrpt::system::COutputLogger* logger = nullptr;
 };
@@ -151,6 +176,51 @@ GNSSFrames extract_gnss_frames_from_sm(
     const std::optional<mrpt::topography::TGeodeticCoords>& refCoord          = std::nullopt,
     unsigned int                                            minimumFixQuality = 0);
 
+struct FrameIMU
+{
+    size_t               kf_index = 0;  //!< Index in the source CSimpleMap
+    mrpt::poses::CPose3D vehiclePose;
+    mrpt::poses::CPose3D sensorPoseOnVehicle;
+
+    /// Set if this keyframe has a valid gravity (accelerometer) observation.
+    std::optional<gtsam::Vector3> normalizedAcc;
+
+    /// Set if this keyframe has a valid absolute-orientation observation.
+    /// Stored raw (not yet corrected for the ENU/azimuth convention), since
+    /// that correction depends on AddIMUAttitudeFactorParams::azimuthOffsetDeg,
+    /// only known when factors are built, not at extraction time.
+    std::optional<gtsam::Rot3> rawAttitude;
+};
+
+struct IMUFrames
+{
+    std::vector<FrameIMU> frames;
+};
+
+/// Single pass over the simplemap collecting both gravity (accelerometer)
+/// and absolute-attitude (orientation) observations per keyframe.
+IMUFrames extract_imu_frames_from_sm(const mrpt::maps::CSimpleMap& sm);
+
+/// Adds MeasuredGravityFactor factors to the graph. Creates new P(kf_index)
+/// variables for keyframes not already present in \a existingPoseKeys.
+void add_imu_gravity_factors(
+    gtsam::NonlinearFactorGraph& fg, gtsam::Values& v, const IMUFrames& imuFrames,
+    const std::set<size_t>& existingPoseKeys, const AddIMUGravityFactorParams& params);
+
+/// Adds Pose3RotationFactor factors to the graph. Creates new P(kf_index)
+/// variables for keyframes not already present in \a existingPoseKeys.
+void add_imu_attitude_factors(
+    gtsam::NonlinearFactorGraph& fg, gtsam::Values& v, const IMUFrames& imuFrames,
+    const std::set<size_t>& existingPoseKeys, const AddIMUAttitudeFactorParams& params);
+
+void add_gnss_factors(
+    gtsam::NonlinearFactorGraph& fg, gtsam::Values& v, const GNSSFrames& frames,
+    const AddGNSSFactorParams& params);
+
+/// \deprecated Use FrameIMU instead. (Not itself tagged [[deprecated]] since
+/// it is only ever referenced through IMUAccFrames, whose own tag already
+/// flags it to callers; doing so here would additionally warn on every
+/// translation unit that merely includes this header.)
 struct FrameIMUAcc
 {
     size_t               kf_index = 0;  //!< Index in the source CSimpleMap
@@ -159,21 +229,14 @@ struct FrameIMUAcc
     gtsam::Vector3       normalizedAcc;
 };
 
-struct IMUAccFrames
-{
-    std::vector<FrameIMUAcc> frames;
-};
+/// \deprecated Use IMUFrames instead.
+struct [[deprecated("Use IMUFrames instead.")]] IMUAccFrames { std::vector<FrameIMUAcc> frames; };
 
-IMUAccFrames extract_imu_acc_frames_from_sm(const mrpt::maps::CSimpleMap& sm);
-
-/// Adds MeasuredGravityFactor factors to the graph. Creates new P(kf_index)
-/// variables for keyframes not already present in \a existingPoseKeys.
-void add_imu_gravity_factors(
-    gtsam::NonlinearFactorGraph& fg, gtsam::Values& v, const IMUAccFrames& imuFrames,
-    const std::set<size_t>& existingPoseKeys, const AddIMUGravityFactorParams& params);
-
-void add_gnss_factors(
-    gtsam::NonlinearFactorGraph& fg, gtsam::Values& v, const GNSSFrames& frames,
-    const AddGNSSFactorParams& params);
+/// \deprecated Use extract_imu_frames_from_sm() instead, which also extracts
+/// absolute-attitude readings alongside gravity ones. This wrapper is kept
+/// for backward compatibility and simply forwards to it, returning only the
+/// gravity (accelerometer) subset.
+[[deprecated("Use extract_imu_frames_from_sm() instead.")]] IMUAccFrames
+    extract_imu_acc_frames_from_sm(const mrpt::maps::CSimpleMap& sm);
 
 }  // namespace mola

--- a/mola_georeferencing/src/simplemap_georeference.cpp
+++ b/mola_georeferencing/src/simplemap_georeference.cpp
@@ -31,6 +31,8 @@
 #include <gtsam/slam/PriorFactor.h>
 #include <mola_gtsam_factors/FactorGnssEnu.h>
 #include <mola_gtsam_factors/MeasuredGravityFactor.h>
+#include <mola_gtsam_factors/Pose3RotationFactor.h>
+#include <mola_gtsam_factors/imu_helpers.h>
 
 #include <algorithm>
 #include <limits>
@@ -70,35 +72,49 @@ mola::SMGeoReferencingOutput mola::simplemap_georeference(
         existingPoseKeys.insert(f.kf_index);
     }
 
-    bool hasIMUGravityFactors = false;
-    if (params.useIMUGravityAlignment)
+    bool hasIMUGravityFactors  = false;
+    bool hasIMUAttitudeFactors = false;
+    if (params.useIMUGravityAlignment || params.useIMUAttitudeAlignment)
     {
-        const IMUAccFrames imuFrames = extract_imu_acc_frames_from_sm(sm);
+        const IMUFrames imuFrames = extract_imu_frames_from_sm(sm);
 
-        if (!imuFrames.frames.empty())
-        {
-            hasIMUGravityFactors = true;
-        }
+        const auto nGravity = std::count_if(
+            imuFrames.frames.begin(), imuFrames.frames.end(),
+            [](const FrameIMU& f) { return f.normalizedAcc.has_value(); });
+        const auto nAttitude = std::count_if(
+            imuFrames.frames.begin(), imuFrames.frames.end(),
+            [](const FrameIMU& f) { return f.rawAttitude.has_value(); });
 
         if (params.logger)
         {
             std::stringstream ss;
-            ss << "[simplemap_georeference] Found: " << imuFrames.frames.size()
-               << " IMU acceleration frames";
+            ss << "[simplemap_georeference] Found: " << nGravity
+               << " IMU gravity (accelerometer) frames, " << nAttitude
+               << " IMU absolute-attitude frames";
             params.logger->logStr(mrpt::system::LVL_INFO, ss.str());
         }
 
-        add_imu_gravity_factors(graph, v, imuFrames, existingPoseKeys, params.imuGravityParams);
+        if (params.useIMUGravityAlignment && nGravity > 0)
+        {
+            hasIMUGravityFactors = true;
+            add_imu_gravity_factors(graph, v, imuFrames, existingPoseKeys, params.imuGravityParams);
+        }
+        if (params.useIMUAttitudeAlignment && nAttitude > 0)
+        {
+            hasIMUAttitudeFactors = true;
+            add_imu_attitude_factors(
+                graph, v, imuFrames, existingPoseKeys, params.imuAttitudeParams);
+        }
     }
 
-    if (smFrames.frames.empty() && !hasIMUGravityFactors)
+    if (smFrames.frames.empty() && !hasIMUGravityFactors && !hasIMUAttitudeFactors)
     {
         if (params.logger)
         {
             params.logger->logStr(
                 mrpt::system::LVL_ERROR,
-                "The input simplemap seems not to have neither GNSS nor IMU acceleration data, so "
-                "no georeferencing/gravity alignment can be performed.");
+                "The input simplemap seems not to have neither GNSS nor IMU acceleration/attitude "
+                "data, so no georeferencing/gravity alignment can be performed.");
         }
         return ret;
     }
@@ -435,44 +451,10 @@ void mola::add_gnss_factors(
     }
 }
 
-namespace
+mola::IMUFrames mola::extract_imu_frames_from_sm(const mrpt::maps::CSimpleMap& sm)
 {
-bool imu_acceleration_seems_valid(const gtsam::Vector3& measuredGravity)
-{
-    const double norm = measuredGravity.norm();
-
-    // Accept both m/s² (~9.8) and already-normalized (~1.0) IMU outputs:
-    if (std::abs(norm - 9.8) > 2.0 && std::abs(norm - 1.0) > 0.2)
-    {
-        return false;
-    }
-
-    return true;
-}
-
-}  // namespace
-
-mola::IMUAccFrames mola::extract_imu_acc_frames_from_sm(const mrpt::maps::CSimpleMap& sm)
-{
-    IMUAccFrames ret;
+    IMUFrames ret;
     ret.frames.reserve(sm.size());
-
-    const auto addMeasurement = [&ret](
-                                    size_t kfIdx, const mrpt::poses::CPose3D& p,
-                                    const mrpt::poses::CPose3D& sensorPose,
-                                    const gtsam::Vector3&       measuredGravity)
-    {
-        if (!imu_acceleration_seems_valid(measuredGravity))
-        {
-            return;  // skip: not a valid gravity-like reading
-        }
-
-        auto& f               = ret.frames.emplace_back();
-        f.kf_index            = kfIdx;
-        f.vehiclePose         = p;
-        f.sensorPoseOnVehicle = sensorPose;
-        f.normalizedAcc       = measuredGravity.normalized();
-    };
 
     for (size_t kfIdx = 0; kfIdx < sm.size(); kfIdx++)
     {
@@ -483,24 +465,56 @@ mola::IMUAccFrames mola::extract_imu_acc_frames_from_sm(const mrpt::maps::CSimpl
 
         const auto p = pose->getMeanVal();
 
-        // 1) Process direct CObservationIMU, if available:
+        // 1) Process direct CObservationIMU observations, if available. A single
+        // observation may carry a gravity (accelerometer) reading, an absolute
+        // attitude (orientation) reading, or both:
         mrpt::obs::CObservationIMU::Ptr obs;
         for (size_t i = 0; !!(obs = sf->getObservationByClass<mrpt::obs::CObservationIMU>(i)); i++)
         {
-            if (!obs->has(mrpt::obs::IMU_X_ACC) || !obs->has(mrpt::obs::IMU_Y_ACC) ||
-                !obs->has(mrpt::obs::IMU_Z_ACC))
+            std::optional<gtsam::Vector3> acc;
+            if (obs->has(mrpt::obs::IMU_X_ACC) && obs->has(mrpt::obs::IMU_Y_ACC) &&
+                obs->has(mrpt::obs::IMU_Z_ACC))
             {
-                continue;
+                const gtsam::Vector3 measuredGravity = {
+                    obs->get(mrpt::obs::IMU_X_ACC), obs->get(mrpt::obs::IMU_Y_ACC),
+                    obs->get(mrpt::obs::IMU_Z_ACC)};
+
+                if (mola::factors::imu_accel_looks_like_gravity(measuredGravity))
+                {
+                    acc = measuredGravity.normalized();
+                }
             }
 
-            const gtsam::Vector3 measuredGravity = {
-                obs->get(mrpt::obs::IMU_X_ACC), obs->get(mrpt::obs::IMU_Y_ACC),
-                obs->get(mrpt::obs::IMU_Z_ACC)};
+            std::optional<gtsam::Rot3> attitude;
+            if (obs->has(mrpt::obs::IMU_ORI_QUAT_W))
+            {
+                const double qw = obs->get(mrpt::obs::IMU_ORI_QUAT_W);
+                const double qx = obs->get(mrpt::obs::IMU_ORI_QUAT_X);
+                const double qy = obs->get(mrpt::obs::IMU_ORI_QUAT_Y);
+                const double qz = obs->get(mrpt::obs::IMU_ORI_QUAT_Z);
 
-            addMeasurement(kfIdx, p, obs->sensorPose, measuredGravity);
+                if (mola::factors::imu_quaternion_looks_valid(qw, qx, qy, qz))
+                {
+                    attitude = gtsam::Rot3::Quaternion(qw, qx, qy, qz);
+                }
+            }
+
+            if (!acc.has_value() && !attitude.has_value())
+            {
+                continue;  // nothing usable in this observation
+            }
+
+            auto& f               = ret.frames.emplace_back();
+            f.kf_index            = kfIdx;
+            f.vehiclePose         = p;
+            f.sensorPoseOnVehicle = obs->sensorPose;
+            f.normalizedAcc       = acc;
+            f.rawAttitude         = attitude;
         }
 
-        // 2) Process embedded IMU info embedded into the metadata:
+        // 2) Process embedded IMU acceleration info embedded into the metadata.
+        // (No absolute-attitude equivalent here: the buffered orientation is only
+        // gravity-leveled, not azimuth-referenced, so it is not usable for this.)
 #if defined(HAS_VELOCITY_BUFFER)
         mola::imu::LocalVelocityBuffer lvb;
         for (const auto& o : *sf)
@@ -516,7 +530,7 @@ mola::IMUAccFrames mola::extract_imu_acc_frames_from_sm(const mrpt::maps::CSimpl
         for (const auto& [t, measuredGravity] : lvb.get_linear_accelerations())
         {
             const auto acc = mrpt::gtsam_wrappers::toPoint3(measuredGravity);
-            if (imu_acceleration_seems_valid(acc))
+            if (mola::factors::imu_accel_looks_like_gravity(acc))
             {
                 avr_count++;
                 avr_acc += acc;
@@ -525,9 +539,11 @@ mola::IMUAccFrames mola::extract_imu_acc_frames_from_sm(const mrpt::maps::CSimpl
 
         if (avr_count > 0)
         {
-            addMeasurement(
-                kfIdx, p, mrpt::poses::CPose3D::Identity(),
-                avr_acc / static_cast<double>(avr_count));
+            auto& f               = ret.frames.emplace_back();
+            f.kf_index            = kfIdx;
+            f.vehiclePose         = p;
+            f.sensorPoseOnVehicle = mrpt::poses::CPose3D::Identity();
+            f.normalizedAcc       = (avr_acc / static_cast<double>(avr_count)).normalized();
         }
 
 #endif
@@ -537,7 +553,7 @@ mola::IMUAccFrames mola::extract_imu_acc_frames_from_sm(const mrpt::maps::CSimpl
 }
 
 void mola::add_imu_gravity_factors(
-    gtsam::NonlinearFactorGraph& fg, gtsam::Values& v, const IMUAccFrames& imuFrames,
+    gtsam::NonlinearFactorGraph& fg, gtsam::Values& v, const IMUFrames& imuFrames,
     const std::set<size_t>& existingPoseKeys, const AddIMUGravityFactorParams& params)
 {
     using gtsam::symbol_shorthand::P;
@@ -570,6 +586,11 @@ void mola::add_imu_gravity_factors(
 
     for (const auto& frame : imuFrames.frames)
     {
+        if (!frame.normalizedAcc.has_value())
+        {
+            continue;
+        }
+
         const auto key = P(frame.kf_index);
 
         // If this KF doesn't already have a P variable (from GNSS), create one:
@@ -584,6 +605,104 @@ void mola::add_imu_gravity_factors(
         const auto sensorOnVehicle = mrpt::gtsam_wrappers::toPose3(frame.sensorPoseOnVehicle);
 
         fg.emplace_shared<mola::factors::MeasuredGravityFactor>(
-            T(0), key, sensorOnVehicle, frame.normalizedAcc, accNoise);
+            T(0), key, sensorOnVehicle, *frame.normalizedAcc, accNoise);
     }
 }
+
+void mola::add_imu_attitude_factors(
+    gtsam::NonlinearFactorGraph& fg, gtsam::Values& v, const IMUFrames& imuFrames,
+    const std::set<size_t>& existingPoseKeys, const AddIMUAttitudeFactorParams& params)
+{
+    using gtsam::symbol_shorthand::P;
+    using gtsam::symbol_shorthand::T;
+
+    auto noisePoses = gtsam::noiseModel::Isotropic::Sigma(6, 1e-2);
+
+    // Roll, pitch, yaw sigmas (approximate correspondence to the Rot3 tangent-space
+    // residual near the optimum). Yaw is independently weighted since IMU-fused yaw
+    // (often magnetometer-based) is typically much noisier than roll/pitch:
+    auto attitudeNoise = gtsam::noiseModel::Diagonal::Sigmas(gtsam::Vector3(
+        mrpt::DEG2RAD(params.imuAttitudeSigmaDeg), mrpt::DEG2RAD(params.imuAttitudeSigmaDeg),
+        mrpt::DEG2RAD(params.imuAttitudeYawSigmaDeg)));
+
+    // If there were no GNSS frames, T(0) still exists in `v` (add_gnss_factors()
+    // always inserts it unconditionally), but with no prior tying down its
+    // *translation*: rotation-only factors (gravity and attitude alike) never
+    // constrain it, since composing poses and then extracting the rotation
+    // discards all translation components along the chain. Without GNSS, add a
+    // weak prior now to keep the linear system well-posed, even though attitude
+    // factors alone already observe T(0)'s full rotation (including azimuth):
+    if (existingPoseKeys.empty())
+    {
+        if (!v.exists(T(0)))
+        {
+            v.insert(T(0), gtsam::Pose3::Identity());
+        }
+
+        double weakSigma = 1.0;  // [rad] or [m], both loose enough not to bias real estimates
+
+        auto noisePriorT0 = gtsam::noiseModel::Isotropic::Sigma(6, weakSigma);
+        fg.emplace_shared<gtsam::PriorFactor<gtsam::Pose3>>(
+            T(0), gtsam::Pose3::Identity(), noisePriorT0);
+    }
+
+    for (const auto& frame : imuFrames.frames)
+    {
+        if (!frame.rawAttitude.has_value())
+        {
+            continue;
+        }
+
+        const auto key = P(frame.kf_index);
+
+        // If this KF doesn't already have a P variable (from GNSS or gravity), create one:
+        if (existingPoseKeys.count(frame.kf_index) == 0 && !v.exists(key))
+        {
+            const auto vehiclePose = mrpt::gtsam_wrappers::toPose3(frame.vehiclePose);
+            v.insert(key, vehiclePose);
+
+            fg.emplace_shared<gtsam::PriorFactor<gtsam::Pose3>>(key, vehiclePose, noisePoses);
+        }
+
+        const auto sensorOnVehicle = mrpt::gtsam_wrappers::toPose3(frame.sensorPoseOnVehicle);
+
+        const auto correctedAttitude = mola::factors::imu_apply_enu_azimuth_correction(
+            *frame.rawAttitude, params.azimuthOffsetDeg);
+
+        fg.emplace_shared<mola::factors::Pose3RotationFactor>(
+            T(0), key, sensorOnVehicle, correctedAttitude, attitudeNoise);
+    }
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+mola::IMUAccFrames mola::extract_imu_acc_frames_from_sm(const mrpt::maps::CSimpleMap& sm)
+{
+    const IMUFrames full = extract_imu_frames_from_sm(sm);
+
+    IMUAccFrames ret;
+    ret.frames.reserve(full.frames.size());
+
+    for (const auto& f : full.frames)
+    {
+        if (!f.normalizedAcc.has_value())
+        {
+            continue;
+        }
+
+        auto& out               = ret.frames.emplace_back();
+        out.kf_index            = f.kf_index;
+        out.vehiclePose         = f.vehiclePose;
+        out.sensorPoseOnVehicle = f.sensorPoseOnVehicle;
+        out.normalizedAcc       = *f.normalizedAcc;
+    }
+
+    return ret;
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif

--- a/mola_georeferencing/tests/CMakeLists.txt
+++ b/mola_georeferencing/tests/CMakeLists.txt
@@ -20,6 +20,13 @@ mola_add_test(
 )
 
 mola_add_test(
+  TARGET  test_imu_full_attitude
+  SOURCES test_imu_full_attitude.cpp
+  LINK_LIBRARIES
+    mola::mola_georeferencing
+)
+
+mola_add_test(
   TARGET  test_gnss_degeneracy
   SOURCES test_gnss_degeneracy.cpp
   LINK_LIBRARIES

--- a/mola_georeferencing/tests/test_imu_full_attitude.cpp
+++ b/mola_georeferencing/tests/test_imu_full_attitude.cpp
@@ -1,0 +1,300 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   test_imu_full_attitude.cpp
+ * @brief  Validates full-attitude (roll+pitch+yaw) IMU fusion in
+ *         simplemap_georeference() with synthetic, noisy data: recovering
+ *         azimuth from IMU alone (no GNSS), the azimuthOffsetDeg calibration
+ *         parameter, and combined gravity+attitude fusion.
+ */
+
+#include <gtsam/geometry/Rot3.h>
+#include <mola_georeferencing/simplemap_georeference.h>
+#include <mrpt/maps/CSimpleMap.h>
+#include <mrpt/obs/CObservationIMU.h>
+#include <mrpt/poses/CPose3DPDFGaussian.h>
+#include <mrpt/poses/gtsam_wrappers.h>
+
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <stdexcept>
+#include <string>
+
+namespace
+{
+void expect(bool cond, const std::string& msg)
+{
+    if (!cond)
+    {
+        throw std::runtime_error("Test assertion failed: " + msg);
+    }
+}
+
+// Signed angle difference (a-b), wrapped to (-180, 180] degrees.
+double angle_diff_deg(double a_deg, double b_deg)
+{
+    return std::fmod(a_deg - b_deg + 540.0, 360.0) - 180.0;
+}
+
+// Builds a simplemap with `nKeyframes` synthetic, independently-noisy IMU
+// absolute-orientation (quaternion) readings for a vehicle purely translating
+// (constant orientation) under a known ground-truth T_enu_to_map and sensor
+// mounting. `trueAzimuthOffsetDeg` simulates a real sensor-to-vehicle azimuth
+// miscalibration baked into the raw readings (as a real IMU driver would
+// report, before any user calibration is applied).
+mrpt::maps::CSimpleMap build_synthetic_attitude_map(
+    double roll_deg, double pitch_deg, double yaw_deg, double sensor_yaw_deg,
+    double trueAzimuthOffsetDeg, double noiseSigmaDeg, size_t nKeyframes, unsigned seed)
+{
+    mrpt::maps::CSimpleMap sm;
+
+    const mrpt::poses::CPose3D T_enu_to_map(
+        0, 0, 0, mrpt::DEG2RAD(yaw_deg), mrpt::DEG2RAD(pitch_deg), mrpt::DEG2RAD(roll_deg));
+    const mrpt::poses::CPose3D T_veh_to_sensor(0, 0, 0, mrpt::DEG2RAD(sensor_yaw_deg), 0, 0);
+
+    std::mt19937                     rng(seed);
+    std::normal_distribution<double> noise(0.0, mrpt::DEG2RAD(noiseSigmaDeg));
+
+    for (size_t i = 0; i < nKeyframes; i++)
+    {
+        const mrpt::poses::CPose3D T_map_to_veh(static_cast<double>(i) * 1.5, 0, 0, 0, 0, 0);
+
+        auto pose_pdf  = mrpt::poses::CPose3DPDFGaussian::Create();
+        pose_pdf->mean = T_map_to_veh;
+
+        auto sf = mrpt::obs::CSensoryFrame::Create();
+
+        auto obs_imu        = mrpt::obs::CObservationIMU::Create();
+        obs_imu->sensorPose = T_veh_to_sensor;
+
+        const mrpt::poses::CPose3D T_enu_to_sensor = T_enu_to_map + T_map_to_veh + T_veh_to_sensor;
+        const gtsam::Rot3 predicted = mrpt::gtsam_wrappers::toPose3(T_enu_to_sensor).rotation();
+
+        // Undo the fixed ENU convention (yaw=0 => East) plus the true azimuth
+        // offset, mirroring exactly the inverse of what
+        // mola::factors::imu_apply_enu_azimuth_correction() applies, to
+        // synthesize the raw reading a real IMU driver would report:
+        const gtsam::Rot3 rawAttitude =
+            gtsam::Rot3::Rz(mrpt::DEG2RAD(-(90.0 + trueAzimuthOffsetDeg))) * predicted;
+
+        // Inject independent per-sample orientation noise:
+        const gtsam::Rot3 noisyRaw =
+            gtsam::Rot3::Ypr(noise(rng), noise(rng), noise(rng)) * rawAttitude;
+
+        const auto q = noisyRaw.toQuaternion();
+        obs_imu->set(mrpt::obs::IMU_ORI_QUAT_W, q.w());
+        obs_imu->set(mrpt::obs::IMU_ORI_QUAT_X, q.x());
+        obs_imu->set(mrpt::obs::IMU_ORI_QUAT_Y, q.y());
+        obs_imu->set(mrpt::obs::IMU_ORI_QUAT_Z, q.z());
+
+        sf->insert(obs_imu);
+        sm.insert(pose_pdf, sf);
+    }
+
+    return sm;
+}
+
+void test_noisy_full_attitude_recovers_yaw_without_gnss()
+{
+    const double roll_deg = 4.0, pitch_deg = -6.0, yaw_deg = 35.0, sensor_yaw_deg = 20.0;
+    const double azimuthOffsetDeg = 0.0;
+    const double noiseSigmaDeg    = 3.0;
+    const size_t nKeyframes       = 40;
+
+    const auto sm = build_synthetic_attitude_map(
+        roll_deg, pitch_deg, yaw_deg, sensor_yaw_deg, azimuthOffsetDeg, noiseSigmaDeg, nKeyframes,
+        /*seed=*/42);
+
+    mola::SMGeoReferencingParams params;
+    params.useIMUGravityAlignment                   = false;
+    params.useIMUAttitudeAlignment                  = true;
+    params.imuAttitudeParams.imuAttitudeSigmaDeg    = noiseSigmaDeg;
+    params.imuAttitudeParams.imuAttitudeYawSigmaDeg = noiseSigmaDeg;
+    params.imuAttitudeParams.azimuthOffsetDeg       = azimuthOffsetDeg;
+
+    const auto out = mola::simplemap_georeference(sm, params);
+    expect(out.geo_ref.has_value(), "Georeferencing from IMU attitude alone should succeed");
+
+    const auto& T_est = out.geo_ref->T_enu_to_map.mean;
+
+    std::cout << "  [noisy attitude] Estimated RPY: (" << mrpt::RAD2DEG(T_est.roll()) << ", "
+              << mrpt::RAD2DEG(T_est.pitch()) << ", " << mrpt::RAD2DEG(T_est.yaw()) << ") deg\n";
+
+    const double tol_deg = 2.0;  // ~ noiseSigmaDeg / sqrt(nKeyframes), with margin
+    expect(
+        std::abs(angle_diff_deg(mrpt::RAD2DEG(T_est.roll()), roll_deg)) < tol_deg,
+        "roll should be recovered despite per-sample noise");
+    expect(
+        std::abs(angle_diff_deg(mrpt::RAD2DEG(T_est.pitch()), pitch_deg)) < tol_deg,
+        "pitch should be recovered despite per-sample noise");
+    expect(
+        std::abs(angle_diff_deg(mrpt::RAD2DEG(T_est.yaw()), yaw_deg)) < tol_deg,
+        "yaw (azimuth) should be recovered from IMU attitude alone, without any GNSS data");
+}
+
+void test_azimuth_offset_param_compensates_known_bias()
+{
+    const double roll_deg = 0.0, pitch_deg = 0.0, yaw_deg = 50.0, sensor_yaw_deg = 0.0;
+    const double trueAzimuthOffsetDeg = 12.0;  // e.g. sensor mounting misalignment
+    const double noiseSigmaDeg        = 1.0;
+    const size_t nKeyframes           = 30;
+
+    const auto sm = build_synthetic_attitude_map(
+        roll_deg, pitch_deg, yaw_deg, sensor_yaw_deg, trueAzimuthOffsetDeg, noiseSigmaDeg,
+        nKeyframes, /*seed=*/7);
+
+    // Case A: uncompensated (azimuthOffsetDeg left at its default, 0) -> yaw
+    // should end up biased by approximately the true (unmodeled) offset.
+    {
+        mola::SMGeoReferencingParams params;
+        params.useIMUGravityAlignment                   = false;
+        params.useIMUAttitudeAlignment                  = true;
+        params.imuAttitudeParams.imuAttitudeSigmaDeg    = 5.0;
+        params.imuAttitudeParams.imuAttitudeYawSigmaDeg = 5.0;
+        // params.imuAttitudeParams.azimuthOffsetDeg left at its default (0.0)
+
+        const auto out = mola::simplemap_georeference(sm, params);
+        expect(
+            out.geo_ref.has_value(), "Georeferencing should still succeed even if miscalibrated");
+
+        const double yaw_err_deg =
+            std::abs(angle_diff_deg(mrpt::RAD2DEG(out.geo_ref->T_enu_to_map.mean.yaw()), yaw_deg));
+
+        expect(
+            yaw_err_deg > trueAzimuthOffsetDeg - 2.0,
+            "leaving azimuthOffsetDeg uncompensated should bias yaw by ~ the true offset");
+    }
+
+    // Case B: compensated with the correct azimuthOffsetDeg -> yaw matches truth.
+    {
+        mola::SMGeoReferencingParams params;
+        params.useIMUGravityAlignment                   = false;
+        params.useIMUAttitudeAlignment                  = true;
+        params.imuAttitudeParams.imuAttitudeSigmaDeg    = noiseSigmaDeg;
+        params.imuAttitudeParams.imuAttitudeYawSigmaDeg = noiseSigmaDeg;
+        params.imuAttitudeParams.azimuthOffsetDeg       = trueAzimuthOffsetDeg;
+
+        const auto out = mola::simplemap_georeference(sm, params);
+        expect(out.geo_ref.has_value(), "Georeferencing should succeed once compensated");
+
+        const double yaw_err_deg =
+            std::abs(angle_diff_deg(mrpt::RAD2DEG(out.geo_ref->T_enu_to_map.mean.yaw()), yaw_deg));
+
+        expect(
+            yaw_err_deg < 1.5, "azimuthOffsetDeg correctly configured should recover the true yaw");
+    }
+}
+
+void test_gravity_and_attitude_factors_combine_without_conflict()
+{
+    // Build a map with BOTH noisy accelerometer and noisy full-attitude
+    // readings on the same observations, and check the combined optimization
+    // still recovers the ground truth (i.e. the two factor types agree).
+    const double roll_deg = 10.0, pitch_deg = 15.0, yaw_deg = -40.0, sensor_yaw_deg = 0.0;
+    const double noiseSigmaDeg = 2.0;
+    const size_t nKeyframes    = 30;
+
+    mrpt::maps::CSimpleMap sm;
+
+    const mrpt::poses::CPose3D T_enu_to_map(
+        0, 0, 0, mrpt::DEG2RAD(yaw_deg), mrpt::DEG2RAD(pitch_deg), mrpt::DEG2RAD(roll_deg));
+    const mrpt::poses::CPose3D  T_veh_to_sensor(0, 0, 0, mrpt::DEG2RAD(sensor_yaw_deg), 0, 0);
+    const mrpt::math::TVector3D g_enu(0, 0, 9.81);
+
+    std::mt19937                     rng(123);
+    std::normal_distribution<double> ang_noise(0.0, mrpt::DEG2RAD(noiseSigmaDeg));
+    std::normal_distribution<double> acc_noise(0.0, 0.15);  // [m/s^2]
+
+    for (size_t i = 0; i < nKeyframes; i++)
+    {
+        const mrpt::poses::CPose3D T_map_to_veh(static_cast<double>(i) * 1.5, 0, 0, 0, 0, 0);
+
+        auto pose_pdf  = mrpt::poses::CPose3DPDFGaussian::Create();
+        pose_pdf->mean = T_map_to_veh;
+
+        auto sf = mrpt::obs::CSensoryFrame::Create();
+
+        auto obs_imu        = mrpt::obs::CObservationIMU::Create();
+        obs_imu->sensorPose = T_veh_to_sensor;
+
+        const mrpt::poses::CPose3D T_enu_to_sensor = T_enu_to_map + T_map_to_veh + T_veh_to_sensor;
+
+        // Noisy gravity (accelerometer) reading:
+        mrpt::math::TVector3D a_sensor = T_enu_to_sensor.inverseRotateVector(g_enu);
+        a_sensor.x += acc_noise(rng);
+        a_sensor.y += acc_noise(rng);
+        a_sensor.z += acc_noise(rng);
+        obs_imu->set(mrpt::obs::IMU_X_ACC, a_sensor.x);
+        obs_imu->set(mrpt::obs::IMU_Y_ACC, a_sensor.y);
+        obs_imu->set(mrpt::obs::IMU_Z_ACC, a_sensor.z);
+
+        // Noisy full-attitude (quaternion) reading, zero calibration offset:
+        const gtsam::Rot3 predicted   = mrpt::gtsam_wrappers::toPose3(T_enu_to_sensor).rotation();
+        const gtsam::Rot3 rawAttitude = gtsam::Rot3::Rz(mrpt::DEG2RAD(-90.0)) * predicted;
+        const gtsam::Rot3 noisyRaw =
+            gtsam::Rot3::Ypr(ang_noise(rng), ang_noise(rng), ang_noise(rng)) * rawAttitude;
+        const auto q = noisyRaw.toQuaternion();
+        obs_imu->set(mrpt::obs::IMU_ORI_QUAT_W, q.w());
+        obs_imu->set(mrpt::obs::IMU_ORI_QUAT_X, q.x());
+        obs_imu->set(mrpt::obs::IMU_ORI_QUAT_Y, q.y());
+        obs_imu->set(mrpt::obs::IMU_ORI_QUAT_Z, q.z());
+
+        sf->insert(obs_imu);
+        sm.insert(pose_pdf, sf);
+    }
+
+    mola::SMGeoReferencingParams params;
+    params.useIMUGravityAlignment                   = true;
+    params.useIMUAttitudeAlignment                  = true;
+    params.imuGravityParams.imuGravitySigmaDeg      = 3.0;
+    params.imuAttitudeParams.imuAttitudeSigmaDeg    = noiseSigmaDeg;
+    params.imuAttitudeParams.imuAttitudeYawSigmaDeg = noiseSigmaDeg;
+
+    const auto out = mola::simplemap_georeference(sm, params);
+    expect(out.geo_ref.has_value(), "Combined gravity+attitude georeferencing should succeed");
+
+    const auto&  T_est   = out.geo_ref->T_enu_to_map.mean;
+    const double tol_deg = 2.0;
+    expect(
+        std::abs(angle_diff_deg(mrpt::RAD2DEG(T_est.roll()), roll_deg)) < tol_deg,
+        "combined gravity+attitude: roll recovered");
+    expect(
+        std::abs(angle_diff_deg(mrpt::RAD2DEG(T_est.pitch()), pitch_deg)) < tol_deg,
+        "combined gravity+attitude: pitch recovered");
+    expect(
+        std::abs(angle_diff_deg(mrpt::RAD2DEG(T_est.yaw()), yaw_deg)) < tol_deg,
+        "combined gravity+attitude: yaw recovered");
+}
+
+}  // namespace
+
+int main()
+{
+    try
+    {
+        test_noisy_full_attitude_recovers_yaw_without_gnss();
+        test_azimuth_offset_param_compensates_known_bias();
+        test_gravity_and_attitude_factors_combine_without_conflict();
+
+        std::cout << "\n[Success] All IMU full-attitude fusion tests passed!" << std::endl;
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "\n[Test Failed] " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/mola_georeferencing/tests/test_imu_full_attitude.cpp
+++ b/mola_georeferencing/tests/test_imu_full_attitude.cpp
@@ -57,16 +57,19 @@ double angle_diff_deg(double a_deg, double b_deg)
 // report, before any user calibration is applied).
 mrpt::maps::CSimpleMap build_synthetic_attitude_map(
     double roll_deg, double pitch_deg, double yaw_deg, double sensor_yaw_deg,
-    double trueAzimuthOffsetDeg, double noiseSigmaDeg, size_t nKeyframes, unsigned seed)
+    double trueAzimuthOffsetDeg, double noiseSigmaDeg, size_t nKeyframes, unsigned seed,
+    bool addGravity = false, double accNoiseSigma = 0.15)
 {
     mrpt::maps::CSimpleMap sm;
 
     const mrpt::poses::CPose3D T_enu_to_map(
         0, 0, 0, mrpt::DEG2RAD(yaw_deg), mrpt::DEG2RAD(pitch_deg), mrpt::DEG2RAD(roll_deg));
-    const mrpt::poses::CPose3D T_veh_to_sensor(0, 0, 0, mrpt::DEG2RAD(sensor_yaw_deg), 0, 0);
+    const mrpt::poses::CPose3D  T_veh_to_sensor(0, 0, 0, mrpt::DEG2RAD(sensor_yaw_deg), 0, 0);
+    const mrpt::math::TVector3D g_enu(0, 0, 9.81);
 
     std::mt19937                     rng(seed);
     std::normal_distribution<double> noise(0.0, mrpt::DEG2RAD(noiseSigmaDeg));
+    std::normal_distribution<double> acc_noise(0.0, accNoiseSigma);
 
     for (size_t i = 0; i < nKeyframes; i++)
     {
@@ -81,6 +84,19 @@ mrpt::maps::CSimpleMap build_synthetic_attitude_map(
         obs_imu->sensorPose = T_veh_to_sensor;
 
         const mrpt::poses::CPose3D T_enu_to_sensor = T_enu_to_map + T_map_to_veh + T_veh_to_sensor;
+
+        if (addGravity)
+        {
+            // Noisy gravity (accelerometer) reading:
+            mrpt::math::TVector3D a_sensor = T_enu_to_sensor.inverseRotateVector(g_enu);
+            a_sensor.x += acc_noise(rng);
+            a_sensor.y += acc_noise(rng);
+            a_sensor.z += acc_noise(rng);
+            obs_imu->set(mrpt::obs::IMU_X_ACC, a_sensor.x);
+            obs_imu->set(mrpt::obs::IMU_Y_ACC, a_sensor.y);
+            obs_imu->set(mrpt::obs::IMU_Z_ACC, a_sensor.z);
+        }
+
         const gtsam::Rot3 predicted = mrpt::gtsam_wrappers::toPose3(T_enu_to_sensor).rotation();
 
         // Undo the fixed ENU convention (yaw=0 => East) plus the true azimuth
@@ -207,54 +223,9 @@ void test_gravity_and_attitude_factors_combine_without_conflict()
     const double noiseSigmaDeg = 2.0;
     const size_t nKeyframes    = 30;
 
-    mrpt::maps::CSimpleMap sm;
-
-    const mrpt::poses::CPose3D T_enu_to_map(
-        0, 0, 0, mrpt::DEG2RAD(yaw_deg), mrpt::DEG2RAD(pitch_deg), mrpt::DEG2RAD(roll_deg));
-    const mrpt::poses::CPose3D  T_veh_to_sensor(0, 0, 0, mrpt::DEG2RAD(sensor_yaw_deg), 0, 0);
-    const mrpt::math::TVector3D g_enu(0, 0, 9.81);
-
-    std::mt19937                     rng(123);
-    std::normal_distribution<double> ang_noise(0.0, mrpt::DEG2RAD(noiseSigmaDeg));
-    std::normal_distribution<double> acc_noise(0.0, 0.15);  // [m/s^2]
-
-    for (size_t i = 0; i < nKeyframes; i++)
-    {
-        const mrpt::poses::CPose3D T_map_to_veh(static_cast<double>(i) * 1.5, 0, 0, 0, 0, 0);
-
-        auto pose_pdf  = mrpt::poses::CPose3DPDFGaussian::Create();
-        pose_pdf->mean = T_map_to_veh;
-
-        auto sf = mrpt::obs::CSensoryFrame::Create();
-
-        auto obs_imu        = mrpt::obs::CObservationIMU::Create();
-        obs_imu->sensorPose = T_veh_to_sensor;
-
-        const mrpt::poses::CPose3D T_enu_to_sensor = T_enu_to_map + T_map_to_veh + T_veh_to_sensor;
-
-        // Noisy gravity (accelerometer) reading:
-        mrpt::math::TVector3D a_sensor = T_enu_to_sensor.inverseRotateVector(g_enu);
-        a_sensor.x += acc_noise(rng);
-        a_sensor.y += acc_noise(rng);
-        a_sensor.z += acc_noise(rng);
-        obs_imu->set(mrpt::obs::IMU_X_ACC, a_sensor.x);
-        obs_imu->set(mrpt::obs::IMU_Y_ACC, a_sensor.y);
-        obs_imu->set(mrpt::obs::IMU_Z_ACC, a_sensor.z);
-
-        // Noisy full-attitude (quaternion) reading, zero calibration offset:
-        const gtsam::Rot3 predicted   = mrpt::gtsam_wrappers::toPose3(T_enu_to_sensor).rotation();
-        const gtsam::Rot3 rawAttitude = gtsam::Rot3::Rz(mrpt::DEG2RAD(-90.0)) * predicted;
-        const gtsam::Rot3 noisyRaw =
-            gtsam::Rot3::Ypr(ang_noise(rng), ang_noise(rng), ang_noise(rng)) * rawAttitude;
-        const auto q = noisyRaw.toQuaternion();
-        obs_imu->set(mrpt::obs::IMU_ORI_QUAT_W, q.w());
-        obs_imu->set(mrpt::obs::IMU_ORI_QUAT_X, q.x());
-        obs_imu->set(mrpt::obs::IMU_ORI_QUAT_Y, q.y());
-        obs_imu->set(mrpt::obs::IMU_ORI_QUAT_Z, q.z());
-
-        sf->insert(obs_imu);
-        sm.insert(pose_pdf, sf);
-    }
+    const auto sm = build_synthetic_attitude_map(
+        roll_deg, pitch_deg, yaw_deg, sensor_yaw_deg, /*trueAzimuthOffsetDeg=*/0.0, noiseSigmaDeg,
+        nKeyframes, /*seed=*/123, /*addGravity=*/true, /*accNoiseSigma=*/0.15);
 
     mola::SMGeoReferencingParams params;
     params.useIMUGravityAlignment                   = true;

--- a/mola_gtsam_factors/CMakeLists.txt
+++ b/mola_gtsam_factors/CMakeLists.txt
@@ -51,6 +51,7 @@ mola_add_library(
     include/mola_gtsam_factors/FactorTricycleKinematic.h
     include/mola_gtsam_factors/gtsam_detect_version.h
     include/mola_gtsam_factors/id.h
+    include/mola_gtsam_factors/imu_helpers.h
     include/mola_gtsam_factors/MapGravityFactor.h
     include/mola_gtsam_factors/MeasuredGravityFactor.h
     include/mola_gtsam_factors/Pose3RotationFactor.h
@@ -60,6 +61,7 @@ mola_add_library(
     src/FactorGnssMapEnu.cpp
     src/FactorTrapezoidalIntegrator.cpp
     src/FactorTricycleKinematic.cpp
+    src/imu_helpers.cpp
     src/MapGravityFactor.cpp
     src/MeasuredGravityFactor.cpp
     src/Pose3RotationFactor.cpp
@@ -74,8 +76,8 @@ mola_add_library(
 
 # -----------------------
 # define tests:
-#enable_testing()
-#add_subdirectory(module/tests)
+enable_testing()
+add_subdirectory(tests)
 
 # -----------------------------------------------------------------------------
 #  ROS2

--- a/mola_gtsam_factors/include/mola_gtsam_factors/imu_helpers.h
+++ b/mola_gtsam_factors/include/mola_gtsam_factors/imu_helpers.h
@@ -1,0 +1,50 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   imu_helpers.h
+ * @brief  Shared, dependency-light helpers to validate and convert raw IMU
+ *         readings into the types used by the IMU-related GTSAM factors.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 10, 2026
+ */
+
+#pragma once
+
+#include <gtsam/base/Vector.h>
+#include <gtsam/geometry/Rot3.h>
+
+namespace mola::factors
+{
+/** Returns true if the given accelerometer reading looks like a plausible
+ *  gravity vector, accepting either raw m/s^2 units (norm ~9.8) or an
+ *  already-normalized ("g") unit vector (norm ~1.0), as reported by
+ *  different IMU drivers.
+ */
+bool imu_accel_looks_like_gravity(const gtsam::Vector3& measuredAcc);
+
+/** Returns true if the given IMU absolute-orientation quaternion (w,x,y,z)
+ *  is finite and normalized, i.e. safe to convert into a gtsam::Rot3.
+ */
+bool imu_quaternion_looks_valid(double qw, double qx, double qy, double qz);
+
+/** Applies the fixed ENU-convention correction (yaw=0 => East) plus a
+ *  user-calibrated azimuth offset (e.g. sensor mounting or magnetic
+ *  declination) to a raw IMU attitude reading, so the result can be
+ *  compared against poses expressed in the ENU frame.
+ */
+gtsam::Rot3 imu_apply_enu_azimuth_correction(
+    const gtsam::Rot3& rawAttitude, double azimuthOffsetDeg);
+
+}  // namespace mola::factors

--- a/mola_gtsam_factors/src/imu_helpers.cpp
+++ b/mola_gtsam_factors/src/imu_helpers.cpp
@@ -1,0 +1,61 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   imu_helpers.cpp
+ * @brief  Shared, dependency-light helpers to validate and convert raw IMU
+ *         readings into the types used by the IMU-related GTSAM factors.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 10, 2026
+ */
+
+#include <mola_gtsam_factors/imu_helpers.h>
+
+#include <cmath>
+
+namespace
+{
+constexpr double kDeg2Rad = M_PI / 180.0;
+}
+
+namespace mola::factors
+{
+
+bool imu_accel_looks_like_gravity(const gtsam::Vector3& measuredAcc)
+{
+    const double norm = measuredAcc.norm();
+
+    // Accept both m/s^2 (~9.8) and already-normalized (~1.0) IMU outputs:
+    return std::abs(norm - 9.8) <= 2.0 || std::abs(norm - 1.0) <= 0.2;
+}
+
+bool imu_quaternion_looks_valid(double qw, double qx, double qy, double qz)
+{
+    if (std::isnan(qw) || std::isnan(qx) || std::isnan(qy) || std::isnan(qz))
+    {
+        return false;
+    }
+
+    const double norm = std::sqrt(qw * qw + qx * qx + qy * qy + qz * qz);
+    return std::abs(norm - 1.0) <= 0.02;
+}
+
+gtsam::Rot3 imu_apply_enu_azimuth_correction(
+    const gtsam::Rot3& rawAttitude, double azimuthOffsetDeg)
+{
+    // ENU convention: yaw=0 => East. Correct wrt true azimuth (north-referenced):
+    return gtsam::Rot3::Rz((90.0 + azimuthOffsetDeg) * kDeg2Rad) * rawAttitude;
+}
+
+}  // namespace mola::factors

--- a/mola_gtsam_factors/tests/CMakeLists.txt
+++ b/mola_gtsam_factors/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+# C++ unit tests:
+mola_add_test(
+  TARGET  test_imu_helpers
+  SOURCES test_imu_helpers.cpp
+  LINK_LIBRARIES
+    mola::mola_gtsam_factors
+)

--- a/mola_gtsam_factors/tests/test_imu_helpers.cpp
+++ b/mola_gtsam_factors/tests/test_imu_helpers.cpp
@@ -1,0 +1,119 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this package
+ alone or in combination with the complete SLAM system.
+*/
+
+#include <mola_gtsam_factors/imu_helpers.h>
+
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace
+{
+void expect(bool cond, const std::string& msg)
+{
+    if (!cond)
+    {
+        throw std::runtime_error("Test assertion failed: " + msg);
+    }
+}
+
+constexpr double kDeg2Rad = M_PI / 180.0;
+
+void test_imu_accel_looks_like_gravity()
+{
+    using mola::factors::imu_accel_looks_like_gravity;
+
+    expect(imu_accel_looks_like_gravity({0, 0, 9.81}), "raw m/s^2 gravity should be accepted");
+    expect(imu_accel_looks_like_gravity({0, 0, 1.0}), "normalized gravity should be accepted");
+    expect(
+        imu_accel_looks_like_gravity({5.0, 5.0, 6.9}),
+        "off-axis but plausible-norm gravity should be accepted");
+
+    expect(
+        !imu_accel_looks_like_gravity({0, 0, 0.05}), "too-small norm should not look like gravity");
+    expect(
+        !imu_accel_looks_like_gravity({0, 0, 20.0}), "too-large norm should not look like gravity");
+    expect(!imu_accel_looks_like_gravity({0, 0, 0}), "zero vector should not look like gravity");
+}
+
+void test_imu_quaternion_looks_valid()
+{
+    using mola::factors::imu_quaternion_looks_valid;
+
+    expect(imu_quaternion_looks_valid(1, 0, 0, 0), "identity quaternion should be valid");
+
+    // An arbitrary normalized quaternion:
+    const double n = std::sqrt(0.5 * 0.5 + 0.5 * 0.5 + 0.5 * 0.5 + 0.5 * 0.5);
+    expect(
+        imu_quaternion_looks_valid(0.5 / n, 0.5 / n, 0.5 / n, 0.5 / n),
+        "arbitrary normalized quaternion should be valid");
+
+    expect(!imu_quaternion_looks_valid(2, 0, 0, 0), "non-normalized quaternion should be invalid");
+    expect(!imu_quaternion_looks_valid(0, 0, 0, 0), "zero quaternion should be invalid");
+
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    expect(!imu_quaternion_looks_valid(nan, 0, 0, 0), "NaN quaternion should be invalid");
+}
+
+void test_imu_apply_enu_azimuth_correction()
+{
+    using mola::factors::imu_apply_enu_azimuth_correction;
+
+    // Definition under test: result = Rz(90deg + offset) * rawAttitude.
+    for (const double offsetDeg : {0.0, 10.0, -30.0, 179.0})
+    {
+        for (const auto& raw :
+             {gtsam::Rot3::Identity(),
+              gtsam::Rot3::Ypr(kDeg2Rad * 20, kDeg2Rad * 5, kDeg2Rad * -8)})
+        {
+            const auto got      = imu_apply_enu_azimuth_correction(raw, offsetDeg);
+            const auto expected = gtsam::Rot3::Rz((90.0 + offsetDeg) * kDeg2Rad) * raw;
+
+            expect(
+                got.equals(expected, 1e-9),
+                "imu_apply_enu_azimuth_correction should match Rz(90+offset)*raw for offset=" +
+                    std::to_string(offsetDeg));
+        }
+    }
+
+    // Sanity check in human terms: a raw reading with zero yaw/pitch/roll, once
+    // ENU-corrected with zero user offset, should point East-referenced yaw=90deg
+    // (i.e. North), matching the fixed convention constant used internally:
+    const auto   corrected = imu_apply_enu_azimuth_correction(gtsam::Rot3::Identity(), 0.0);
+    const double yaw_deg   = corrected.yaw() / kDeg2Rad;
+    expect(
+        std::abs(yaw_deg - 90.0) < 1e-6,
+        "zero-offset correction of identity attitude should yield yaw=90deg");
+}
+}  // namespace
+
+int main()
+{
+    try
+    {
+        test_imu_accel_looks_like_gravity();
+        test_imu_quaternion_looks_valid();
+        test_imu_apply_enu_azimuth_correction();
+
+        std::cout << "[Success] All imu_helpers tests passed!" << std::endl;
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "\n[Test Failed] " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -52,6 +52,7 @@
 #include <mola_gtsam_factors/FactorTricycleKinematic.h>
 #include <mola_gtsam_factors/MeasuredGravityFactor.h>
 #include <mola_gtsam_factors/Pose3RotationFactor.h>
+#include <mola_gtsam_factors/imu_helpers.h>
 
 // arguments: class_name, parent_class, class namespace
 IMPLEMENTS_MRPT_OBJECT(
@@ -411,30 +412,21 @@ void StateEstimationSmoother::fuse_imu(const mrpt::obs::CObservationIMU& imu)
     // -------------------------------------------------
     if (imu.has(mrpt::obs::IMU_ORI_QUAT_W))
     {
-        mrpt::math::CQuaternionDouble q;
-        q.w(imu.get(mrpt::obs::IMU_ORI_QUAT_W));
-        q.x(imu.get(mrpt::obs::IMU_ORI_QUAT_X));
-        q.y(imu.get(mrpt::obs::IMU_ORI_QUAT_Y));
-        q.z(imu.get(mrpt::obs::IMU_ORI_QUAT_Z));
-        if (std::isnan(q.w()) || std::isnan(q.x()) || std::isnan(q.y()) || std::isnan(q.z()))
+        const double qw = imu.get(mrpt::obs::IMU_ORI_QUAT_W);
+        const double qx = imu.get(mrpt::obs::IMU_ORI_QUAT_X);
+        const double qy = imu.get(mrpt::obs::IMU_ORI_QUAT_Y);
+        const double qz = imu.get(mrpt::obs::IMU_ORI_QUAT_Z);
+
+        if (!mola::factors::imu_quaternion_looks_valid(qw, qx, qy, qz))
         {
-            MRPT_LOG_THROTTLE_WARN(5.0, "Ignoring IMU orientation quaternion with NaN components");
-        }
-        else if (std::abs(q.norm() - 1.0) > 0.02)
-        {
-            MRPT_LOG_THROTTLE_WARN(5.0, "Ignoring non-normalized IMU orientation quaternion");
+            MRPT_LOG_THROTTLE_WARN(
+                5.0, "Ignoring invalid (NaN or non-normalized) IMU orientation quaternion");
         }
         else
         {
-            // correct heading:
-
-            // Convert MRPT quaternion to GTSAM Rot3. (GTSAM uses w,x,y,z order)
-            auto measuredRotation = gtsam::Rot3::Quaternion(q.w(), q.x(), q.y(), q.z());
-
-            // ENU is such yaw=0 ==> East. Correct this wrt Azimuth wrt true North:
-            measuredRotation =
-                gtsam::Rot3::Rz(mrpt::DEG2RAD(90.0 + params_.imu_attitude_azimuth_offset_deg)) *
-                measuredRotation;
+            // GTSAM uses w,x,y,z quaternion order:
+            const auto measuredRotation = mola::factors::imu_apply_enu_azimuth_correction(
+                gtsam::Rot3::Quaternion(qw, qx, qy, qz), params_.imu_attitude_azimuth_offset_deg);
 
             const auto sensorOnVehicle = mrpt::gtsam_wrappers::toPose3(imu.sensorPose);
 
@@ -459,8 +451,7 @@ void StateEstimationSmoother::fuse_imu(const mrpt::obs::CObservationIMU& imu)
             imu.get(mrpt::obs::IMU_Z_ACC)};
 
         // Some IMU drivers publishes normalized acc:
-        if (std::abs(measuredGravity.norm() - 9.8) < 2.0 ||
-            std::abs(measuredGravity.norm() - 1.0) < 0.2)
+        if (mola::factors::imu_accel_looks_like_gravity(measuredGravity))
         {
             const gtsam::Vector3 measuredGravityNormalized = measuredGravity.normalized();
 
@@ -639,7 +630,8 @@ void StateEstimationSmoother::fuse_pose_locked(
         // Remember this source's own last raw pose (in {odom_i}), the anchor
         // estimated_navstate() extrapolates from to keep the short-term
         // prediction continuous in the front end's own frame.
-        state_.last_raw_pose_by_source[frame_id_idx] = State::RawSourcePose{timestamp, poseSanitized};
+        state_.last_raw_pose_by_source[frame_id_idx] =
+            State::RawSourcePose{timestamp, poseSanitized};
     }
 }
 


### PR DESCRIPTION
## Summary
- `simplemap_georeference()` now fuses IMU absolute-orientation (quaternion) readings, not just raw accelerometer gravity, into the ENU-to-map optimization via `Pose3RotationFactor`. Unlike gravity-only alignment (roll/pitch), full attitude also observes azimuth (yaw), so georeferencing can recover a complete pose from IMU data alone, with no GNSS required.
- New `AddIMUAttitudeFactorParams` exposes independent roll/pitch vs. yaw noise sigmas and an `azimuthOffsetDeg` calibration term (sensor mounting / magnetic declination), wired into the `mola-sm-georeferencing` CLI (`--imu-attitude-*` flags).
- `extract_imu_acc_frames_from_sm()`/`IMUAccFrames` are kept as `[[deprecated]]` forwarding wrappers over the new unified `extract_imu_frames_from_sm()`/`IMUFrames`, which collects both gravity and attitude readings in a single pass over the simplemap.
- Deduplicated accelerometer-validity and quaternion-to-ENU-`Rot3` conversion logic that was copy-pasted between `mola_state_estimation_smoother` and `mola_georeferencing` into shared, dependency-light helpers in `mola_gtsam_factors/imu_helpers.h`, used by both packages.

## Test plan
- [x] New `mola_gtsam_factors/tests/test_imu_helpers.cpp`: unit tests for the shared helpers.
- [x] New `mola_georeferencing/tests/test_imu_full_attitude.cpp`: synthetic noisy-data tests — recovering full attitude (incl. yaw) from IMU alone without GNSS, validating `azimuthOffsetDeg`, and combined noisy gravity+attitude fusion.
- [x] Existing `test_imu_attitude`, `test_gnss_degeneracy`, `test_recenter_georeference`, smoother's `test-static-gnss-imu-orientation` and `test-lidar-imu-leveling` all still pass (no regressions from the refactor).
- [x] `mola-sm-georeferencing` CLI sanity check against the sample dataset still reproduces the expected georeferencing output.
- [x] clang-format-14 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IMU full-attitude alignment for roll, pitch, and yaw during georeferencing.
  * Added configuration for attitude uncertainty, yaw uncertainty, and azimuth offset calibration.
  * Added an option to disable IMU attitude alignment.
  * Improved IMU validation and ENU azimuth correction handling.

* **Bug Fixes**
  * IMU gravity and attitude data can now be combined reliably during alignment.

* **Tests**
  * Added coverage for full-attitude fusion, calibration offsets, gravity detection, and quaternion validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->