### PR TITLE
fix: relocalize mode (GNSS+IMU init against a known map) crashed or never converged

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ incremental optimization. The primary estimator for multi-sensor fusion.
 | ROS 2 launch | `mola_state_estimation_smoother/ros2-launchs/ros2-state-estimator.launch.py` |
 | MOLA-CLI launch | `mola_state_estimation_smoother/mola-cli-launchs/state_estimator_ros2.yaml` |
 | CLI app | `mola_state_estimation_smoother/apps/mola-navstate-cli.cpp` |
-| Tests (6) | `mola_state_estimation_smoother/tests/test-*.cpp` |
+| Tests (7) | `mola_state_estimation_smoother/tests/test-*.cpp` |
 | Integration tests | `mola_state_estimation_smoother/test/integration/test_*.py` |
 
 Key traits:
@@ -207,6 +207,69 @@ Major parameter groups:
 - **IMU**: attitude sigma, azimuth offset, gravity alignment sigma
 - **Georeferencing**: `estimate_geo_reference`, convergence thresholds
 - **Sensor filtering**: regex patterns to match/reject sensor labels
+
+## Relocalize mode (`estimate_geo_reference=false`, GNSS+IMU init against a known map)
+
+Found and fixed via MOLA + MVSIM end-to-end testing (loading a geo-referenced
+map, then relying purely on GNSS position + IMU attitude to recover the
+initial pose, no `FixedPose` seed):
+
+- **`set_geo_reference()` was unimplemented** (`StateEstimationSmoother` never
+  overrode `NavStateFilter`'s default no-op). Front ends (e.g.
+  `mola_lidar_odometry`) call this once a geo-referenced map is loaded, to
+  anchor `T_enu_to_map` to a known, fixed value instead of leaving it a free
+  variable. Without an override, `symbol_T_enu_to_map` kept its
+  construction-time `ENU2MAP_WEAK_SIGMA` (1e4, i.e. effectively
+  unconstrained) prior forever: every `Pose3RotationFactor`/
+  `MeasuredGravityFactor` only measures rotation *relative to*
+  `T_enu_to_map`, so with `T_enu_to_map` itself unpinned, the whole system's
+  absolute rotation was a genuine gauge freedom (a null space GTSAM can't
+  solve) -- reproduced as a `gtsam::IndeterminantLinearSystemException`
+  ("underconstrained variables") a few dozen keyframes into any run. Now
+  implemented: stores the geo-reference in `params_.fixed_geo_reference` and
+  calls `reset_locked()` (not `reinitialize_gtsam_locked()` directly --
+  that alone leaves stale pending `newValues`/`newFactors` around from the
+  load-params-time initialization, which throws "key already exists" on the
+  next `smoother.update()`).
+- **`estimated_navstate()` didn't catch exceptions** from
+  `get_latest_state_and_covariance()`'s `marginalCovariance()` calls, despite
+  its own `[[nodiscard]] std::optional<NavState>` signature promising a
+  graceful "not ready yet" for exactly this kind of case (an under-constrained
+  factor graph, expected transiently at the start of any fusion). The
+  exception propagated all the way up through the calling module's thread and
+  crashed it entirely (`MolaLauncherApp`: "thread ... ended due to an
+  exception"), killing GNSS/IMU fusion for the rest of the run. Now caught
+  and treated like the function's other early `return {};` paths.
+- **`has_converged_localization()` used the wrong criterion for relocalize
+  mode**: it returned `params_.estimate_geo_reference &&
+  state_.geo_reference.has_value()`, which is unconditionally false whenever
+  `estimate_geo_reference=false` (true by definition in relocalize mode,
+  where the geo-reference is fixed, not estimated) -- so relocalization could
+  never be reported as converged, no matter how good the GNSS+IMU fix
+  actually was. Now mode-aware: for `estimate_geo_reference=true`, unchanged
+  (sticky on `state_.geo_reference.has_value()`, since that's only ever set
+  once T_enu_to_map's own sigmas already passed the same thresholds); for
+  `estimate_geo_reference=false`, checks the vehicle's own latest pose
+  sigma (position + orientation) against `convergence_max_position_sigma`/
+  `convergence_max_orientation_sigma_deg` instead.
+- **`imu_attitude_azimuth_offset_deg` gotcha, not a bug**: `fuse_imu()`
+  unconditionally applies a `+90 deg` rotation to the IMU's reported
+  orientation, assuming raw IMU yaw is North-referenced ("yaw=0 => North",
+  common for a real magnetometer/compass) and needs that correction to
+  become ENU-referenced ("yaw=0 => East"). Simulators that report IMU
+  orientation directly in the world/ENU frame (confirmed with MVSIM) need
+  `imu_attitude_azimuth_offset_deg: -90` to cancel it out; forgetting this
+  produces a stable, self-consistent, but exactly 90 deg wrong localization
+  (high ICP goodness, high confidence -- easy to mistake for a real result).
+- **Steady-state position sigma is bounded by raw GNSS noise, not by
+  window duration**: with a real-time sliding-window filter (not a batch
+  averager), position sigma settles close to the raw single-fix GNSS noise
+  (e.g. ~1.2-2.0m steady-state for 1.5m raw noise), not indefinitely lower.
+  `convergence_max_position_sigma` and `mola_lidar_odometry`'s separate,
+  stricter `from_state_estimator_max_position_sigma` re-check both default
+  to sub-meter values tuned for better-than-1.5m GNSS; with noisier GNSS
+  they must be raised to match, or convergence will simply never be
+  reported (not wrong, just perpetually "not yet").
 
 ## Code style
 

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -175,7 +175,9 @@ class StateEstimationSmoother : public mola::NavStateFilter,
      *  ever measured). Re-initializes the smoother's factor graph, so it
      *  should be called before any run-relevant sensor fusion, not mid-run.
      */
+#if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)
     void set_geo_reference(const mola::Georeferencing& georef) override;
+#endif
 
     /** Integrates new twist estimation (in the odom frame) */
     void fuse_twist(

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -164,6 +164,19 @@ class StateEstimationSmoother : public mola::NavStateFilter,
     /** Integrates new GNSS observations into the estimator */
     void fuse_gnss(const mrpt::obs::CObservationGPS& gps) override;
 
+    /** Anchors T_enu_to_map to a known, fixed value (equivalent to setting
+     *  the `fixed_geo_reference` YAML parameter, but at runtime): used by
+     *  localization front-ends (e.g. mola_lidar_odometry) once they load a
+     *  geo-referenced map, so GNSS fixes constrain the vehicle's position in
+     *  that map's frame without the estimator also trying to solve for
+     *  T_enu_to_map itself (that combination leaves T_enu_to_map and every
+     *  fused Pose3RotationFactor/MeasuredGravityFactor-derived orientation
+     *  jointly underconstrained, since only their *relative* rotation is
+     *  ever measured). Re-initializes the smoother's factor graph, so it
+     *  should be called before any run-relevant sensor fusion, not mid-run.
+     */
+    void set_geo_reference(const mola::Georeferencing& georef) override;
+
     /** Integrates new twist estimation (in the odom frame) */
     void fuse_twist(
         const mrpt::Clock::time_point& timestamp, const mrpt::math::TTwist3D& twist,

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -269,6 +269,25 @@ void StateEstimationSmoother::reinitialize_gtsam_locked()
     state_.gtsam->newFactors.addPrior(symbol_T_enu_to_map, enu2map, enu2map_cov);
 }
 
+void StateEstimationSmoother::set_geo_reference(const mola::Georeferencing& georef)
+{
+    auto lck = mrpt::lockHelper(stateMutex_);
+
+    MRPT_LOG_INFO_STREAM(
+        "[set_geo_reference] Anchoring T_enu_to_map to a fixed, known value: "
+        << georef.T_enu_to_map.mean.asString());
+
+    params_.fixed_geo_reference = georef;
+
+    // reset_locked() clears state_ (including the gtsam pimpl's pending
+    // newValues/newFactors/newKeyStamps buffers, which already hold a
+    // symbol_T_enu_to_map entry from the load-params-time
+    // reinitialize_gtsam_locked() call) before re-running it -- calling
+    // reinitialize_gtsam_locked() directly here would try to insert that
+    // same key a second time into the still-pending newValues and throw.
+    reset_locked();
+}
+
 void StateEstimationSmoother::spinOnce()
 {
     // At the predefined module rate, publish the current estimation, if we have any subscriber:
@@ -639,7 +658,8 @@ void StateEstimationSmoother::fuse_pose_locked(
         // Remember this source's own last raw pose (in {odom_i}), the anchor
         // estimated_navstate() extrapolates from to keep the short-term
         // prediction continuous in the front end's own frame.
-        state_.last_raw_pose_by_source[frame_id_idx] = State::RawSourcePose{timestamp, poseSanitized};
+        state_.last_raw_pose_by_source[frame_id_idx] =
+            State::RawSourcePose{timestamp, poseSanitized};
     }
 }
 
@@ -746,7 +766,27 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
     }
 
     // Recover the closest state *in the reference frame*:
-    const NavState retKf = get_latest_state_and_covariance(*closesFrameIdx);
+    //
+    // get_latest_state_and_covariance() can throw if the factor graph is
+    // still under-constrained (e.g. GTSAM's marginalCovariance() failing
+    // with IndeterminantLinearSystemException): expected during the first
+    // instants of any fusion (not enough diverse sensor data yet to fully
+    // observe all 6 DOF), not a fatal error. Treat it the same as the other
+    // "not ready yet" early returns above rather than letting it propagate
+    // and take down the whole module thread.
+    NavState retKf;
+    try
+    {
+        retKf = get_latest_state_and_covariance(*closesFrameIdx);
+    }
+    catch (const std::exception& e)
+    {
+        MRPT_LOG_DEBUG_FMT(
+            "[estimated_navstate] State for KF %u not ready yet (factor graph likely still "
+            "under-constrained): %s",
+            static_cast<unsigned>(*closesFrameIdx), e.what());
+        return {};
+    }
 
     MRPT_TODO("Implement probabilistic extrapolation");
     // For now, approximate extrapolation only:
@@ -1892,15 +1932,85 @@ bool StateEstimationSmoother::has_converged_localization(
         return false;
     }
 
-    // Converged if we were told to estimate, and already have it:
-    const bool converged = params_.estimate_geo_reference && state_.geo_reference.has_value();
+    // A geo-reference is required before a pose in the reference ("map")
+    // frame is even meaningful -- either already estimated live
+    // (estimate_geo_reference=true) or fixed from a loaded geo-referenced
+    // map (relocalize mode, via set_geo_reference()).
+    if (!state_.geo_reference.has_value())
+    {
+        return false;
+    }
+
+    const auto& latestIt       = state_.stamp2frame_index.getDirectMap().rbegin();
+    const auto  latestFrameIdx = latestIt->second;
+
+    NavState ns;
+    try
+    {
+        ns = get_latest_state_and_covariance(latestFrameIdx);
+    }
+    catch (const std::exception& e)
+    {
+        // Factor graph still under-constrained: not converged yet, not a
+        // fatal error (see estimated_navstate(), which handles the same
+        // exception the same way).
+        MRPT_LOG_DEBUG_FMT(
+            "[has_converged_localization] State for KF %u not ready yet: %s",
+            static_cast<unsigned>(latestFrameIdx), e.what());
+        return false;
+    }
+
+    bool converged;
+    if (params_.estimate_geo_reference)
+    {
+        // Live-georeferencing mode: state_.geo_reference is only ever
+        // populated (see process_pending_gtsam_updates_locked()) once
+        // T_enu_to_map's OWN position+orientation sigmas already passed
+        // these same thresholds, and is sticky afterwards (a later,
+        // temporarily-worse per-frame vehicle-pose sigma -- e.g. right
+        // after a kinematics-only extrapolation past the last GNSS fix --
+        // must not un-converge an already-established geo-reference).
+        converged = true;
+    }
+    else
+    {
+        // Relocalize mode: state_.geo_reference is set up-front, before any
+        // GNSS/IMU fusion has actually happened (see set_geo_reference()),
+        // so its mere presence says nothing about whether the vehicle is
+        // actually localized yet. Use the vehicle's OWN latest pose
+        // uncertainty instead (this was the previous bug here: this
+        // function used to return `params_.estimate_geo_reference &&
+        // state_.geo_reference.has_value()`, unconditionally false in
+        // relocalize mode since estimate_geo_reference is false there by
+        // design -- so relocalization could never be reported as converged
+        // no matter how good the GNSS+IMU fix actually was).
+        const mrpt::math::CMatrixDouble66 poseCov = ns.pose.cov_inv.inverse_LLt();
+
+        const double pos_sigma_x   = std::sqrt(poseCov(0, 0));
+        const double pos_sigma_y   = std::sqrt(poseCov(1, 1));
+        const double pos_sigma_z   = std::sqrt(poseCov(2, 2));
+        const double max_pos_sigma = std::max({pos_sigma_x, pos_sigma_y, pos_sigma_z});
+
+        const double ori_sigma_yaw   = std::sqrt(poseCov(3, 3));
+        const double ori_sigma_pitch = std::sqrt(poseCov(4, 4));
+        const double ori_sigma_roll  = std::sqrt(poseCov(5, 5));
+        const double max_ori_sigma_deg =
+            mrpt::RAD2DEG(std::max({ori_sigma_yaw, ori_sigma_pitch, ori_sigma_roll}));
+
+        converged = max_pos_sigma <= params_.convergence_max_position_sigma &&
+                    max_ori_sigma_deg <= params_.convergence_max_orientation_sigma_deg;
+
+        MRPT_LOG_DEBUG_FMT(
+            "[has_converged_localization] converged=%s pos_sigmas=(%.3f,%.3f,%.3f) m "
+            "ori_sigmas=(%.2f,%.2f,%.2f) deg thresholds=(%.3f m, %.2f deg)",
+            converged ? "YES" : "NO", pos_sigma_x, pos_sigma_y, pos_sigma_z,
+            mrpt::RAD2DEG(ori_sigma_yaw), mrpt::RAD2DEG(ori_sigma_pitch),
+            mrpt::RAD2DEG(ori_sigma_roll), params_.convergence_max_position_sigma,
+            params_.convergence_max_orientation_sigma_deg);
+    }
 
     if (converged)
     {
-        const auto& latestIt       = state_.stamp2frame_index.getDirectMap().rbegin();
-        const auto  latestFrameIdx = latestIt->second;
-
-        const NavState ns = get_latest_state_and_covariance(latestFrameIdx);
         pose.copyFrom(ns.pose);
     }
 

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -269,6 +269,7 @@ void StateEstimationSmoother::reinitialize_gtsam_locked()
     state_.gtsam->newFactors.addPrior(symbol_T_enu_to_map, enu2map, enu2map_cov);
 }
 
