### PR TITLE
fix(smoother): don't double-count the motion model when splicing a keyframe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@ Localization and mApping) framework. It fuses odometry, IMU, GNSS and pose
 measurements to estimate a vehicle's pose, velocity and orientation over time.
 It also provides offline georeferencing of keyframe-based maps.
 
+Rules: keep this AGENTS.md in sync with architecture/code changes. Use American
+spelling. Don't use en/em dashes. Don't sign commits as an AI agent. Keep 
+explanations short and general, not "this fixes the problem we had with XXX".
+Use clang-format-14 before commiting.
+
 License: GNU GPL v3 (commercial options available upon request).
 
 ## Repository layout

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -49,6 +49,7 @@
 #include <mutex>
 #include <optional>
 #include <set>
+#include <utility>
 
 namespace mola::state_estimation_smoother
 {
@@ -220,6 +221,17 @@ class StateEstimationSmoother : public mola::NavStateFilter,
      *  reached the solver. Returns a plain count so GTSAM stays out of this header.
      */
     [[nodiscard]] size_t count_const_vel_factors_for_testing() const;
+
+    /** Identifies each constant-velocity kinematic link currently live in the
+     *  underlying factor graph by its endpoint timestamps, one entry per link
+     *  (not per factor: each link emits two factors, linear and angular).
+     *
+     *  For tests only, to check the graph topology survives a splice as expected
+     *  (e.g. that the direct a->b link was replaced by a->n and n->b, not left
+     *  alongside them).
+     */
+    [[nodiscard]] std::set<std::pair<mrpt::Clock::time_point, mrpt::Clock::time_point>>
+        const_vel_factor_links_for_testing() const;
 
     /** @} */
 

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -212,6 +212,15 @@ class StateEstimationSmoother : public mola::NavStateFilter,
     /// Returns the current georeferencing, if available
     [[nodiscard]] std::optional<mola::Georeferencing> current_georeferencing() const;
 
+    /** Number of constant-velocity kinematic factors currently live in the
+     *  underlying factor graph (2 per kinematic link).
+     *
+     *  For tests only. It counts the real GTSAM graph rather than this class's own
+     *  link bookkeeping, so that a test can tell whether a factor removal actually
+     *  reached the solver. Returns a plain count so GTSAM stays out of this header.
+     */
+    [[nodiscard]] size_t count_const_vel_factors_for_testing() const;
+
     /** @} */
 
     // Implementation of RawDataConsumer
@@ -371,6 +380,15 @@ class StateEstimationSmoother : public mola::NavStateFilter,
         const mrpt::Clock::time_point&       stamp) const;
 
     void add_kinematic_factor_between(const frame_index_t from, const frame_index_t to);
+
+    /** Withdraws the kinematic link between two keyframes, undoing
+     *  add_kinematic_factor_between(). Needed when a new keyframe is spliced
+     *  between them: the direct link they used to share must go away, or its
+     *  constraint would be counted a second time alongside the two links that now
+     *  replace it. Cheap if the link has not reached the solver yet; otherwise its
+     *  factors are queued for removal at the next update().
+     */
+    void remove_kinematic_factor_between(const frame_index_t from, const frame_index_t to);
 
     /// Gets the latest state of a pose wrt the reference frame ("map")
     [[nodiscard]] NavState get_latest_state_and_covariance(const frame_index_t idx) const;

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -157,6 +157,15 @@ struct StateEstimationSmoother::GtsamImpl
 {
     GtsamImpl() = default;
 
+    /// Identifies the kinematic link between two keyframes. Links are undirected,
+    /// so the pair is normalized and (a,b) and (b,a) name the same link.
+    using frame_pair_t = std::pair<frame_index_t, frame_index_t>;
+
+    static frame_pair_t link_key(const frame_index_t a, const frame_index_t b)
+    {
+        return {std::min(a, b), std::max(a, b)};
+    }
+
     // This is initialized in initialize(), once we have the parameters
     std::optional<gtsam::IncrementalFixedLagSmoother> smoother;
 
@@ -164,6 +173,20 @@ struct StateEstimationSmoother::GtsamImpl
     gtsam::NonlinearFactorGraph              newFactors;
     gtsam::Values                            newValues;
     gtsam::FixedLagSmoother::KeyTimestampMap newKeyStamps;
+
+    /** Kinematic links built but not yet handed to iSAM2, keyed by the keyframe
+     *  pair they connect. Keeping them keyed, instead of appending straight into
+     *  newFactors, is what allows a link to be withdrawn again before it ever
+     *  reaches the solver, when a keyframe gets spliced between its endpoints.
+     */
+    std::map<frame_pair_t, gtsam::NonlinearFactorGraph> pendingKinematic;
+
+    /** iSAM2 factor indices of the kinematic links already inside the smoother,
+     *  so a link can be removed on a later splice. */
+    std::map<frame_pair_t, gtsam::FactorIndices> flushedKinematic;
+
+    /** Queued for removal at the next update(). */
+    gtsam::FactorIndices factorsToRemove;
 };
 
 // -------- StateEstimationSmoother::State -------
