### PR TITLE
StateEstimationSmoother: actually rebuild the smoother on GTSAM failure

### DIFF
--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -1346,10 +1346,12 @@ void StateEstimationSmoother::process_pending_gtsam_updates_locked()
             "underconstrained or ill-conditioned). Resetting smoother state. Exception:\n"
             << e.what());
 
-        // Discard pending data and reset so the node can continue operating.
-        state_.gtsam->newFactors.resize(0);
-        state_.gtsam->newValues.clear();
-        state_.gtsam->newKeyStamps.clear();
+        // smoother.update() is not strongly exception-safe: a failed call can
+        // leave the iSAM2 Bayes tree internally inconsistent, so every later
+        // update would keep throwing the same way forever. Merely discarding
+        // the pending (not-yet-applied) factors/values/stamps does not fix
+        // that. Rebuild the smoother from scratch instead.
+        reset_locked();
         return;
     }
 
@@ -1421,12 +1423,13 @@ void StateEstimationSmoother::process_pending_gtsam_updates_locked()
     {
         MRPT_LOG_ERROR_STREAM(
             "[process_pending_gtsam_updates] GTSAM calculateEstimate() failed. "
-            "Discarding this update cycle. Exception:\n"
+            "Resetting smoother state. Exception:\n"
             << e.what());
 
-        state_.gtsam->newFactors.resize(0);
-        state_.gtsam->newValues.clear();
-        state_.gtsam->newKeyStamps.clear();
+        // Same reasoning as the update() catch above: calculateEstimate()
+        // failing after a successful update() still means the smoother is in
+        // a state we can't trust going forward, so rebuild it from scratch.
+        reset_locked();
         return;
     }
 


### PR DESCRIPTION
## Summary
- `process_pending_gtsam_updates_locked()`'s catch blocks around `smoother.update()`/`calculateEstimate()` logged "Resetting smoother state" but only cleared the pending `newFactors`/`newValues`/`newKeyStamps` queues -- the `state_.gtsam->smoother` (iSAM2) object itself was never rebuilt.
- iSAM2's `update()` is not strongly exception-safe, so a single failure can leave the Bayes tree internally inconsistent. Every subsequent tick then re-throws the same exception indefinitely.
- Observed in a live mvsim run: 1978 consecutive "GTSAM update failed" errors over ~113s, with no recovery, eventually feeding bad/stale state estimates to downstream consumers.
- Fix: call the existing `reset_locked()` (already used elsewhere, e.g. `set_geo_reference()`) in both catch blocks, matching what the log message already claimed was happening.

## Test plan
- [x] `colcon build --packages-select mola_state_estimation_smoother` clean
- [x] Live mvsim run driving a `NAVIGATE_ZONE` mission (idm-robots): with the fix, only 1 GTSAM failure occurred in the whole ~6-minute run (vs. 1978 before) and it self-recovered; no crash, all nodes stayed alive
- [x] Reviewer sign-off on rebuilding the whole smoother (vs. a narrower recovery) as the right failure-mode response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when smoothing updates or estimate calculations fail.
  * Automatically rebuilds the smoother after an internal processing error, helping prevent repeated failures and maintain reliable state estimation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->