+#if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)
 void StateEstimationSmoother::set_geo_reference(const mola::Georeferencing& georef)
 {
     auto lck = mrpt::lockHelper(stateMutex_);
@@ -287,6 +288,7 @@ void StateEstimationSmoother::set_geo_reference(const mola::Georeferencing& geor
     // same key a second time into the still-pending newValues and throw.
     reset_locked();
 }
+#endif
 
 void StateEstimationSmoother::spinOnce()
 {

--- a/mola_state_estimation_smoother/tests/CMakeLists.txt
+++ b/mola_state_estimation_smoother/tests/CMakeLists.txt
@@ -21,6 +21,13 @@ mola_add_test(
 )
 
 mola_add_test(
+  TARGET  test-relocalize-set-geo-reference
+  SOURCES test-relocalize-set-geo-reference.cpp
+  LINK_LIBRARIES
+    mola::mola_state_estimation_smoother
+)
+
+mola_add_test(
   TARGET  test-two-odometries
   SOURCES test-two-odometries.cpp
   LINK_LIBRARIES

--- a/mola_state_estimation_smoother/tests/test-relocalize-set-geo-reference.cpp
+++ b/mola_state_estimation_smoother/tests/test-relocalize-set-geo-reference.cpp
@@ -68,6 +68,14 @@
 using namespace std::string_literals;
 using namespace mrpt::literals;
 
+// This whole test exercises StateEstimationSmoother::set_geo_reference(),
+// which is only compiled in when the installed mola_kernel provides the
+// (optional) NavStateFilter::set_geo_reference()/get_geo_reference() virtual
+// methods -- see the same guard in StateEstimationSmoother.h/.cpp. Older
+// mola_kernel releases (pre-dating that interface addition) lack it, so skip
+// this test entirely rather than fail to compile against them.
+#if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)
+
 namespace
 {
 
@@ -279,3 +287,14 @@ int main()
         return 1;
     }
 }
+
+#else
+
+int main()
+{
+    std::cout << "\nSKIPPED: installed mola_kernel lacks "
+                 "NavStateFilter::set_geo_reference()/get_geo_reference()\n";
+    return 0;
+}
+
+#endif

--- a/mola_state_estimation_smoother/tests/test-relocalize-set-geo-reference.cpp
+++ b/mola_state_estimation_smoother/tests/test-relocalize-set-geo-reference.cpp
@@ -1,0 +1,281 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   test-relocalize-set-geo-reference.cpp
+ * @brief  Regression test for the "relocalize" front-end integration path
+ *         (a georeferenced map is already loaded; the geo-reference is
+ *         pushed in at runtime via set_geo_reference(), not via YAML at
+ *         load time). Covers three bugs fixed together (see
+ *         mola_state_estimation's AGENTS.md "Relocalize mode" section):
+ *
+ *         1. set_geo_reference() being an unimplemented no-op (T_enu_to_map
+ *            left effectively unconstrained, a GTSAM gauge freedom that
+ *            eventually throws IndeterminantLinearSystemException once
+ *            enough attitude factors accumulate) -- exercised here by fusing
+ *            readings both before and after calling set_geo_reference(), and
+ *            checking current_georeferencing() reflects the pushed value.
+ *         2. estimated_navstate() not catching that exception (crashing the
+ *            whole calling thread instead of returning std::nullopt like its
+ *            signature promises) -- exercised by fusing enough
+ *            pre-set_geo_reference() readings to reach the same
+ *            under-constrained state and confirming no exception escapes.
+ *         3. has_converged_localization() requiring estimate_geo_reference=
+ *            true unconditionally (impossible to satisfy in relocalize mode
+ *            by definition) -- exercised directly by asserting it returns
+ *            false (not throws) before set_geo_reference(), matching the
+ *            mode-aware logic's relocalize branch.
+ *
+ *         None of the other tests in this directory call set_geo_reference()
+ *         at runtime, so none of them covered this path before. This test
+ *         does not assert eventual GNSS+IMU convergence (has_converged_
+ *         localization() -> true): with a synthetically *perfectly static*
+ *         vehicle and independent per-reading IID noise (no correlated
+ *         integrator signal, unlike a real sensor stream), the
+ *         ConstantVelocity kinematic model's angular-velocity variable is
+ *         numerically singular (confirmed via a *different* GTSAM
+ *         IndeterminantLinearSystemException, on a W(k) symbol) -- a
+ *         separate, pre-existing numerical-conditioning question from the
+ *         three bugs above, out of scope here. End-to-end convergence
+ *         accuracy for this exact code path is validated instead against
+ *         real, correlated GNSS+IMU noise in MOLA + MVSIM simulation
+ *         (mola-georef-init's Phase 5, 5/5 repeated runs + 2 adversarial
+ *         variants, 5/5 each -- see that project's PLAN.md).
+ */
+
+#include <mola_kernel/interfaces/NavStateFilter.h>
+#include <mola_state_estimation_smoother/StateEstimationSmoother.h>
+#include <mrpt/core/get_env.h>
+#include <mrpt/math/CQuaternion.h>
+#include <mrpt/poses/CPose3D.h>
+#include <mrpt/random/RandomGenerators.h>
+#include <mrpt/topography/conversions.h>
+
+#include <iostream>
+#include <tuple>
+
+using namespace std::string_literals;
+using namespace mrpt::literals;
+
+namespace
+{
+
+constexpr double GNSS_NOISE_XY_M = 0.10;
+constexpr double GNSS_NOISE_Z_M  = 0.15;
+constexpr double IMU_NOISE_QUAT  = 0.01;
+
+const bool VERBOSE = mrpt::get_env<bool>("VERBOSE", false);
+
+const size_t numReadingsBeforeGeoRef = 5;  // fused with NO geo-reference yet
+const size_t numReadingsAfterGeoRef  = 30;
+const double T                       = 0.2;  // sensor period (5 Hz)
+
+auto& rng = mrpt::random::getRandomGenerator();
+
+const char* navStateParams =
+    R"###(# Config for Parameters
+params:
+    vehicle_frame_name: "base_link"
+    reference_frame_name: "map"
+    max_time_to_use_velocity_model: 2.0
+    kinematic_model: KinematicModel::ConstantVelocity
+    sliding_window_length: 8.0
+    min_time_difference_to_create_new_frame: 0.05
+    sigma_random_walk_acceleration_linear: 0.1
+    sigma_random_walk_acceleration_angular: 0.1
+    sigma_integrator_position: 0.02
+    sigma_integrator_orientation: 0.02
+
+    # No fixed_geo_reference here on purpose: it must arrive later, at
+    # runtime, via set_geo_reference() -- as mola_lidar_odometry does once
+    # it finishes loading a geo-referenced map.
+    estimate_geo_reference: false
+)###";
+
+using Pose = mrpt::poses::CPose3D;
+
+void fuse_one_gnss_imu_reading(
+    mola::state_estimation_smoother::StateEstimationSmoother& stateEst, double t,
+    const mrpt::topography::TGeodeticCoords& vehicleGeodetic, const Pose& actualImuPoseGlobal)
+{
+    // GNSS:
+    {
+        mrpt::obs::CObservationGPS obsGps;
+        obsGps.timestamp   = mrpt::Clock::fromDouble(t);
+        obsGps.sensorLabel = "gnss";
+
+        constexpr double gnss_noise_deg = GNSS_NOISE_XY_M * mrpt::RAD2DEG(1.0 / 6300e3);
+
+        mrpt::obs::gnss::Message_NMEA_GGA gga_msg;
+        gga_msg.fields.latitude_degrees =
+            vehicleGeodetic.lat + rng.drawGaussian1D(0, gnss_noise_deg);
+        gga_msg.fields.longitude_degrees =
+            vehicleGeodetic.lon + rng.drawGaussian1D(0, gnss_noise_deg);
+        gga_msg.fields.altitude_meters =
+            vehicleGeodetic.height + rng.drawGaussian1D(0, GNSS_NOISE_Z_M);
+        gga_msg.fields.fix_quality = 4;  // RTK fixed
+        obsGps.setMsg(gga_msg);
+
+        auto& cov = obsGps.covariance_enu.emplace();
+        cov.setIdentity();
+        cov(0, 0) = cov(1, 1) = mrpt::square(GNSS_NOISE_XY_M);
+        cov(2, 2)             = mrpt::square(GNSS_NOISE_Z_M);
+
+        stateEst.fuse_gnss(obsGps);
+    }
+
+    // IMU:
+    {
+        mrpt::obs::CObservationIMU obsImu;
+        obsImu.timestamp   = mrpt::Clock::fromDouble(t);
+        obsImu.sensorLabel = "imu";
+
+        mrpt::math::CQuaternionDouble gtQuatGlobal;
+        actualImuPoseGlobal.getAsQuaternion(gtQuatGlobal);
+
+        mrpt::math::CQuaternionDouble noisyQuat;
+        for (int k = 0; k < 4; k++)
+        {
+            noisyQuat[k] = gtQuatGlobal[k] + rng.drawGaussian1D(0, IMU_NOISE_QUAT);
+        }
+        noisyQuat.normalize();
+
+        obsImu.set(mrpt::obs::IMU_ORI_QUAT_W, noisyQuat.w());
+        obsImu.set(mrpt::obs::IMU_ORI_QUAT_X, noisyQuat.x());
+        obsImu.set(mrpt::obs::IMU_ORI_QUAT_Y, noisyQuat.y());
+        obsImu.set(mrpt::obs::IMU_ORI_QUAT_Z, noisyQuat.z());
+
+        const auto localUp = actualImuPoseGlobal.inverseRotateVector({0, 0, 9.81});
+        obsImu.set(mrpt::obs::IMU_X_ACC, localUp.x + rng.drawGaussian1D(0, 0.1));
+        obsImu.set(mrpt::obs::IMU_Y_ACC, localUp.y + rng.drawGaussian1D(0, 0.1));
+        obsImu.set(mrpt::obs::IMU_Z_ACC, localUp.z + rng.drawGaussian1D(0, 0.1));
+
+        obsImu.set(mrpt::obs::IMU_WX, rng.drawGaussian1D(0, 0.01));
+        obsImu.set(mrpt::obs::IMU_WY, rng.drawGaussian1D(0, 0.01));
+        obsImu.set(mrpt::obs::IMU_WZ, rng.drawGaussian1D(0, 0.01));
+
+        stateEst.onNewObservation(std::make_shared<const mrpt::obs::CObservationIMU>(obsImu));
+    }
+}
+
+void run_test()
+{
+    mola::state_estimation_smoother::StateEstimationSmoother stateEst;
+    if (VERBOSE)
+    {
+        stateEst.setMinLoggingLevel(mrpt::system::LVL_DEBUG);
+    }
+
+    {
+        auto cfgYaml = mrpt::containers::yaml::FromText(navStateParams);
+        stateEst.initialize(cfgYaml);
+    }
+
+    const auto actualVehiclePose =
+        Pose::FromXYZYawPitchRoll(5.0, -3.0, 0.2, 30.0_deg, 0.5_deg, -0.3_deg);
+    const auto vehicleToAzimuth =
+        mrpt::poses::CPose3D::FromYawPitchRoll(mrpt::DEG2RAD(-90.0), 0.0_deg, 0.0_deg);
+    const auto actualImuPoseGlobal = actualVehiclePose + vehicleToAzimuth;
+
+    mrpt::topography::TGeodeticCoords geoReference;
+    geoReference.lat    = 40.1234;
+    geoReference.lon    = -74.5678;
+    geoReference.height = 100.0;
+
+    mrpt::topography::TGeocentricCoords vehicleGeocentric;
+    mrpt::topography::ENUToGeocentric(
+        {actualVehiclePose.x(), actualVehiclePose.y(), actualVehiclePose.z()}, geoReference,
+        vehicleGeocentric, mrpt::topography::TEllipsoid::Ellipsoid_WGS84());
+    mrpt::topography::TGeodeticCoords vehicleGeodetic;
+    mrpt::topography::geocentricToGeodetic(vehicleGeocentric, vehicleGeodetic);
+
+    double t = 0;
+
+    // --- Phase A: fuse a few readings with NO geo-reference set yet -----
+    // Before the fix, this alone was enough to eventually leave
+    // symbol_T_enu_to_map's rotation an unconstrained GTSAM gauge freedom;
+    // has_converged_localization() must gracefully report "not converged",
+    // never throw.
+    for (size_t i = 0; i < numReadingsBeforeGeoRef; i++, t += T)
+    {
+        fuse_one_gnss_imu_reading(stateEst, t, vehicleGeodetic, actualImuPoseGlobal);
+
+        // In production, mola_lidar_odometry's periodic spinOnce() (via
+        // estimated_navstate()) flushes pending GTSAM factors/values ahead
+        // of any has_converged_localization() poll; replicate that here so
+        // this test exercises the same calling pattern. Two calls: ISAM2
+        // needs the *following* update() to fold a brand-new variable into
+        // a queryable BayesTree clique, so the very latest keyframe isn't
+        // reliably queryable after only one flush.
+        std::ignore = stateEst.estimated_navstate(mrpt::Clock::fromDouble(t), "map");
+        std::ignore = stateEst.estimated_navstate(mrpt::Clock::fromDouble(t), "map");
+
+        mrpt::poses::CPose3DPDFGaussian pose;
+        const bool                      converged = stateEst.has_converged_localization(pose);
+        ASSERT_(!converged);
+    }
+
+    // --- Phase B: push the geo-reference in at runtime, as a localization
+    // front-end (mola_lidar_odometry) does once it finishes loading a
+    // geo-referenced map -------------------------------------------------
+    mola::Georeferencing georef;
+    georef.geo_coord         = geoReference;
+    georef.T_enu_to_map.mean = mrpt::poses::CPose3D::Identity();
+    georef.T_enu_to_map.cov.setZero();
+    stateEst.set_geo_reference(georef);
+
+    // set_geo_reference() must have actually taken effect (bug 1's core
+    // defect: it used to be a silent no-op).
+    const auto storedGeoref = stateEst.current_georeferencing();
+    ASSERT_(storedGeoref.has_value());
+    ASSERT_(storedGeoref->geo_coord.lat == geoReference.lat);
+    ASSERT_(storedGeoref->geo_coord.lon == geoReference.lon);
+
+    // --- Phase C: fuse more readings past set_geo_reference() and confirm
+    // no exception ever escapes (bug 2) and has_converged_localization()
+    // stays well-defined (never throws) throughout, whatever it returns
+    // (bug 3's mode-aware logic path; see the file header for why this test
+    // doesn't additionally assert it eventually becomes true) -------------
+    for (size_t i = 0; i < numReadingsAfterGeoRef; i++, t += T)
+    {
+        fuse_one_gnss_imu_reading(stateEst, t, vehicleGeodetic, actualImuPoseGlobal);
+
+        std::ignore = stateEst.estimated_navstate(mrpt::Clock::fromDouble(t), "map");
+
+        mrpt::poses::CPose3DPDFGaussian pose;
+        std::ignore = stateEst.has_converged_localization(pose);
+    }
+
+    if (VERBOSE)
+    {
+        std::cout << "Ground truth: " << actualVehiclePose << "\n";
+    }
+}
+
+}  // namespace
+
+int main()
+{
+    try
+    {
+        run_test();
+        std::cout << "\n✅ SUCCESS\n";
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "\n❌ FAILED:\n" << e.what() << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary
Found via end-to-end MOLA + MVSIM simulation testing of geo-referencing-based initial pose estimation: a robot placed anywhere inside a previously-built, geo-referenced map should auto-localize using GNSS position + IMU global attitude fused by `StateEstimationSmoother`, seeding `mola_lidar_odometry`'s ICP via `InitLocalization::FromStateEstimator`. That scenario (`estimate_geo_reference=false`, i.e. "relocalize" mode as opposed to "live_georef" mode) was completely broken by three connected bugs:

1. **`set_geo_reference()` was unimplemented** — silently inherited the base class's no-op default, so a loaded map's `T_enu_to_map` never reached the smoother, leaving the vehicle's absolute rotation a genuine GTSAM gauge freedom. Crashed as `IndeterminantLinearSystemException` a few dozen keyframes into any run.
2. **`estimated_navstate()` didn't catch that exception**, despite its own `std::optional` return type promising a graceful "not ready yet" — it crashed the whole calling module thread instead, killing GNSS/IMU fusion for the rest of the run.
3. **`has_converged_localization()` required `estimate_geo_reference=true` unconditionally** — always false in relocalize mode by definition, so convergence could never be reported no matter how good the actual GNSS+IMU fix was.

Fixed all three; see the first commit for full detail on each.

## Test plan
- [x] New regression test `test-relocalize-set-geo-reference.cpp`, covering all three bugs (see its own commit and file header for exactly what it does and doesn't assert, and why)
- [x] `colcon test --packages-select mola_state_estimation_smoother`: 16/16 passed
- [x] clang-format-14 and clang-tidy clean (no new warnings in touched code; pre-existing warnings elsewhere in the file are untouched by this diff)
- [x] End-to-end MOLA + MVSIM simulation: relocalization main scenario passes 5/5 repeated runs, plus two adversarial variants (reversed heading, degraded GNSS) 5/5 each — previously crashed or never converged before this fix, in every run
- [x] `AGENTS.md` updated with the full bug-chain writeup

Companion PR in `mola_lidar_odometry` (two further bugs needed for the same end-to-end scenario to work): MOLAorg/mola_lidar_odometry#101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting a fixed geographic reference during relocalization.
  * Improved localization convergence reporting for relocalization and live georeferencing modes.

* **Bug Fixes**
  * Prevented exceptions when navigation state estimates are requested before the factor graph is sufficiently constrained.
  * Improved stability when checking localization status during startup and relocalization.

* **Tests**
  * Added end-to-end coverage for setting geographic references and continuing sensor fusion safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->