@@ -1022,6 +1045,11 @@ void StateEstimationSmoother::addFactor(const AbsFactorConstVelKinematics& f)
         MRPT_LOG_WARN_FMT("Constant-velocity kinematics factor added for large dT=%.03f s.", dt);
     }
 
+    // Emit into this link's own graph rather than straight into newFactors, so the
+    // whole link can be withdrawn as a unit if a keyframe is later spliced between
+    // its endpoints. Flushed into newFactors at the next update.
+    auto& sink = state_.gtsam->pendingKinematic[GtsamImpl::link_key(f.from_kf, f.to_kf)];
+
     // 1) Add GTSAM factors for constant velocity model
     // -------------------------------------------------
     const auto kTi  = T(f.from_kf);
@@ -1034,12 +1062,12 @@ void StateEstimationSmoother::addFactor(const AbsFactorConstVelKinematics& f)
     // See line 3 of eq (4) in the MOLA RSS2019 paper
     // Modify to use velocity in local frame: reuse FactorConstLocalVelocity
     // here too:
-    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
+    sink.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
         kTi, kbVi, kTj, kbVj, gtsam::noiseModel::Isotropic::Sigma(3, std_lin_vel * dt));
 
     // \omega is in the body frame, we need a special factor to rotate it:
     // See line 4 of eq (4) in the MOLA RSS2019 paper.
-    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
+    sink.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
         kTi, kbWi, kTj, kbWj, gtsam::noiseModel::Isotropic::Sigma(3, std_ang_vel * dt));
 
     // 2) Add kinematics / numerical integration factor
@@ -1051,11 +1079,11 @@ void StateEstimationSmoother::addFactor(const AbsFactorConstVelKinematics& f)
         gtsam::noiseModel::Isotropic::Sigma(3, params_.sigma_integrator_orientation);
 
     // Impl. line 2 of eq (1) in the MOLA RSS2019 paper
-    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorTrapezoidalIntegratorPose>(
+    sink.emplace_shared<mola::factors::FactorTrapezoidalIntegratorPose>(
         kTi, kbVi, kTj, kbVj, dt, noise_kinematicsPosition);
 
     // Impl. line 1 of eq (4) in the MOLA RSS2019 paper.
-    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorAngularVelocityIntegrationPose>(
+    sink.emplace_shared<mola::factors::FactorAngularVelocityIntegrationPose>(
         kTi, kbWi, kTj, dt, noise_kinematicsOrientation);
 }
 
@@ -1085,6 +1113,10 @@ void StateEstimationSmoother::addFactor(const AbsFactorTricycleKinematics& f)
         MRPT_LOG_WARN_FMT("Tricycle kinematics factor added for large dT=%.03f s.", dt);
     }
 
+    // See the note in the ConstantVelocity overload: emit into this link's own
+    // graph so it can be withdrawn as a unit on a later splice.
+    auto& sink = state_.gtsam->pendingKinematic[GtsamImpl::link_key(f.from_kf, f.to_kf)];
+
     // 1) Add GTSAM factors for constant velocity model
     // -------------------------------------------------
     const auto kTi  = T(f.from_kf);
@@ -1097,12 +1129,12 @@ void StateEstimationSmoother::addFactor(const AbsFactorTricycleKinematics& f)
     // See line 3 of eq (4) in the MOLA RSS2019 paper
     // Modify to use velocity in local frame: reuse FactorConstLocalVelocity
     // here too:
-    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
+    sink.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
         kTi, kbVi, kTj, kbVj, gtsam::noiseModel::Isotropic::Sigma(3, std_lin_vel * dt));
 
     // \omega is in the body frame, we need a special factor to rotate it:
     // See line 4 of eq (4) in the MOLA RSS2019 paper.
-    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
+    sink.emplace_shared<mola::factors::FactorConstLocalVelocityPose>(
         kTi, kbWi, kTj, kbWj, gtsam::noiseModel::Isotropic::Sigma(3, std_ang_vel * dt));
 
     // In the tricycle model, body v_y must be zero:
@@ -1110,14 +1142,14 @@ void StateEstimationSmoother::addFactor(const AbsFactorTricycleKinematics& f)
         const Eigen::Vector3d sigmas = {
             TRICYCLE_LARGE_SIGMAS, std_lin_vel * dt, TRICYCLE_LARGE_SIGMAS};
 
-        state_.gtsam->newFactors.emplace_shared<gtsam::PriorFactor<gtsam::Point3>>(
+        sink.emplace_shared<gtsam::PriorFactor<gtsam::Point3>>(
             kbVj, gtsam::Point3::Zero(), gtsam::noiseModel::Diagonal::Sigmas(sigmas));
     }
     // In the tricycle model, body w_x,w_y must be zero:
     {
         const Eigen::Vector3d sigmas = {std_ang_vel * dt, std_ang_vel * dt, TRICYCLE_LARGE_SIGMAS};
 
-        state_.gtsam->newFactors.emplace_shared<gtsam::PriorFactor<gtsam::Point3>>(
+        sink.emplace_shared<gtsam::PriorFactor<gtsam::Point3>>(
             kbWj, gtsam::Point3::Zero(), gtsam::noiseModel::Diagonal::Sigmas(sigmas));
     }
 
@@ -1131,7 +1163,7 @@ void StateEstimationSmoother::addFactor(const AbsFactorTricycleKinematics& f)
     auto noise_kinematics = gtsam::noiseModel::Diagonal::Sigmas(sigmas);
 
     // (To be written in a report/paper!)
-    state_.gtsam->newFactors.emplace_shared<mola::factors::FactorTricycleKinematic>(
+    sink.emplace_shared<mola::factors::FactorTricycleKinematic>(
         kTi, kbVi, kbWi, kTj, dt, noise_kinematics);
 }
 
@@ -1162,6 +1194,24 @@ void StateEstimationSmoother::delete_too_old_entries()
     for (const auto& idx : ids_to_erase)
     {
         state_.last_estimated_states.erase(idx);
+    }
+
+    // Forget the kinematic bookkeeping of links touching a marginalized keyframe.
+    // The fixed-lag smoother drops those factors itself, so their indices must
+    // never be queued for removal again (they would refer to slots GTSAM has
+    // already reused or freed). This also bounds the maps' growth.
+    const auto touchesErased = [&ids_to_erase](const GtsamImpl::frame_pair_t& k)
+    { return ids_to_erase.count(k.first) != 0 || ids_to_erase.count(k.second) != 0; };
+
+    for (auto it = state_.gtsam->flushedKinematic.begin();
+         it != state_.gtsam->flushedKinematic.end();)
+    {
+        it = touchesErased(it->first) ? state_.gtsam->flushedKinematic.erase(it) : std::next(it);
+    }
+    for (auto it = state_.gtsam->pendingKinematic.begin();
+         it != state_.gtsam->pendingKinematic.end();)
+    {
+        it = touchesErased(it->first) ? state_.gtsam->pendingKinematic.erase(it) : std::next(it);
     }
 }
 
@@ -1215,6 +1265,17 @@ StateEstimationSmoother::frame_index_t
 
     // Create new GTSAM symbols for this keyframe:
     initialize_new_frame(newFrameIdx, closestPost);
+
+    // If this keyframe is being spliced BETWEEN two existing ones, the direct link
+    // those two share must be withdrawn first. Otherwise its constraint stays in
+    // the graph alongside the two links that replace it below, so the motion model
+    // over that span is counted twice: it over-stiffens the window, biases the
+    // states and makes the covariance over-confident.
+    const auto& stamp2frameEnd = state_.stamp2frame_index.getDirectMap().end();
+    if (closestPost.first != stamp2frameEnd && closestPost.second != stamp2frameEnd)
+    {
+        remove_kinematic_factor_between(closestPost.first->second, closestPost.second->second);
+    }
 
     if (closestPost.first != state_.stamp2frame_index.getDirectMap().end())
     {
@@ -1323,14 +1384,44 @@ void StateEstimationSmoother::process_pending_gtsam_updates_locked()
 
     auto& smoother = *state_.gtsam->smoother;
 
+    // Flush the per-link kinematic factors into newFactors, remembering the range
+    // each link occupies so its iSAM2 indices can be recovered below.
+    std::vector<std::pair<GtsamImpl::frame_pair_t, std::pair<size_t, size_t>>> flushedRanges;
+    for (const auto& [linkKey, linkFactors] : state_.gtsam->pendingKinematic)
+    {
+        const size_t start = state_.gtsam->newFactors.size();
+        for (const auto& f : linkFactors)
+        {
+            state_.gtsam->newFactors.push_back(f);
+        }
+        flushedRanges.emplace_back(linkKey, std::make_pair(start, state_.gtsam->newFactors.size()));
+    }
+    state_.gtsam->pendingKinematic.clear();
+
     // Update the smoother with pending factors/values:
     try
     {
         if (!state_.gtsam->newFactors.empty() || !state_.gtsam->newValues.empty() ||
-            !state_.gtsam->newKeyStamps.empty())
+            !state_.gtsam->newKeyStamps.empty() || !state_.gtsam->factorsToRemove.empty())
         {
             smoother.update(
-                state_.gtsam->newFactors, state_.gtsam->newValues, state_.gtsam->newKeyStamps);
+                state_.gtsam->newFactors, state_.gtsam->newValues, state_.gtsam->newKeyStamps,
+                state_.gtsam->factorsToRemove);
+
+            // newFactorsIndices is 1-to-1 with the factors just passed in, so each
+            // link's range maps straight onto the indices it was given. Keep them:
+            // that is what makes a later splice able to remove this link again.
+            const auto& newIdx = smoother.getISAM2Result().newFactorsIndices;
+            for (const auto& [linkKey, range] : flushedRanges)
+            {
+                gtsam::FactorIndices indices;
+                for (size_t i = range.first; i < range.second && i < newIdx.size(); i++)
+                {
+                    indices.push_back(newIdx[i]);
+                }
+                state_.gtsam->flushedKinematic[linkKey] = indices;
+            }
+            state_.gtsam->factorsToRemove.clear();
         }
 
         // Optional: Perform extra internal iterations for better accuracy
@@ -1715,6 +1806,12 @@ void StateEstimationSmoother::initialize_new_frame(
 
         // And initialize the state struct too:
         newKfState = kfState;
+
+        // ...but seed only the pose/twist from the neighbor: this keyframe is brand
+        // new and not connected to anything yet. Inheriting the neighbor's link set
+        // would make add_kinematic_factor_between() believe a link already exists
+        // and silently skip it, leaving this keyframe under-constrained.
+        newKfState.kinematic_links_to.clear();
     }
     else
     {
@@ -1815,6 +1912,64 @@ void StateEstimationSmoother::add_kinematic_factor_between(
 
         default:
             THROW_EXCEPTION("Invalid kinematic_model value");
+    }
+}
+
+size_t StateEstimationSmoother::count_const_vel_factors_for_testing() const
+{
+    auto lck = mrpt::lockHelper(stateMutex_);
+
+    if (!state_.gtsam->smoother.has_value())
+    {
+        return 0;
+    }
+
+    size_t n = 0;
+    for (const auto& f : state_.gtsam->smoother->getFactors())
+    {
+        // findUnusedFactorSlots=true leaves null slots behind for removed factors.
+        if (!f)
+        {
+            continue;
+        }
+        if (dynamic_cast<const mola::factors::FactorConstLocalVelocityPose*>(f.get()) != nullptr)
+        {
+            n++;
+        }
+    }
+    return n;
+}
+
+void StateEstimationSmoother::remove_kinematic_factor_between(
+    const frame_index_t from, const frame_index_t to)  // NOLINT
+{
+    // Undo the link bookkeeping, so the pair can legitimately be re-linked later.
+    if (auto it = state_.last_estimated_states.find(from); it != state_.last_estimated_states.end())
+    {
+        it->second.kinematic_links_to.erase(to);
+    }
+    if (auto it = state_.last_estimated_states.find(to); it != state_.last_estimated_states.end())
+    {
+        it->second.kinematic_links_to.erase(from);
+    }
+
+    const auto key = GtsamImpl::link_key(from, to);
+
+    // Still pending: it never reached the solver, so dropping it costs nothing.
+    if (auto it = state_.gtsam->pendingKinematic.find(key);
+        it != state_.gtsam->pendingKinematic.end())
+    {
+        state_.gtsam->pendingKinematic.erase(it);
+        return;
+    }
+
+    // Already inside the smoother: queue its factors for removal at the next update.
+    if (auto it = state_.gtsam->flushedKinematic.find(key);
+        it != state_.gtsam->flushedKinematic.end())
+    {
+        auto& rm = state_.gtsam->factorsToRemove;
+        rm.insert(rm.end(), it->second.begin(), it->second.end());
+        state_.gtsam->flushedKinematic.erase(it);
     }
 }
 

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -1940,6 +1940,42 @@ size_t StateEstimationSmoother::count_const_vel_factors_for_testing() const
     return n;
 }
 
+std::set<std::pair<mrpt::Clock::time_point, mrpt::Clock::time_point>>
+    StateEstimationSmoother::const_vel_factor_links_for_testing() const
+{
+    auto lck = mrpt::lockHelper(stateMutex_);
+
+    std::set<std::pair<mrpt::Clock::time_point, mrpt::Clock::time_point>> links;
+
+    if (!state_.gtsam->smoother.has_value())
+    {
+        return links;
+    }
+
+    for (const auto& f : state_.gtsam->smoother->getFactors())
+    {
+        // findUnusedFactorSlots=true leaves null slots behind for removed factors.
+        if (!f)
+        {
+            continue;
+        }
+        const auto* fc = dynamic_cast<const mola::factors::FactorConstLocalVelocityPose*>(f.get());
+        if (fc == nullptr)
+        {
+            continue;
+        }
+        // keys() layout is {kTi, kWi, kTj, kWj}: pose keys are at indices 0 and 2,
+        // shared with both the linear- and angular-velocity factor of the same link.
+        const auto& keys    = fc->keys();
+        const auto  idxFrom = static_cast<frame_index_t>(gtsam::Symbol(keys.at(0)).index());
+        const auto  idxTo   = static_cast<frame_index_t>(gtsam::Symbol(keys.at(2)).index());
+
+        links.emplace(
+            state_.stamp2frame_index.inverse(idxFrom), state_.stamp2frame_index.inverse(idxTo));
+    }
+    return links;
+}
+
 void StateEstimationSmoother::remove_kinematic_factor_between(
     const frame_index_t from, const frame_index_t to)  // NOLINT
 {

--- a/mola_state_estimation_smoother/tests/CMakeLists.txt
+++ b/mola_state_estimation_smoother/tests/CMakeLists.txt
@@ -48,3 +48,10 @@ mola_add_test(
     mola::mola_state_estimation_smoother
 )
 
+mola_add_test(
+  TARGET  test-kinematic-splice-no-triangle
+  SOURCES test-kinematic-splice-no-triangle.cpp
+  LINK_LIBRARIES
+    mola::mola_state_estimation_smoother
+)
+

--- a/mola_state_estimation_smoother/tests/test-kinematic-splice-no-triangle.cpp
+++ b/mola_state_estimation_smoother/tests/test-kinematic-splice-no-triangle.cpp
@@ -1,0 +1,133 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   test-kinematic-splice-no-triangle.cpp
+ * @brief  Regression test: splicing a keyframe between two linked ones must
+ *         withdraw their direct kinematic link, not leave it double-counted.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 17, 2026
+ */
+
+#include <mola_state_estimation_smoother/StateEstimationSmoother.h>
+#include <mrpt/core/exceptions.h>
+#include <mrpt/core/get_env.h>
+#include <mrpt/poses/CPose3DPDFGaussian.h>
+
+#include <iostream>
+
+namespace
+{
+const bool VERBOSE = mrpt::get_env<bool>("VERBOSE", false);
+
+const char* navStateParams =
+    R"###(# Config for Parameters
+params:
+    vehicle_frame_name: "base_link"
+    reference_frame_name: "map"
+    max_time_to_use_velocity_model: 2.0
+    kinematic_model: KinematicModel::ConstantVelocity
+    sliding_window_length: 60.0
+    min_time_difference_to_create_new_frame: 0.05
+    sigma_random_walk_acceleration_linear: 1.0
+    sigma_random_walk_acceleration_angular: 1.0
+    sigma_integrator_position: 0.10
+    sigma_integrator_orientation: 0.10
+    sigma_twist_from_consecutive_poses_linear: 1.0
+    sigma_twist_from_consecutive_poses_angular: 1.0
+    estimate_geo_reference: false
+)###";
+
+mrpt::poses::CPose3DPDFGaussian pose_at(double x)
+{
+    auto cov = mrpt::math::CMatrixDouble66::Identity();
+    cov *= 1e-4;
+    return {mrpt::poses::CPose3D::FromXYZYawPitchRoll(x, 0, 0, 0, 0, 0), cov};
+}
+
+// Each kinematic link emits exactly two FactorConstLocalVelocityPose (one for
+// linear, one for angular velocity), so the smoother's count is 2x the links.
+size_t count_const_vel_factors(
+    const mola::state_estimation_smoother::StateEstimationSmoother& stateEst)
+{
+    return stateEst.count_const_vel_factors_for_testing();
+}
+
+// A keyframe spliced between two already-linked keyframes must not leave the
+// original direct link in the graph: `a->b` plus the `a->n` and `n->b` that
+// replace it would count the constant-velocity model twice over that span,
+// over-stiffening the window and making the covariance over-confident.
+void test_splice_does_not_leave_a_triangle()
+{
+    mola::state_estimation_smoother::StateEstimationSmoother stateEst;
+    if (VERBOSE)
+    {
+        stateEst.setMinLoggingLevel(mrpt::system::LVL_DEBUG);
+    }
+
+    auto cfgYaml = mrpt::containers::yaml::FromText(navStateParams);
+    stateEst.initialize(cfgYaml);
+
+    const auto& mapFrame = stateEst.parameters().reference_frame_name;
+
+    // In-order stream at 0.2 s spacing: a plain chain of N keyframes has N-1
+    // links. Spacing stays well above min_time_difference_to_create_new_frame so
+    // that every pose really does create its own keyframe.
+    const int kNumInOrder = 6;  // t = 0.0 .. 1.0
+    for (int i = 0; i < kNumInOrder; i++)
+    {
+        const double t = 0.2 * i;
+        stateEst.fuse_pose(mrpt::Clock::fromDouble(t), pose_at(t), mapFrame);
+    }
+    // Force the pending factors into iSAM2.
+    (void)stateEst.estimated_navstate(mrpt::Clock::fromDouble(1.0), mapFrame);
+
+    const size_t nBefore = count_const_vel_factors(stateEst);
+    std::cout << "[no-triangle] const-vel factors for a " << kNumInOrder
+              << "-keyframe chain: " << nBefore << " (expected " << 2 * (kNumInOrder - 1) << ")\n";
+    ASSERT_EQUAL_(nBefore, static_cast<size_t>(2 * (kNumInOrder - 1)));
+
+    // Now splice: t=0.5 lands between the keyframes at 0.4 and 0.6, 0.1 s from
+    // either, so it creates a keyframe in the past rather than snapping.
+    stateEst.fuse_pose(mrpt::Clock::fromDouble(0.5), pose_at(0.5), mapFrame);
+    (void)stateEst.estimated_navstate(mrpt::Clock::fromDouble(1.0), mapFrame);
+
+    const size_t nAfter = count_const_vel_factors(stateEst);
+
+    // The chain gained one keyframe, so it must gain exactly one link: the
+    // 0.4->0.6 link is replaced by 0.4->0.5 and 0.5->0.6. Leaving the old link in
+    // would give one link (2 factors) more than this.
+    const size_t nExpected = 2 * kNumInOrder;
+    std::cout << "[no-triangle] after splicing one keyframe: " << nAfter << " (expected "
+              << nExpected << "; a surviving stale link would give " << nExpected + 2 << ")\n";
+    ASSERT_EQUAL_(nAfter, nExpected);
+}
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    (void)argc;
+    (void)argv;
+    try
+    {
+        test_splice_does_not_leave_a_triangle();
+        std::cout << "Test passed." << std::endl;
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Test failed:\n" << mrpt::exception_to_str(e) << "\n";
+        return 1;
+    }
+}

--- a/mola_state_estimation_smoother/tests/test-kinematic-splice-no-triangle.cpp
+++ b/mola_state_estimation_smoother/tests/test-kinematic-splice-no-triangle.cpp
@@ -26,18 +26,24 @@
 #include <mrpt/poses/CPose3DPDFGaussian.h>
 
 #include <iostream>
+#include <set>
+#include <string>
+#include <utility>
 
 namespace
 {
 const bool VERBOSE = mrpt::get_env<bool>("VERBOSE", false);
 
-const char* navStateParams =
-    R"###(# Config for Parameters
+std::string navStateParams(const char* kinematicModel)
+{
+    return std::string(
+               R"###(# Config for Parameters
 params:
     vehicle_frame_name: "base_link"
     reference_frame_name: "map"
     max_time_to_use_velocity_model: 2.0
-    kinematic_model: KinematicModel::ConstantVelocity
+    kinematic_model: )###") +
+           kinematicModel + R"###(
     sliding_window_length: 60.0
     min_time_difference_to_create_new_frame: 0.05
     sigma_random_walk_acceleration_linear: 1.0
@@ -48,6 +54,7 @@ params:
     sigma_twist_from_consecutive_poses_angular: 1.0
     estimate_geo_reference: false
 )###";
+}
 
 mrpt::poses::CPose3DPDFGaussian pose_at(double x)
 {
@@ -64,19 +71,41 @@ size_t count_const_vel_factors(
     return stateEst.count_const_vel_factors_for_testing();
 }
 
+using link_set_t = std::set<std::pair<mrpt::Clock::time_point, mrpt::Clock::time_point>>;
+
+void assert_link_present(const link_set_t& links, double from, double to)
+{
+    const bool present =
+        links.count({mrpt::Clock::fromDouble(from), mrpt::Clock::fromDouble(to)}) != 0;
+    std::cout << "[no-triangle] link " << from << "->" << to << " present=" << present
+              << " (expected: true)\n";
+    ASSERT_(present);
+}
+
+void assert_link_absent(const link_set_t& links, double from, double to)
+{
+    const bool present =
+        links.count({mrpt::Clock::fromDouble(from), mrpt::Clock::fromDouble(to)}) != 0;
+    std::cout << "[no-triangle] link " << from << "->" << to << " present=" << present
+              << " (expected: false)\n";
+    ASSERT_(!present);
+}
+
 // A keyframe spliced between two already-linked keyframes must not leave the
 // original direct link in the graph: `a->b` plus the `a->n` and `n->b` that
 // replace it would count the constant-velocity model twice over that span,
 // over-stiffening the window and making the covariance over-confident.
-void test_splice_does_not_leave_a_triangle()
+void test_splice_does_not_leave_a_triangle(const char* kinematicModel)
 {
+    std::cout << "[no-triangle] kinematic_model=" << kinematicModel << "\n";
+
     mola::state_estimation_smoother::StateEstimationSmoother stateEst;
     if (VERBOSE)
     {
         stateEst.setMinLoggingLevel(mrpt::system::LVL_DEBUG);
     }
 
-    auto cfgYaml = mrpt::containers::yaml::FromText(navStateParams);
+    auto cfgYaml = mrpt::containers::yaml::FromText(navStateParams(kinematicModel));
     stateEst.initialize(cfgYaml);
 
     const auto& mapFrame = stateEst.parameters().reference_frame_name;
@@ -98,6 +127,9 @@ void test_splice_does_not_leave_a_triangle()
               << "-keyframe chain: " << nBefore << " (expected " << 2 * (kNumInOrder - 1) << ")\n";
     ASSERT_EQUAL_(nBefore, static_cast<size_t>(2 * (kNumInOrder - 1)));
 
+    const auto linksBefore = stateEst.const_vel_factor_links_for_testing();
+    assert_link_present(linksBefore, 0.4, 0.6);
+
     // Now splice: t=0.5 lands between the keyframes at 0.4 and 0.6, 0.1 s from
     // either, so it creates a keyframe in the past rather than snapping.
     stateEst.fuse_pose(mrpt::Clock::fromDouble(0.5), pose_at(0.5), mapFrame);
@@ -112,6 +144,14 @@ void test_splice_does_not_leave_a_triangle()
     std::cout << "[no-triangle] after splicing one keyframe: " << nAfter << " (expected "
               << nExpected << "; a surviving stale link would give " << nExpected + 2 << ")\n";
     ASSERT_EQUAL_(nAfter, nExpected);
+
+    // Same check at the graph-topology level, not just the factor count: the
+    // 0.4->0.6 link must be gone, replaced by 0.4->0.5 and 0.5->0.6, so a
+    // count-only check can't be fooled by e.g. a stale link plus a missing new one.
+    const auto linksAfter = stateEst.const_vel_factor_links_for_testing();
+    assert_link_absent(linksAfter, 0.4, 0.6);
+    assert_link_present(linksAfter, 0.4, 0.5);
+    assert_link_present(linksAfter, 0.5, 0.6);
 }
 }  // namespace
 
@@ -121,7 +161,8 @@ int main(int argc, char** argv)
     (void)argv;
     try
     {
-        test_splice_does_not_leave_a_triangle();
+        test_splice_does_not_leave_a_triangle("KinematicModel::ConstantVelocity");
+        test_splice_does_not_leave_a_triangle("KinematicModel::Tricycle");
         std::cout << "Test passed." << std::endl;
         return 0;
     }


### PR DESCRIPTION
Two defects in the keyframe splice path, both of which corrupt the graph when an out-of-order measurement inserts a keyframe between two existing ones.

1) The direct link between the two neighbours was never withdrawn. The new
   keyframe got its own links to each of them, but the original link stayed,
   so the constant-velocity model was counted twice over that span: it
   over-stiffens the window, biases the states and makes the covariance
   over-confident. There was no factor-removal path in the package at all.

   Kinematic factors are now built into a per-link graph keyed by the keyframe
   pair, so a link can be withdrawn as a unit: for free if it has not reached
   the solver yet, otherwise by queueing its iSAM2 indices for removal at the
   next update(). Links touching a marginalized keyframe are forgotten, since
   the fixed-lag smoother drops those factors itself and their indices must
   never be re-submitted.

2) initialize_new_frame() seeded a new keyframe by copying the whole state
   struct of its nearest neighbour, including that neighbour's set of kinematic
   links. add_kinematic_factor_between() uses that set to avoid duplicates, so
   an inherited link made it believe a link already existed and silently skip
   it, leaving the new keyframe under-constrained. It now inherits pose/twist
   only, which is what the seeding is for.

Defect (2) is what made a spliced keyframe get only one of its two links: it needs the neighbour picked by pick_closest() to be the one being linked, which happens whenever the splice lands closer to the later keyframe (ties included).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate motion constraints when inserting keyframes between existing ones.
  * Improved handling of kinematic links during keyframe removal and graph updates.

* **Tests**
  * Added regression coverage to verify correct factor counts after keyframe splicing.
  * Added test-only introspection for validating constant-velocity constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->