### PR TITLE
Sub-ms estimated_navstate() via async backend + high-rate keyframe decimation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ incremental optimization. The primary estimator for multi-sensor fusion.
 | ROS 2 launch | `mola_state_estimation_smoother/ros2-launchs/ros2-state-estimator.launch.py` |
 | MOLA-CLI launch | `mola_state_estimation_smoother/mola-cli-launchs/state_estimator_ros2.yaml` |
 | CLI app | `mola_state_estimation_smoother/apps/mola-navstate-cli.cpp` |
-| Tests (7) | `mola_state_estimation_smoother/tests/test-*.cpp` |
+| Tests (11) | `mola_state_estimation_smoother/tests/test-*.cpp` |
 | Integration tests | `mola_state_estimation_smoother/test/integration/test_*.py` |
 
 Key traits:
@@ -88,6 +88,23 @@ Key traits:
 - Optional ENU-to-map georeferencing from GNSS.
 - Thread-safe (`std::recursive_mutex`).
 - Configuration via YAML with `${ENV_VAR|default}` substitution.
+- Optional high-rate same-sensor decimation (both default `0` = off):
+  `odometry_min_sample_period` and `imu_min_sample_period` cap how often a
+  high-rate stream spawns keyframes/factors (solve cost grows with keyframe
+  count). Wheel-odom drops are *merged* (the pose anchor is held across the
+  dropped span, so the next kept reading fuses the accumulated increment +
+  covariance -- no motion lost); IMU drops are skipped (attitude/gravity are
+  absolute). Distinct from `min_time_difference_to_create_new_frame`, which only
+  merges near-simultaneous readings from different sensors.
+- Optional async backend (`async_backend: true`, default `false`): the iSAM2
+  window solve runs in a dedicated thread and `estimated_navstate()` is served
+  by a lock-free `FastPredictor` (`src/FastPredictor.{h,cpp}`) that extrapolates
+  the latest solved Snapshot (`src/Snapshot.h`) with the configured kinematic
+  model (shared with the backend via `src/extrapolation.h`). A query then runs
+  no solve and never takes `stateMutex_`, so its latency stays sub-millisecond;
+  the frame-local `{odom_i}` hardening is preserved (a query anchors on that
+  source's own last raw pose in the Snapshot). The default synchronous path is
+  byte-for-byte unchanged (deterministic offline/unit-test runs).
 
 Sensor inputs:
 - `fuse_pose()` - localization / LiDAR odometry poses

--- a/mola_state_estimation_smoother/CMakeLists.txt
+++ b/mola_state_estimation_smoother/CMakeLists.txt
@@ -52,8 +52,12 @@ mola_add_library(
   SOURCES
     src/Parameters.cpp
     src/StateEstimationSmoother.cpp
+    src/FastPredictor.cpp
     src/pose_pdf_to_string_with_sigmas.cpp
     src/register.cpp
+    src/Snapshot.h
+    src/FastPredictor.h
+    src/extrapolation.h
     include/mola_state_estimation_smoother/Parameters.h
     include/mola_state_estimation_smoother/StateEstimationSmoother.h
     include/mola_state_estimation_smoother/pose_pdf_to_string_with_sigmas.h

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
@@ -227,6 +227,25 @@ class Parameters
 
     /** @} */
 
+    /** @name Real-time async backend
+     * @{ */
+
+    /** If `true`, the iSAM2 window solve runs in a dedicated backend thread and
+     * `estimated_navstate()` is served by a lock-free FastPredictor re-anchored
+     * on the latest backend solution, so a query never runs a solve nor blocks
+     * on `stateMutex_` (per-query latency stays sub-millisecond). If `false`
+     * (default) the solve runs inline on the caller's thread, which is
+     * deterministic and is what the unit tests and offline batch runs use.
+     */
+    bool async_backend = false;
+
+    /** [s] Only used when `async_backend` is `true`: how far back the
+     * FastPredictor keeps high-rate observations to extrapolate from the anchor.
+     */
+    double fast_predictor_buffer_length = 1.0;  // [s]
+
+    /** @} */
+
     /** @name Sensor input names
      * @{  */
 

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
@@ -102,6 +102,28 @@ class Parameters
      */
     double imu_nearby_keyframe_stamp_tolerance = 0.10;  // [s]
 
+    /** High-rate same-sensor decimation for wheel odometry. If > 0, wheel
+     * odometry readings arriving less than this many seconds after the last
+     * *kept* one are MERGED rather than turned into their own keyframe: the
+     * reading is dropped without advancing the pose anchor, so the next kept
+     * reading fuses the accumulated pose increment together with its
+     * accumulated motion-model covariance. This caps the keyframe/factor rate
+     * a high-rate odometry stream imposes on the solver without discarding any
+     * motion. 0 disables it (every reading creates/updates a keyframe as
+     * before). This is independent of, and coarser than,
+     * min_time_difference_to_create_new_frame (which only merges
+     * near-simultaneous readings from different sensors). [seconds]
+     */
+    double odometry_min_sample_period = 0.0;  // [s]
+
+    /** High-rate same-sensor decimation for IMU. If > 0, IMU readings arriving
+     * less than this many seconds after the last *processed* one are skipped.
+     * Unlike wheel odometry, IMU attitude/gravity are absolute observations, so
+     * dropping intermediate readings simply lowers the redundant-factor rate;
+     * there is nothing to accumulate. 0 disables it. [seconds]
+     */
+    double imu_min_sample_period = 0.0;  // [s]
+
     double sigma_random_walk_acceleration_linear  = 1.0;  // [m/s²]
     double sigma_random_walk_acceleration_angular = 1.0;  // [rad/s²]
     double sigma_integrator_position              = 0.10;  // [m]

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -382,6 +382,11 @@ class StateEstimationSmoother : public mola::NavStateFilter,
     std::atomic<bool>                                                     backendStop_{false};
     bool                                                                  backendRunning_ = false;
 
+    /// Bumped by reset_locked() so a batch already detached by backend_loop()
+    /// (pre-reset) is discarded instead of repopulating the fresh graph with
+    /// stale measurements (e.g. across set_geo_reference()).
+    std::atomic<uint64_t> resetEpoch_{0};
+
     /// Appends a work item to the backend queue and wakes the backend thread.
     void enqueue_async(const mrpt::Clock::time_point& stamp, std::function<void()> fn);
 

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -46,10 +46,15 @@
 #include <mrpt/system/CTimeLogger.h>
 
 // std:
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <set>
+#include <thread>
 #include <utility>
 
 namespace mola::state_estimation_smoother
@@ -369,6 +374,27 @@ class StateEstimationSmoother : public mola::NavStateFilter,
     /// Returns nullptr if there is no keyframe/state to snapshot yet.
     [[nodiscard]] std::shared_ptr<const Snapshot> build_snapshot_locked() const;
 
+    // ---- async backend (only used when params_.async_backend) ----
+    std::thread                                                           backendThread_;
+    std::mutex                                                            queueMutex_;
+    std::condition_variable                                               queueCv_;
+    std::deque<std::pair<mrpt::Clock::time_point, std::function<void()>>> ingestQueue_;
+    std::atomic<bool>                                                     backendStop_{false};
+    bool                                                                  backendRunning_ = false;
+
+    /// Appends a work item to the backend queue and wakes the backend thread.
+    void enqueue_async(const mrpt::Clock::time_point& stamp, std::function<void()> fn);
+
+    /// Backend thread body: drains the queue, applies measurements in timestamp
+    /// order under stateMutex_, runs one solve, and publishes a snapshot.
+    void backend_loop();
+
+    /// Starts the backend thread if async mode is on and it is not running yet.
+    void start_backend_thread();
+
+    /// Signals the backend thread to stop and joins it.
+    void stop_backend_thread();
+
     /// Creates a new frame index for timestamp t, or returns the existing one if close enough.
     /// This also is in charge of the complex task of finding nearby existing frames and adding the
     /// kinematic factors to ensure smooth motion estimation.
@@ -385,6 +411,13 @@ class StateEstimationSmoother : public mola::NavStateFilter,
     void fuse_pose_locked(
         const mrpt::Clock::time_point& timestamp, const mrpt::poses::CPose3DPDFGaussian& pose,
         const std::string& frame_id);
+    void fuse_odometry_locked(
+        const mrpt::obs::CObservationOdometry& odom, const std::string& odomName);
+    void fuse_imu_locked(const mrpt::obs::CObservationIMU& imu);
+    void fuse_gnss_locked(const mrpt::obs::CObservationGPS& gps);
+    void fuse_twist_locked(
+        const mrpt::Clock::time_point& timestamp, const mrpt::math::TTwist3D& twist,
+        const mrpt::math::CMatrixDouble66& twistCov);
     [[nodiscard]] frame_index_t create_or_get_keyframe_by_timestamp_locked(
         const mrpt::Clock::time_point& t,
         const std::optional<double>&   overrideCloseEnough = std::nullopt);

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -317,6 +317,18 @@ class StateEstimationSmoother : public mola::NavStateFilter,
         std::optional<mrpt::poses::CPose2D> last_wheels_odometry;
         std::optional<std::string>          last_wheels_odometry_name;
 
+        /// Stamp of the last wheel-odometry reading that was actually KEPT
+        /// (turned into a keyframe/factor). Used by odometry_min_sample_period
+        /// to merge higher-rate readings: while a reading arrives within that
+        /// period of this stamp it is dropped without advancing the pose anchor
+        /// (last_wheels_odometry), so the next kept reading fuses the whole
+        /// accumulated increment.
+        std::optional<mrpt::Clock::time_point> last_wheels_odometry_stamp;
+
+        /// Stamp of the last IMU reading that was actually processed. Used by
+        /// imu_min_sample_period to skip higher-rate readings.
+        std::optional<mrpt::Clock::time_point> last_processed_imu_stamp;
+
         /** Refer to Parameters for possible sources of this.
          * Anyways: this will always hold either the estimated or the fixed (externally set)
          * georeferencing parameters.

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -46,6 +46,7 @@
 #include <mrpt/system/CTimeLogger.h>
 
 // std:
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <set>
@@ -53,6 +54,10 @@
 
 namespace mola::state_estimation_smoother
 {
+// Defined in src/, kept out of the public API (used only via pointer here):
+struct Snapshot;
+class FastPredictor;
+
 /** Sliding window Factor-graph data fusion for odometry, IMU, GNSS, and SE(3)
  * pose/twist estimations.
  *
@@ -125,7 +130,8 @@ class StateEstimationSmoother : public mola::NavStateFilter,
     StateEstimationSmoother(StateEstimationSmoother&&)                 = delete;
     StateEstimationSmoother& operator=(const StateEstimationSmoother&) = delete;
     StateEstimationSmoother& operator=(StateEstimationSmoother&&)      = delete;
-    ~StateEstimationSmoother()                                         = default;
+    // Out-of-line: fastPredictor_ is a unique_ptr to an incomplete type here.
+    ~StateEstimationSmoother();
 
     /** \name Main API
      *  @{ */
@@ -353,6 +359,15 @@ class StateEstimationSmoother : public mola::NavStateFilter,
     State      state_;
     std::mutex stateMutex_;
     bool       params_loaded_ = false;
+
+    /// Lock-free read model for async_backend mode. Populated at the end of each
+    /// solve; queried by estimated_navstate()/spinOnce() without stateMutex_.
+    std::unique_ptr<FastPredictor> fastPredictor_;
+
+    /// Builds an immutable Snapshot of the current solution (newest keyframe
+    /// anchor + frame transforms + georef). Assumes stateMutex_ is held.
+    /// Returns nullptr if there is no keyframe/state to snapshot yet.
+    [[nodiscard]] std::shared_ptr<const Snapshot> build_snapshot_locked() const;
 
     /// Creates a new frame index for timestamp t, or returns the existing one if close enough.
     /// This also is in charge of the complex task of finding nearby existing frames and adding the

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -68,6 +68,18 @@ params:
   # to use instead of "min_time_difference_to_create_new_frame". [seconds]
   imu_nearby_keyframe_stamp_tolerance: 0.10
 
+  # High-rate same-sensor decimation for wheel odometry [seconds]. If > 0,
+  # readings arriving less than this after the last KEPT one are MERGED (dropped
+  # without advancing the pose anchor, so the next kept reading fuses the whole
+  # accumulated increment + covariance). Caps the keyframe rate a high-rate
+  # odometry stream imposes on the solver without losing motion. 0 = disabled.
+  odometry_min_sample_period: ${MOLA_ODOMETRY_MIN_SAMPLE_PERIOD|0.0}
+
+  # High-rate same-sensor decimation for IMU [seconds]. If > 0, readings
+  # arriving less than this after the last processed one are skipped (attitude/
+  # gravity are absolute, so nothing is accumulated). 0 = disabled.
+  imu_min_sample_period: ${MOLA_IMU_MIN_SAMPLE_PERIOD|0.0}
+
   # Random walk model for linear acceleration uncertainty [m/s²]
   sigma_random_walk_acceleration_linear: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC|1.0}
 

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -80,6 +80,11 @@ params:
   # gravity are absolute, so nothing is accumulated). 0 = disabled.
   imu_min_sample_period: ${MOLA_IMU_MIN_SAMPLE_PERIOD|0.0}
 
+  # If true, run the iSAM2 window solve in a dedicated backend thread and serve
+  # estimated_navstate() from a lock-free fast predictor (sub-ms queries). The
+  # default synchronous path is deterministic and used by offline/unit runs.
+  async_backend: ${MOLA_ASYNC_BACKEND|false}
+
   # Random walk model for linear acceleration uncertainty [m/s²]
   sigma_random_walk_acceleration_linear: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC|1.0}
 

--- a/mola_state_estimation_smoother/src/FastPredictor.cpp
+++ b/mola_state_estimation_smoother/src/FastPredictor.cpp
@@ -1,0 +1,175 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   FastPredictor.cpp
+ * @brief  Lock-free, sub-ms pose predictor anchored on the latest backend
+ *         snapshot.
+ * @author Jose Luis Blanco Claraco
+ */
+
+#include "FastPredictor.h"
+
+#include <mrpt/core/bits_math.h>  // mrpt::square
+#include <mrpt/poses/CPose3DPDFGaussian.h>
+#include <mrpt/poses/CPose3DPDFGaussianInf.h>
+#include <mrpt/system/datetime.h>  // timeDifference
+
+#include <cmath>
+
+#include "extrapolation.h"
+
+namespace mola::state_estimation_smoother
+{
+
+void FastPredictor::set_snapshot(std::shared_ptr<const Snapshot> snap)
+{
+    std::lock_guard<std::mutex> lck(mtx_);
+    snapshot_ = std::move(snap);
+}
+
+std::shared_ptr<const Snapshot> FastPredictor::snapshot() const
+{
+    std::lock_guard<std::mutex> lck(mtx_);
+    return snapshot_;
+}
+
+void FastPredictor::note_observation_stamp(const mrpt::Clock::time_point& obsStamp)
+{
+    std::lock_guard<std::mutex> lck(mtx_);
+    // Keep the freshest observation stamp (inputs are usually monotonic), so a
+    // late arrival never drags the published stamp backwards.
+    if (!lastObsStamp_ || mrpt::system::timeDifference(*lastObsStamp_, obsStamp) > 0)
+    {
+        lastObsStamp_     = obsStamp;
+        lastObsWallclock_ = mrpt::Clock::now();
+    }
+}
+
+std::optional<mrpt::Clock::time_point> FastPredictor::get_current_extrapolated_stamp() const
+{
+    std::lock_guard<std::mutex> lck(mtx_);
+    if (!lastObsStamp_)
+    {
+        return std::nullopt;
+    }
+    return mrpt::Clock::fromDouble(
+        (mrpt::Clock::nowDouble() - mrpt::Clock::toDouble(lastObsWallclock_)) +
+        mrpt::Clock::toDouble(*lastObsStamp_));
+}
+
+void FastPredictor::clear()
+{
+    std::lock_guard<std::mutex> lck(mtx_);
+    snapshot_.reset();
+    lastObsStamp_.reset();
+}
+
+std::optional<NavState> FastPredictor::predict(
+    const mrpt::Clock::time_point& t_query, const std::string& frame_id,
+    const Parameters& params) const
+{
+    std::shared_ptr<const Snapshot> snap;
+    {
+        std::lock_guard<std::mutex> lck(mtx_);
+        snap = snapshot_;
+    }
+    if (!snap || !snap->valid)
+    {
+        return std::nullopt;
+    }
+
+    // dt from the anchor (newest solved keyframe) to the requested time.
+    const double dt = mrpt::system::timeDifference(snap->anchorStamp, t_query);
+    if (std::abs(dt) > params.max_time_to_use_velocity_model)
+    {
+        return std::nullopt;
+    }
+
+    // Start from the anchor state and grow the twist uncertainty by the
+    // random-walk model over the extrapolation interval (mirrors the
+    // synchronous estimated_navstate()).
+    NavState ret = snap->anchor;
+    {
+        auto twist_cov = ret.twist_inv_cov.inverse_LLt();
+        for (int i = 0; i < 3; i++)
+        {
+            twist_cov(0 + i, 0 + i) +=
+                mrpt::square(params.sigma_random_walk_acceleration_linear * dt);
+            twist_cov(3 + i, 3 + i) +=
+                mrpt::square(params.sigma_random_walk_acceleration_angular * dt);
+        }
+        ret.twist_inv_cov = twist_cov.inverse_LLt();
+    }
+
+    // Reference ({map}) frame: extrapolate the anchor pose forward.
+    if (frame_id == params.reference_frame_name)
+    {
+        ret.pose.mean = ret.pose.mean + body_twist_delta(params, ret.twist, dt);
+        return ret;
+    }
+
+    // Odometry frame {odom_i}: resolve its numeric id.
+    const auto& str2id = snap->frameNames.getDirectMap();
+    const auto  itName = str2id.find(frame_id);
+    if (itName == str2id.end())
+    {
+        return std::nullopt;
+    }
+    const auto requestedFrameIdx = itName->second;
+
+    // Frame-local prediction: anchor on the source's OWN last raw pose in
+    // {odom_i} and extrapolate by the body-twist increment, so the prediction
+    // stays immune to {map} corrections (geo-ref / loop closure / per-solve
+    // jitter). Falls back to the global conversion before the first raw pose.
+    const auto itRaw = snap->lastRawPoseBySource.find(requestedFrameIdx);
+    if (itRaw == snap->lastRawPoseBySource.end())
+    {
+        const auto itFrame = snap->frameTransforms.find(requestedFrameIdx);
+        if (itFrame == snap->frameTransforms.end())
+        {
+            return std::nullopt;
+        }
+        ret.pose.mean = ret.pose.mean + body_twist_delta(params, ret.twist, dt);
+        mrpt::poses::CPose3DPDFGaussianInf posePdfFrame_wrt_map_inf;
+        posePdfFrame_wrt_map_inf.copyFrom(itFrame->second);
+        ret.pose = ret.pose - posePdfFrame_wrt_map_inf;
+        return ret;
+    }
+
+    const auto&  rawAnchor = itRaw->second;
+    const double dtPred    = mrpt::system::timeDifference(rawAnchor.stamp, t_query);
+    if (std::abs(dtPred) > params.max_time_to_use_velocity_model)
+    {
+        return std::nullopt;
+    }
+
+    mrpt::poses::CPose3DPDFGaussian pred;
+    pred.mean = rawAnchor.pose.mean + body_twist_delta(params, ret.twist, dtPred);
+
+    pred.cov         = rawAnchor.pose.cov;
+    const double adt = std::abs(dtPred);
+    for (int i = 0; i < 3; i++)
+    {
+        pred.cov(i, i) += mrpt::square(params.sigma_random_walk_acceleration_linear * adt * adt);
+        pred.cov(3 + i, 3 + i) +=
+            mrpt::square(params.sigma_random_walk_acceleration_angular * adt * adt);
+    }
+
+    ret.pose.copyFrom(pred);  // NavState.pose is CPose3DPDFGaussianInf
+
+    return ret;
+}
+
+}  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/src/FastPredictor.h
+++ b/mola_state_estimation_smoother/src/FastPredictor.h
@@ -1,0 +1,88 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   FastPredictor.h
+ * @brief  Lock-free, sub-ms pose predictor anchored on the latest backend
+ *         snapshot.
+ * @author Jose Luis Blanco Claraco
+ */
+#pragma once
+
+#include <mola_kernel/interfaces/NavStateFilter.h>  // NavState
+#include <mola_state_estimation_smoother/Parameters.h>
+#include <mrpt/core/Clock.h>
+
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+
+#include "Snapshot.h"
+
+namespace mola::state_estimation_smoother
+{
+/** Serves `estimated_navstate()` queries in sub-millisecond time, without
+ *  touching the smoother's `stateMutex_` or running any factor-graph solve.
+ *
+ *  It holds the latest immutable Snapshot published by the backend and, on each
+ *  query, extrapolates that anchor to the requested time with the configured
+ *  kinematic model (identical maths to the synchronous
+ *  StateEstimationSmoother::estimated_navstate(), so the two agree up to the
+ *  backend's solve lag). The frame-local {odom_i} hardening is preserved: an
+ *  odometry-frame query anchors on that source's own last raw pose, never on a
+ *  {map}-frame reconstruction.
+ *
+ *  Thread-safety: its own mutex, deliberately separate from the smoother's
+ *  `stateMutex_`, so a query never blocks on a backend batch solve.
+ */
+class FastPredictor
+{
+   public:
+    FastPredictor() = default;
+
+    /// Publishes a newly solved snapshot (called by the backend after a solve).
+    void set_snapshot(std::shared_ptr<const Snapshot> snap);
+
+    /// Returns the current snapshot (may be null / invalid before the first solve).
+    [[nodiscard]] std::shared_ptr<const Snapshot> snapshot() const;
+
+    /// Records the timestamp of the latest incoming observation together with
+    /// the current wallclock, so a real-time "now" stamp can be computed without
+    /// touching the smoother's stateMutex_.
+    void note_observation_stamp(const mrpt::Clock::time_point& obsStamp);
+
+    /// Real-time "now" stamp: the latest observation stamp advanced by the
+    /// wallclock elapsed since it was received. nullopt if none seen yet.
+    [[nodiscard]] std::optional<mrpt::Clock::time_point> get_current_extrapolated_stamp() const;
+
+    /// Extrapolates the snapshot anchor to `t_query` in `frame_id`. nullopt if
+    /// there is no valid snapshot, the frame is unknown, or `t_query` is beyond
+    /// `max_time_to_use_velocity_model`.
+    [[nodiscard]] std::optional<NavState> predict(
+        const mrpt::Clock::time_point& t_query, const std::string& frame_id,
+        const Parameters& params) const;
+
+    /// Drops the snapshot and the observation-stamp tracking (used on reset()).
+    void clear();
+
+   private:
+    mutable std::mutex              mtx_;
+    std::shared_ptr<const Snapshot> snapshot_;
+
+    std::optional<mrpt::Clock::time_point> lastObsStamp_;
+    mrpt::Clock::time_point                lastObsWallclock_;
+};
+
+}  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/src/Parameters.cpp
+++ b/mola_state_estimation_smoother/src/Parameters.cpp
@@ -50,6 +50,9 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
     MCP_LOAD_OPT(cfg, gnss_nearby_keyframe_stamp_tolerance);
     MCP_LOAD_OPT(cfg, imu_nearby_keyframe_stamp_tolerance);
 
+    MCP_LOAD_OPT(cfg, odometry_min_sample_period);
+    MCP_LOAD_OPT(cfg, imu_min_sample_period);
+
     MCP_LOAD_OPT(cfg, initial_twist_sigma_lin);
     MCP_LOAD_OPT(cfg, initial_twist_sigma_ang);
 

--- a/mola_state_estimation_smoother/src/Parameters.cpp
+++ b/mola_state_estimation_smoother/src/Parameters.cpp
@@ -53,6 +53,9 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
     MCP_LOAD_OPT(cfg, odometry_min_sample_period);
     MCP_LOAD_OPT(cfg, imu_min_sample_period);
 
+    MCP_LOAD_OPT(cfg, async_backend);
+    MCP_LOAD_OPT(cfg, fast_predictor_buffer_length);
+
     MCP_LOAD_OPT(cfg, initial_twist_sigma_lin);
     MCP_LOAD_OPT(cfg, initial_twist_sigma_ang);
 

--- a/mola_state_estimation_smoother/src/Snapshot.h
+++ b/mola_state_estimation_smoother/src/Snapshot.h
@@ -1,0 +1,81 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   Snapshot.h
+ * @brief  Immutable read-model of the smoother's latest solution.
+ * @author Jose Luis Blanco Claraco
+ */
+#pragma once
+
+#include <mola_kernel/Georeferencing.h>
+#include <mola_kernel/interfaces/NavStateFilter.h>  // NavState
+#include <mrpt/containers/bimap.h>
+#include <mrpt/core/Clock.h>
+#include <mrpt/poses/CPose3DPDFGaussian.h>
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+
+namespace mola::state_estimation_smoother
+{
+/** An immutable snapshot of everything the read side of the smoother needs,
+ *  produced once per backend solve and published atomically as a
+ *  std::shared_ptr<const Snapshot>.
+ *
+ *  In synchronous mode it is built at the end of each
+ *  process_pending_gtsam_updates() so the getters can read a consistent set of
+ *  values; in async mode it is what the FastPredictor and the lock-free getters
+ *  read while the backend thread holds stateMutex_ for the next solve.
+ */
+struct Snapshot
+{
+    using odometry_frameid_t = uint8_t;
+
+    /// False until the first successful solve, and again after a reset(): a
+    /// consumer must treat an invalid snapshot as "not ready", never as stale
+    /// certainty.
+    bool valid = false;
+
+    /// Newest keyframe stamp and its optimized state (in the reference {map}
+    /// frame). This is the anchor the fast predictor extrapolates from.
+    mrpt::Clock::time_point anchorStamp;
+    NavState                anchor;
+
+    /// Latest estimated T_map_to_odom_i, keyed by numeric odometry frame id,
+    /// plus the name<->id mapping so a query by frame name can be resolved.
+    std::map<odometry_frameid_t, mrpt::poses::CPose3DPDFGaussian> frameTransforms;
+    mrpt::containers::bimap<std::string, odometry_frameid_t>      frameNames;
+
+    /// Each odometry source's own last raw pose in its own {odom_i} frame. The
+    /// frame-local prediction anchors on this to stay immune to {map}
+    /// corrections (see AGENTS.md / estimated_navstate()).
+    struct RawSourcePose
+    {
+        mrpt::Clock::time_point         stamp;
+        mrpt::poses::CPose3DPDFGaussian pose;  //!< in {odom_i}
+    };
+    std::map<odometry_frameid_t, RawSourcePose> lastRawPoseBySource;
+
+    /// Current georeference (fixed or estimated), if any.
+    std::optional<mola::Georeferencing> geoReference;
+
+    /// Whether localization has converged (mode-aware, mirrors
+    /// has_converged_localization()).
+    bool localizationConverged = false;
+};
+
+}  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -793,7 +793,8 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
     NavState retKf;
     try
     {
-        retKf = get_latest_state_and_covariance(*closesFrameIdx);
+        const auto tleMarg = mola::ProfilerEntry(profiler_, "estimated_navstate.marginals.anchor");
+        retKf              = get_latest_state_and_covariance(*closesFrameIdx);
     }
     catch (const std::exception& e)
     {
@@ -1414,6 +1415,7 @@ void StateEstimationSmoother::process_pending_gtsam_updates_locked()
         if (!state_.gtsam->newFactors.empty() || !state_.gtsam->newValues.empty() ||
             !state_.gtsam->newKeyStamps.empty() || !state_.gtsam->factorsToRemove.empty())
         {
+            const auto tleUpd = mola::ProfilerEntry(profiler_, "process_pending.iSAM2.update");
             smoother.update(
                 state_.gtsam->newFactors, state_.gtsam->newValues, state_.gtsam->newKeyStamps,
                 state_.gtsam->factorsToRemove);
@@ -1435,9 +1437,14 @@ void StateEstimationSmoother::process_pending_gtsam_updates_locked()
         }
 
         // Optional: Perform extra internal iterations for better accuracy
-        for (unsigned int i = 1; i < params_.additional_isam2_update_steps; ++i)
+        if (params_.additional_isam2_update_steps > 1)
         {
-            smoother.update();
+            const auto tleExtra =
+                mola::ProfilerEntry(profiler_, "process_pending.iSAM2.extra_updates");
+            for (unsigned int i = 1; i < params_.additional_isam2_update_steps; ++i)
+            {
+                smoother.update();
+            }
         }
     }
     catch (const std::exception& e)
@@ -1518,7 +1525,8 @@ void StateEstimationSmoother::process_pending_gtsam_updates_locked()
     gtsam::Values optValues;
     try
     {
-        optValues = smoother.calculateEstimate();
+        const auto tleCalc = mola::ProfilerEntry(profiler_, "process_pending.calculateEstimate");
+        optValues          = smoother.calculateEstimate();
     }
     catch (const std::exception& e)
     {
@@ -1535,25 +1543,30 @@ void StateEstimationSmoother::process_pending_gtsam_updates_locked()
     }
 
     // Retrieve the latest estimate and save it into "state_.last_estimated_state":
-    for (auto& [kfIdx, kf] : state_.last_estimated_states)
     {
-        const auto pose = optValues.at<gtsam::Pose3>(T(kfIdx));
-        const auto linV = optValues.at<gtsam::Vector3>(V(kfIdx));
-        const auto angV = optValues.at<gtsam::Vector3>(W(kfIdx));
-
-        kf.pose  = mrpt::poses::CPose3D(mrpt::gtsam_wrappers::toTPose3D(pose));
-        kf.twist = {linV.x(), linV.y(), linV.z(), angV.x(), angV.y(), angV.z()};
-
-        if (params_.enforce_planar_motion)
+        const auto tleWriteback = mola::ProfilerEntry(profiler_, "process_pending.writeback");
+        for (auto& [kfIdx, kf] : state_.last_estimated_states)
         {
-            enforce_planar_pose(kf.pose);
-            enforce_planar_twist(kf.twist);
+            const auto pose = optValues.at<gtsam::Pose3>(T(kfIdx));
+            const auto linV = optValues.at<gtsam::Vector3>(V(kfIdx));
+            const auto angV = optValues.at<gtsam::Vector3>(W(kfIdx));
+
+            kf.pose  = mrpt::poses::CPose3D(mrpt::gtsam_wrappers::toTPose3D(pose));
+            kf.twist = {linV.x(), linV.y(), linV.z(), angV.x(), angV.y(), angV.z()};
+
+            if (params_.enforce_planar_motion)
+            {
+                enforce_planar_pose(kf.pose);
+                enforce_planar_twist(kf.twist);
+            }
         }
     }
 
     // Retrieve latest enu_to_map for geo-referencing:
     if (params_.estimate_geo_reference)
     {
+        const auto tleGeoref = mola::ProfilerEntry(profiler_, "process_pending.marginals.georef");
+
         const auto T_enu_to_map     = optValues.at<gtsam::Pose3>(symbol_T_enu_to_map);
         const auto T_enu_to_map_cov = smoother.marginalCovariance(symbol_T_enu_to_map);
 
@@ -1633,16 +1646,20 @@ void StateEstimationSmoother::process_pending_gtsam_updates_locked()
     }
 
     // retrieve odometry frames:
-    for (const auto& [_, odomFrameIdx] : state_.known_odom_frames)
     {
-        const auto symbolOdom        = symbol_T_map_to_odom_i_base + odomFrameIdx;
-        const auto T_map2_odom_i     = optValues.at<gtsam::Pose3>(symbolOdom);
-        const auto T_map2_odom_i_cov = smoother.marginalCovariance(symbolOdom);
+        const auto tleOdomMarg =
+            mola::ProfilerEntry(profiler_, "process_pending.marginals.odom_frames");
+        for (const auto& [_, odomFrameIdx] : state_.known_odom_frames)
+        {
+            const auto symbolOdom        = symbol_T_map_to_odom_i_base + odomFrameIdx;
+            const auto T_map2_odom_i     = optValues.at<gtsam::Pose3>(symbolOdom);
+            const auto T_map2_odom_i_cov = smoother.marginalCovariance(symbolOdom);
 
-        auto& pdf = state_.last_estimated_frames[odomFrameIdx];
+            auto& pdf = state_.last_estimated_frames[odomFrameIdx];
 
-        pdf.mean = mrpt::poses::CPose3D(mrpt::gtsam_wrappers::toTPose3D(T_map2_odom_i));
-        pdf.cov  = mrpt::gtsam_wrappers::to_mrpt_se3_cov6(T_map2_odom_i_cov);
+            pdf.mean = mrpt::poses::CPose3D(mrpt::gtsam_wrappers::toTPose3D(T_map2_odom_i));
+            pdf.cov  = mrpt::gtsam_wrappers::to_mrpt_se3_cov6(T_map2_odom_i_cov);
+        }
     }
 
     if (NAVSTATE_PRINT_FG)

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -54,6 +54,10 @@
 #include <mola_gtsam_factors/Pose3RotationFactor.h>
 #include <mola_gtsam_factors/imu_helpers.h>
 
+#include "FastPredictor.h"
+#include "Snapshot.h"
+#include "extrapolation.h"
+
 // arguments: class_name, parent_class, class namespace
 IMPLEMENTS_MRPT_OBJECT(
     StateEstimationSmoother, mola::ExecutableBase, mola::state_estimation_smoother)
@@ -83,53 +87,6 @@ void enforce_planar_twist(mrpt::math::TTwist3D& tw)
 
 namespace mola::state_estimation_smoother
 {
-
-namespace
-{
-/// Integrates a constant body-frame twist over `dt` seconds, returning the
-/// relative pose increment T_i_to_j (right-composed onto an anchor: T_j = T_i
-/// (+) delta). Branches on the configured kinematic model so the short-term
-/// extrapolation matches the motion model used to build the inter-keyframe
-/// factors: full SE(3) exp of the 6D body twist for ConstantVelocity; the planar
-/// arc from forward velocity v=vx and yaw rate w=wz for Tricycle, mirroring
-/// mola::factors::FactorTricycleKinematic exactly.
-mrpt::poses::CPose3D body_twist_delta(
-    const Parameters& params, const mrpt::math::TTwist3D& twist, double dt)
-{
-    switch (params.kinematic_model)
-    {
-        case KinematicModel::Tricycle:
-        {
-            constexpr double w_threshold = 1e-4;  // [rad/s], as FactorTricycleKinematic
-            const double     v           = twist.vx;
-            const double     w           = twist.wz;
-            if (std::abs(w) < w_threshold)
-            {
-                return mrpt::poses::CPose3D(v * dt, .0, .0, .0, .0, .0);
-            }
-            const double R     = v / w;
-            const double theta = w * dt;
-            const double dx    = R * std::sin(theta);
-            const double dy    = R * (1.0 - std::cos(theta));
-            // CPose3D(x, y, z, yaw, pitch, roll); the arc rotates about +z (yaw).
-            return mrpt::poses::CPose3D(dx, dy, .0, theta, .0, .0);
-        }
-        case KinematicModel::ConstantVelocity:
-        default:
-        {
-            mrpt::math::CVectorFixed<double, 6> twistDt;
-            twistDt[0] = twist.vx;
-            twistDt[1] = twist.vy;
-            twistDt[2] = twist.vz;
-            twistDt[3] = twist.wx;
-            twistDt[4] = twist.wy;
-            twistDt[5] = twist.wz;
-            twistDt *= dt;
-            return mrpt::poses::CPose3D(mrpt::poses::Lie::SE<3>::exp(twistDt));
-        }
-    }
-}
-}  // namespace
 
 const bool   NAVSTATE_PRINT_FG        = mrpt::get_env<bool>("NAVSTATE_PRINT_FG", false);
 const bool   NAVSTATE_PRINT_FG_ERRORS = mrpt::get_env<bool>("NAVSTATE_PRINT_FG_ERRORS", false);
@@ -200,7 +157,10 @@ StateEstimationSmoother::StateEstimationSmoother()
 {  //
     profiler_.setName("StateEstimationSmoother");
     ExecutableBase::setModuleInstanceName("StateEstimationSmoother");
+    fastPredictor_ = std::make_unique<FastPredictor>();
 }
+
+StateEstimationSmoother::~StateEstimationSmoother() = default;
 
 void StateEstimationSmoother::initialize(const mrpt::containers::yaml& cfg)
 {
@@ -374,6 +334,10 @@ void StateEstimationSmoother::reset()
 void StateEstimationSmoother::reset_locked()
 {
     state_ = State();
+    if (fastPredictor_)
+    {
+        fastPredictor_->clear();
+    }
     if (params_loaded_)
     {
         reinitialize_gtsam_locked();
@@ -1727,6 +1691,17 @@ void StateEstimationSmoother::process_pending_gtsam_updates_locked()
     state_.gtsam->newValues.clear();
     state_.gtsam->newKeyStamps.clear();
 
+    // Publish an immutable snapshot for the lock-free read path. Only built in
+    // async mode: the synchronous path reads state_ directly and building the
+    // snapshot would add marginals to every solve for no benefit.
+    if (params_.async_backend)
+    {
+        if (auto snap = build_snapshot_locked())
+        {
+            fastPredictor_->set_snapshot(std::move(snap));
+        }
+    }
+
     // Check convergence for initialization from GNSS / georeferencing.
     // If we just converged and should publish geo-ref, do it now:
     if (params_.estimate_geo_reference && params_.publish_estimated_georef_on_convergence &&
@@ -2071,6 +2046,74 @@ void StateEstimationSmoother::remove_kinematic_factor_between(
         rm.insert(rm.end(), it->second.begin(), it->second.end());
         state_.gtsam->flushedKinematic.erase(it);
     }
+}
+
+std::shared_ptr<const Snapshot> StateEstimationSmoother::build_snapshot_locked() const
+{
+    if (state_.stamp2frame_index.empty())
+    {
+        return nullptr;
+    }
+
+    auto snap = std::make_shared<Snapshot>();
+
+    // Anchor: the newest keyframe's optimized state + covariance.
+    const auto& latestIt      = state_.stamp2frame_index.getDirectMap().rbegin();
+    const auto  latestStamp   = latestIt->first;
+    const auto  latestFrameId = latestIt->second;
+    try
+    {
+        snap->anchor = get_latest_state_and_covariance(latestFrameId);
+    }
+    catch (const std::exception&)
+    {
+        // Graph still under-constrained: no usable snapshot yet.
+        return nullptr;
+    }
+    snap->anchorStamp = latestStamp;
+
+    // Odometry-frame transforms (numeric id >= 1) and the name<->id mapping.
+    snap->frameNames = state_.known_odom_frames;
+    for (const auto& [id, pdf] : state_.last_estimated_frames)
+    {
+        if (id == REFERENCE_FRAME_ID)
+        {
+            continue;
+        }
+        snap->frameTransforms[id] = pdf;
+    }
+
+    // Each source's own last raw pose in {odom_i}, for the frame-local path.
+    for (const auto& [id, raw] : state_.last_raw_pose_by_source)
+    {
+        snap->lastRawPoseBySource[id] = Snapshot::RawSourcePose{raw.stamp, raw.pose};
+    }
+
+    snap->geoReference = state_.geo_reference;
+
+    // Convergence flag, mode-aware, mirroring has_converged_localization().
+    bool converged = false;
+    if (state_.geo_reference.has_value())
+    {
+        if (params_.estimate_geo_reference)
+        {
+            converged = true;
+        }
+        else
+        {
+            const mrpt::math::CMatrixDouble66 poseCov = snap->anchor.pose.cov_inv.inverse_LLt();
+            const double                      maxPos =
+                std::sqrt(std::max({poseCov(0, 0), poseCov(1, 1), poseCov(2, 2)}));
+            const double maxOriDeg =
+                mrpt::RAD2DEG(std::sqrt(std::max({poseCov(3, 3), poseCov(4, 4), poseCov(5, 5)})));
+            converged = maxPos <= params_.convergence_max_position_sigma &&
+                        maxOriDeg <= params_.convergence_max_orientation_sigma_deg;
+        }
+    }
+    snap->localizationConverged = converged;
+
+    snap->valid = true;
+    return snap;
 }
 
 NavState StateEstimationSmoother::get_latest_state_and_covariance(const frame_index_t idx) const

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -399,14 +399,31 @@ void StateEstimationSmoother::fuse_odometry(
 
         ASSERT_(state_.last_wheels_odometry.has_value());
         lastOdom = *state_.last_wheels_odometry;
+
+        // High-rate decimation/merge: if this reading arrives too soon after
+        // the last *kept* one, drop it WITHOUT advancing the pose anchor
+        // (last_wheels_odometry) nor the kept stamp. The next kept reading then
+        // fuses the accumulated increment (lastOdom -> current) with its
+        // accumulated motion-model covariance, merging several consecutive
+        // odometry readings into a single keyframe/factor without losing motion.
+        if (params_.odometry_min_sample_period > 0 && state_.last_wheels_odometry_stamp.has_value())
+        {
+            const double dt =
+                mrpt::system::timeDifference(*state_.last_wheels_odometry_stamp, odom.timestamp);
+            if (dt < params_.odometry_min_sample_period)
+            {
+                return;
+            }
+        }
     }
     else
     {
         // This is the first time we have wheels odometry.
         // Store the pose but skip factor creation: the increment is zero,
         // which would produce a stiff near-zero BetweenFactor.
-        state_.last_wheels_odometry_name = odomName;
-        state_.last_wheels_odometry      = odom.odometry;
+        state_.last_wheels_odometry_name  = odomName;
+        state_.last_wheels_odometry       = odom.odometry;
+        state_.last_wheels_odometry_stamp = odom.timestamp;
         return;
     }
     // Use a probabilistic motion model:
@@ -432,9 +449,10 @@ void StateEstimationSmoother::fuse_odometry(
         mrpt::Clock::toDouble(odom.timestamp), odomName.c_str(), odom.odometry.asString().c_str(),
         odoAct.poseChange->getMeanVal().asString().c_str());
 
-    // Save for next iteration:
-    state_.last_wheels_odometry_name = odomName;
-    state_.last_wheels_odometry      = odom.odometry;
+    // Save for next iteration (advance the anchor: this reading was kept):
+    state_.last_wheels_odometry_name  = odomName;
+    state_.last_wheels_odometry       = odom.odometry;
+    state_.last_wheels_odometry_stamp = odom.timestamp;
 
     // Fuse this new probabilistic pose observation:
     fuse_pose_locked(odom.timestamp, newOdomPosePdf, odomName);
@@ -443,6 +461,21 @@ void StateEstimationSmoother::fuse_odometry(
 void StateEstimationSmoother::fuse_imu(const mrpt::obs::CObservationIMU& imu)
 {
     auto lck = mrpt::lockHelper(stateMutex_);
+
+    // High-rate decimation: skip IMU readings arriving too soon after the last
+    // processed one. IMU attitude/gravity are absolute observations, so dropping
+    // intermediate readings just lowers the redundant-factor rate (unlike wheel
+    // odometry, there is no increment to accumulate).
+    if (params_.imu_min_sample_period > 0 && state_.last_processed_imu_stamp.has_value())
+    {
+        const double dt =
+            mrpt::system::timeDifference(*state_.last_processed_imu_stamp, imu.timestamp);
+        if (dt < params_.imu_min_sample_period)
+        {
+            return;
+        }
+    }
+    state_.last_processed_imu_stamp = imu.timestamp;
 
     // Create a new KF id (or reuse a very close match):
     const auto this_kf_id = create_or_get_keyframe_by_timestamp_locked(
@@ -1575,8 +1608,12 @@ void StateEstimationSmoother::process_pending_gtsam_updates_locked()
         pdf.mean = mrpt::poses::CPose3D(mrpt::gtsam_wrappers::toTPose3D(T_enu_to_map));
         pdf.cov  = mrpt::gtsam_wrappers::to_mrpt_se3_cov6(T_enu_to_map_cov);
 
-        // Convert info matrix to covariance
-        if (!state_.stamp2frame_index.empty())
+        // Convergence check: only meaningful until the geo-reference is
+        // finalized. Once state_.geo_reference is set it is sticky, so
+        // re-evaluating it every solve just burns a marginalCovariance() on the
+        // latest keyframe and needlessly re-finalizes/re-publishes the same
+        // reference. Skip it once converged.
+        if (!state_.geo_reference.has_value() && !state_.stamp2frame_index.empty())
         {
             const auto& latestIt       = state_.stamp2frame_index.getDirectMap().rbegin();
             const auto  latestFrameIdx = latestIt->second;

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -356,6 +356,14 @@ void StateEstimationSmoother::reset_locked()
     {
         fastPredictor_->clear();
     }
+    // Drop any queued (and any already-detached) async work: it targets the old
+    // graph and must not repopulate the fresh one (required across
+    // set_geo_reference(), see coding guidelines).
+    {
+        std::lock_guard<std::mutex> lk(queueMutex_);
+        ingestQueue_.clear();
+        resetEpoch_.fetch_add(1, std::memory_order_relaxed);
+    }
     if (params_loaded_)
     {
         reinitialize_gtsam_locked();
@@ -365,8 +373,20 @@ void StateEstimationSmoother::reset_locked()
 void StateEstimationSmoother::enqueue_async(
     const mrpt::Clock::time_point& stamp, std::function<void()> fn)
 {
+    // Safety bound: the backend coalesces (drains all pending each iteration), so
+    // in normal operation the queue holds only one solve's worth of arrivals.
+    // This cap only trips if the backend stalls; dropping the oldest keeps memory
+    // bounded and is visible via the throttled warning.
+    constexpr size_t kMaxIngestQueue = 10000;
     {
         std::lock_guard<std::mutex> lk(queueMutex_);
+        if (ingestQueue_.size() >= kMaxIngestQueue)
+        {
+            ingestQueue_.pop_front();
+            MRPT_LOG_THROTTLE_WARN(
+                5.0,
+                "[async] ingest queue full: backend not keeping up, dropping oldest measurement");
+        }
         ingestQueue_.emplace_back(stamp, std::move(fn));
     }
     queueCv_.notify_one();
@@ -377,6 +397,7 @@ void StateEstimationSmoother::backend_loop()
     while (!backendStop_.load())
     {
         std::deque<std::pair<mrpt::Clock::time_point, std::function<void()>>> batch;
+        uint64_t                                                              batchEpoch = 0;
         {
             std::unique_lock<std::mutex> lk(queueMutex_);
             queueCv_.wait(lk, [this] { return backendStop_.load() || !ingestQueue_.empty(); });
@@ -385,6 +406,7 @@ void StateEstimationSmoother::backend_loop()
                 break;
             }
             batch.swap(ingestQueue_);
+            batchEpoch = resetEpoch_.load(std::memory_order_relaxed);
         }
 
         // Apply in timestamp order, so most residual out-of-order arrivals become
@@ -394,13 +416,34 @@ void StateEstimationSmoother::backend_loop()
             [](const auto& a, const auto& b) { return a.first < b.first; });
 
         auto lck = mrpt::lockHelper(stateMutex_);
-        for (auto& [stamp, fn] : batch)
+
+        // If a reset happened after this batch was detached, it targets a graph
+        // that no longer exists: discard it rather than corrupt the fresh one.
+        if (resetEpoch_.load(std::memory_order_relaxed) != batchEpoch)
         {
-            fn();
+            continue;
         }
-        // Runs the solve and, in async mode, publishes a fresh snapshot to the
-        // fast predictor.
-        process_pending_gtsam_updates_locked();
+
+        // A measurement callback or the solve can throw (e.g. an
+        // under-constrained marginal). In the backend thread that would escape
+        // to std::terminate, so contain it: log and rebuild the smoother.
+        try
+        {
+            for (auto& [stamp, fn] : batch)
+            {
+                fn();
+            }
+            // Runs the solve and, in async mode, publishes a fresh snapshot to
+            // the fast predictor.
+            process_pending_gtsam_updates_locked();
+        }
+        catch (const std::exception& e)
+        {
+            MRPT_LOG_ERROR_STREAM(
+                "[backend_loop] Exception while applying a batch; resetting smoother:\n"
+                << e.what());
+            reset_locked();
+        }
     }
 }
 
@@ -537,6 +580,18 @@ void StateEstimationSmoother::fuse_imu(const mrpt::obs::CObservationIMU& imu)
 
 void StateEstimationSmoother::fuse_imu_locked(const mrpt::obs::CObservationIMU& imu)
 {
+    // Ignore an IMU reading with no usable content up front, before touching the
+    // decimation stamp or creating a keyframe: otherwise an empty sample would
+    // consume the decimation interval (skipping the next, useful one) and add a
+    // factor-less keyframe.
+    const bool hasAttitude = imu.has(mrpt::obs::IMU_ORI_QUAT_W);
+    const bool hasGravity =
+        imu.has(mrpt::obs::IMU_X_ACC) && params_.imu_normalized_gravity_alignment_sigma > 0;
+    if (!hasAttitude && !hasGravity)
+    {
+        return;
+    }
+
     // High-rate decimation: skip IMU readings arriving too soon after the last
     // processed one. IMU attitude/gravity are absolute observations, so dropping
     // intermediate readings just lowers the redundant-factor rate (unlike wheel

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -1778,12 +1778,8 @@ void StateEstimationSmoother::process_pending_gtsam_updates_locked()
         pdf.mean = mrpt::poses::CPose3D(mrpt::gtsam_wrappers::toTPose3D(T_enu_to_map));
         pdf.cov  = mrpt::gtsam_wrappers::to_mrpt_se3_cov6(T_enu_to_map_cov);
 
-        // Convergence check: only meaningful until the geo-reference is
-        // finalized. Once state_.geo_reference is set it is sticky, so
-        // re-evaluating it every solve just burns a marginalCovariance() on the
-        // latest keyframe and needlessly re-finalizes/re-publishes the same
-        // reference. Skip it once converged.
-        if (!state_.geo_reference.has_value() && !state_.stamp2frame_index.empty())
+        // Convert info matrix to covariance
+        if (!state_.stamp2frame_index.empty())
         {
             const auto& latestIt       = state_.stamp2frame_index.getDirectMap().rbegin();
             const auto  latestFrameIdx = latestIt->second;

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -58,6 +58,10 @@
 #include "Snapshot.h"
 #include "extrapolation.h"
 
+// std:
+#include <algorithm>
+#include <utility>
+
 // arguments: class_name, parent_class, class namespace
 IMPLEMENTS_MRPT_OBJECT(
     StateEstimationSmoother, mola::ExecutableBase, mola::state_estimation_smoother)
@@ -160,7 +164,11 @@ StateEstimationSmoother::StateEstimationSmoother()
     fastPredictor_ = std::make_unique<FastPredictor>();
 }
 
-StateEstimationSmoother::~StateEstimationSmoother() = default;
+StateEstimationSmoother::~StateEstimationSmoother()
+{
+    // Join the backend thread before any member it touches is destroyed.
+    stop_backend_thread();
+}
 
 void StateEstimationSmoother::initialize(const mrpt::containers::yaml& cfg)
 {
@@ -216,6 +224,10 @@ void StateEstimationSmoother::initialize(const mrpt::containers::yaml& cfg)
 
     params_loaded_ = true;
     reinitialize_gtsam_locked();
+
+    // In async mode, spin up the backend solver thread. It immediately waits on
+    // an empty queue, so starting it while stateMutex_ is held is safe.
+    start_backend_thread();
 }
 
 void StateEstimationSmoother::reinitialize_gtsam_locked()
@@ -285,6 +297,12 @@ void StateEstimationSmoother::spinOnce()
     // Read the extrapolated stamp under the lock, then release before calling estimated_navstate()
     // to avoid recursive locking (estimated_navstate() acquires the mutex internally).
     std::optional<mrpt::Clock::time_point> tNowOpt;
+    if (params_.async_backend)
+    {
+        // Lock-free: the fast predictor tracks the freshest observation stamp.
+        tNowOpt = fastPredictor_->get_current_extrapolated_stamp();
+    }
+    else
     {
         auto lck = mrpt::lockHelper(stateMutex_);
         tNowOpt  = state_.get_current_extrapolated_stamp();
@@ -344,11 +362,93 @@ void StateEstimationSmoother::reset_locked()
     }
 }
 
+void StateEstimationSmoother::enqueue_async(
+    const mrpt::Clock::time_point& stamp, std::function<void()> fn)
+{
+    {
+        std::lock_guard<std::mutex> lk(queueMutex_);
+        ingestQueue_.emplace_back(stamp, std::move(fn));
+    }
+    queueCv_.notify_one();
+}
+
+void StateEstimationSmoother::backend_loop()
+{
+    while (!backendStop_.load())
+    {
+        std::deque<std::pair<mrpt::Clock::time_point, std::function<void()>>> batch;
+        {
+            std::unique_lock<std::mutex> lk(queueMutex_);
+            queueCv_.wait(lk, [this] { return backendStop_.load() || !ingestQueue_.empty(); });
+            if (backendStop_.load())
+            {
+                break;
+            }
+            batch.swap(ingestQueue_);
+        }
+
+        // Apply in timestamp order, so most residual out-of-order arrivals become
+        // in-order; cross-batch stragglers still splice, handled by the graph.
+        std::stable_sort(
+            batch.begin(), batch.end(),
+            [](const auto& a, const auto& b) { return a.first < b.first; });
+
+        auto lck = mrpt::lockHelper(stateMutex_);
+        for (auto& [stamp, fn] : batch)
+        {
+            fn();
+        }
+        // Runs the solve and, in async mode, publishes a fresh snapshot to the
+        // fast predictor.
+        process_pending_gtsam_updates_locked();
+    }
+}
+
+void StateEstimationSmoother::start_backend_thread()
+{
+    if (!params_.async_backend || backendRunning_)
+    {
+        return;
+    }
+    backendStop_.store(false);
+    backendRunning_ = true;
+    backendThread_  = std::thread(&StateEstimationSmoother::backend_loop, this);
+}
+
+void StateEstimationSmoother::stop_backend_thread()
+{
+    if (!backendRunning_)
+    {
+        return;
+    }
+    backendStop_.store(true);
+    queueCv_.notify_all();
+    if (backendThread_.joinable())
+    {
+        backendThread_.join();
+    }
+    backendRunning_ = false;
+}
+
 void StateEstimationSmoother::fuse_odometry(
     const mrpt::obs::CObservationOdometry& odom, const std::string& odomName)
 {
+    if (params_.async_backend)
+    {
+        fastPredictor_->note_observation_stamp(odom.timestamp);
+        const auto odomCopy = odom;
+        enqueue_async(
+            odom.timestamp,
+            [this, odomCopy, odomName] { fuse_odometry_locked(odomCopy, odomName); });
+        return;
+    }
     auto lck = mrpt::lockHelper(stateMutex_);
+    fuse_odometry_locked(odom, odomName);
+}
 
+void StateEstimationSmoother::fuse_odometry_locked(
+    const mrpt::obs::CObservationOdometry& odom, const std::string& odomName)
+{
     // Integrates new wheels-based odometry observations into the estimator.
     //  This is a convenience method that internally ends up calling
     //  fuse_pose(), but computing the uncertainty of odometry increments
@@ -424,8 +524,19 @@ void StateEstimationSmoother::fuse_odometry(
 
 void StateEstimationSmoother::fuse_imu(const mrpt::obs::CObservationIMU& imu)
 {
+    if (params_.async_backend)
+    {
+        fastPredictor_->note_observation_stamp(imu.timestamp);
+        const auto imuCopy = imu;
+        enqueue_async(imu.timestamp, [this, imuCopy] { fuse_imu_locked(imuCopy); });
+        return;
+    }
     auto lck = mrpt::lockHelper(stateMutex_);
+    fuse_imu_locked(imu);
+}
 
+void StateEstimationSmoother::fuse_imu_locked(const mrpt::obs::CObservationIMU& imu)
+{
     // High-rate decimation: skip IMU readings arriving too soon after the last
     // processed one. IMU attitude/gravity are absolute observations, so dropping
     // intermediate readings just lowers the redundant-factor rate (unlike wheel
@@ -511,8 +622,19 @@ void StateEstimationSmoother::fuse_imu(const mrpt::obs::CObservationIMU& imu)
 
 void StateEstimationSmoother::fuse_gnss(const mrpt::obs::CObservationGPS& gps)
 {
+    if (params_.async_backend)
+    {
+        fastPredictor_->note_observation_stamp(gps.timestamp);
+        const auto gpsCopy = gps;
+        enqueue_async(gps.timestamp, [this, gpsCopy] { fuse_gnss_locked(gpsCopy); });
+        return;
+    }
     auto lck = mrpt::lockHelper(stateMutex_);
+    fuse_gnss_locked(gps);
+}
 
+void StateEstimationSmoother::fuse_gnss_locked(const mrpt::obs::CObservationGPS& gps)
+{
     if (!gps.has_GGA_datum())
     {
         MRPT_LOG_DEBUG("[fuse_gnss]: Ignoring reading since it has no GGA data.");
@@ -600,6 +722,14 @@ void StateEstimationSmoother::fuse_pose(
     const mrpt::Clock::time_point& timestamp, const mrpt::poses::CPose3DPDFGaussian& pose,
     const std::string& frame_id)
 {
+    if (params_.async_backend)
+    {
+        fastPredictor_->note_observation_stamp(timestamp);
+        enqueue_async(
+            timestamp,
+            [this, timestamp, pose, frame_id] { fuse_pose_locked(timestamp, pose, frame_id); });
+        return;
+    }
     auto lck = mrpt::lockHelper(stateMutex_);
     fuse_pose_locked(timestamp, pose, frame_id);
 }
@@ -680,8 +810,22 @@ void StateEstimationSmoother::fuse_twist(
     const mrpt::Clock::time_point& timestamp, const mrpt::math::TTwist3D& twist,
     const mrpt::math::CMatrixDouble66& twistCov)
 {
+    if (params_.async_backend)
+    {
+        fastPredictor_->note_observation_stamp(timestamp);
+        enqueue_async(
+            timestamp,
+            [this, timestamp, twist, twistCov] { fuse_twist_locked(timestamp, twist, twistCov); });
+        return;
+    }
     auto lck = mrpt::lockHelper(stateMutex_);
+    fuse_twist_locked(timestamp, twist, twistCov);
+}
 
+void StateEstimationSmoother::fuse_twist_locked(
+    const mrpt::Clock::time_point& timestamp, const mrpt::math::TTwist3D& twist,
+    const mrpt::math::CMatrixDouble66& twistCov)
+{
     const gtsam::Vector3 v    = {twist.vx, twist.vy, twist.vz};
     const gtsam::Vector3 w    = {twist.wx, twist.wy, twist.wz};
     gtsam::Matrix3       vCov = twistCov.asEigen().block<3, 3>(0, 0);
@@ -737,6 +881,13 @@ void StateEstimationSmoother::fuse_twist(
 std::optional<NavState> StateEstimationSmoother::estimated_navstate(
     const mrpt::Clock::time_point& timestamp, const std::string& frame_id)
 {
+    // Async mode: served sub-ms by the lock-free fast predictor, without running
+    // a solve or taking stateMutex_ (the backend thread may be holding it).
+    if (params_.async_backend)
+    {
+        return fastPredictor_->predict(timestamp, frame_id, params_);
+    }
+
     auto lck = mrpt::lockHelper(stateMutex_);
 
     // 1) Make sure we processed all pending sensor data, and have updated the cached values from

--- a/mola_state_estimation_smoother/src/extrapolation.h
+++ b/mola_state_estimation_smoother/src/extrapolation.h
@@ -1,0 +1,78 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   extrapolation.h
+ * @brief  Kinematic short-term extrapolation shared by the backend smoother and
+ *         the fast predictor, so both integrate a body twist identically.
+ * @author Jose Luis Blanco Claraco
+ */
+#pragma once
+
+#include <mola_state_estimation_smoother/Parameters.h>
+#include <mrpt/math/CVectorFixed.h>
+#include <mrpt/math/TTwist3D.h>
+#include <mrpt/poses/CPose3D.h>
+#include <mrpt/poses/Lie/SE.h>
+
+#include <cmath>
+
+namespace mola::state_estimation_smoother
+{
+/** Integrates a constant body-frame twist over `dt` seconds, returning the
+ *  relative pose increment T_i_to_j (right-composed onto an anchor: T_j = T_i
+ *  (+) delta). Branches on the configured kinematic model so the short-term
+ *  extrapolation matches the motion model used to build the inter-keyframe
+ *  factors: full SE(3) exp of the 6D body twist for ConstantVelocity; the planar
+ *  arc from forward velocity v=vx and yaw rate w=wz for Tricycle, mirroring
+ *  mola::factors::FactorTricycleKinematic exactly.
+ */
+inline mrpt::poses::CPose3D body_twist_delta(
+    const Parameters& params, const mrpt::math::TTwist3D& twist, double dt)
+{
+    switch (params.kinematic_model)
+    {
+        case KinematicModel::Tricycle:
+        {
+            constexpr double w_threshold = 1e-4;  // [rad/s], as FactorTricycleKinematic
+            const double     v           = twist.vx;
+            const double     w           = twist.wz;
+            if (std::abs(w) < w_threshold)
+            {
+                return mrpt::poses::CPose3D(v * dt, .0, .0, .0, .0, .0);
+            }
+            const double R     = v / w;
+            const double theta = w * dt;
+            const double dx    = R * std::sin(theta);
+            const double dy    = R * (1.0 - std::cos(theta));
+            // CPose3D(x, y, z, yaw, pitch, roll); the arc rotates about +z (yaw).
+            return mrpt::poses::CPose3D(dx, dy, .0, theta, .0, .0);
+        }
+        case KinematicModel::ConstantVelocity:
+        default:
+        {
+            mrpt::math::CVectorFixed<double, 6> twistDt;
+            twistDt[0] = twist.vx;
+            twistDt[1] = twist.vy;
+            twistDt[2] = twist.vz;
+            twistDt[3] = twist.wx;
+            twistDt[4] = twist.wy;
+            twistDt[5] = twist.wz;
+            twistDt *= dt;
+            return mrpt::poses::CPose3D(mrpt::poses::Lie::SE<3>::exp(twistDt));
+        }
+    }
+}
+
+}  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/tests/CMakeLists.txt
+++ b/mola_state_estimation_smoother/tests/CMakeLists.txt
@@ -69,3 +69,10 @@ mola_add_test(
     mola::mola_state_estimation_smoother
 )
 
+mola_add_test(
+  TARGET  test-async-navstate
+  SOURCES test-async-navstate.cpp
+  LINK_LIBRARIES
+    mola::mola_state_estimation_smoother
+)
+

--- a/mola_state_estimation_smoother/tests/CMakeLists.txt
+++ b/mola_state_estimation_smoother/tests/CMakeLists.txt
@@ -62,3 +62,10 @@ mola_add_test(
     mola::mola_state_estimation_smoother
 )
 
+mola_add_test(
+  TARGET  test-keyframe-decimation
+  SOURCES test-keyframe-decimation.cpp
+  LINK_LIBRARIES
+    mola::mola_state_estimation_smoother
+)
+

--- a/mola_state_estimation_smoother/tests/test-async-navstate.cpp
+++ b/mola_state_estimation_smoother/tests/test-async-navstate.cpp
@@ -200,6 +200,51 @@ void test_concurrency()
     ASSERT_GT_(queries.load(), static_cast<size_t>(0));
 }
 
+// reset() while the async backend is running (and may have work in flight) must
+// discard the stale queue and rebuild cleanly, then track a fresh trajectory.
+void test_reset_during_async()
+{
+    mola::state_estimation_smoother::StateEstimationSmoother est;
+    est.initialize(mrpt::containers::yaml::FromText(params_yaml(true)));
+
+    // Phase A: feed some poses, then immediately reset (Phase A work may still be
+    // queued / in flight in the backend when the reset lands).
+    for (size_t i = 0; i < 30; i++)
+    {
+        est.fuse_pose(
+            mrpt::Clock::fromDouble(POSE_DT * static_cast<double>(i)), pose_at(i), ODOM_FRAME);
+    }
+    est.reset();
+
+    // Phase B: a fresh trajectory (restarting at the origin) at later timestamps.
+    constexpr double        PHASE_B_T0 = 100.0;
+    mrpt::Clock::time_point last;
+    for (size_t i = 0; i < NUM_POSES; i++)
+    {
+        const auto stamp = mrpt::Clock::fromDouble(PHASE_B_T0 + POSE_DT * static_cast<double>(i));
+        last             = stamp;
+        est.fuse_pose(stamp, pose_at(i), ODOM_FRAME);
+    }
+
+    double mapX = std::nan("");
+    for (int iter = 0; iter < 800; iter++)
+    {
+        const auto nav = est.estimated_navstate(last, "map");
+        if (nav.has_value())
+        {
+            mapX = nav->pose.mean.x();
+            if (std::abs(mapX - EXPECTED_X) < 0.05)
+            {
+                break;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    std::cout << "reset-during-async map x: " << mapX << " (expected " << EXPECTED_X << ")\n";
+    ASSERT_(std::isfinite(mapX));
+    ASSERT_LT_(std::abs(mapX - EXPECTED_X), 0.05);
+}
+
 }  // namespace
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
@@ -208,6 +253,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
     {
         test_equivalence();
         test_concurrency();
+        test_reset_during_async();
         std::cout << "✅ SUCCESS\n";
         return 0;
     }

--- a/mola_state_estimation_smoother/tests/test-async-navstate.cpp
+++ b/mola_state_estimation_smoother/tests/test-async-navstate.cpp
@@ -1,0 +1,219 @@
+/* _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   test-async-navstate.cpp
+ * @brief  Async backend: eventual correctness, sync-equivalence, and a
+ *         concurrency stress (no deadlock/crash while querying under load).
+ * @author Jose Luis Blanco Claraco
+ */
+
+#include <mola_state_estimation_smoother/StateEstimationSmoother.h>
+#include <mrpt/core/get_env.h>
+#include <mrpt/poses/CPose3D.h>
+
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <thread>
+
+using namespace std::string_literals;
+
+namespace
+{
+const bool VERBOSE = mrpt::get_env<bool>("VERBOSE", false);
+
+constexpr double POSE_DT    = 0.05;  // [s]  (20 Hz)
+constexpr double VELOCITY_X = 1.0;  // [m/s]
+constexpr size_t NUM_POSES  = 60;
+const double     EXPECTED_X = VELOCITY_X * POSE_DT * static_cast<double>(NUM_POSES - 1);
+const char*      ODOM_FRAME = "odom";
+
+std::string params_yaml(bool async)
+{
+    return
+        R"###(
+params:
+    vehicle_frame_name: "base_link"
+    reference_frame_name: "map"
+    link_first_pose_to_reference_origin_sigma: 1e-6
+    kinematic_model: KinematicModel::ConstantVelocity
+    sliding_window_length: 10.0
+    max_time_to_use_velocity_model: 5.0
+    sigma_random_walk_acceleration_linear: 2.0
+    sigma_random_walk_acceleration_angular: 1.0
+    sigma_integrator_position: 0.10
+    sigma_integrator_orientation: 0.10
+    estimate_geo_reference: false
+    async_backend: )###" +
+        (async ? "true"s : "false"s) + "\n";
+}
+
+mrpt::poses::CPose3DPDFGaussian pose_at(size_t i)
+{
+    mrpt::poses::CPose3DPDFGaussian p;
+    p.mean = mrpt::poses::CPose3D(VELOCITY_X * POSE_DT * static_cast<double>(i), 0, 0, 0, 0, 0);
+    p.cov.setDiagonal(0.001);
+    return p;
+}
+
+/// Feeds NUM_POSES into a sync instance and returns the final map-frame x.
+double run_sync()
+{
+    mola::state_estimation_smoother::StateEstimationSmoother est;
+    est.initialize(mrpt::containers::yaml::FromText(params_yaml(false)));
+
+    mrpt::Clock::time_point last;
+    for (size_t i = 0; i < NUM_POSES; i++)
+    {
+        const auto stamp = mrpt::Clock::fromDouble(POSE_DT * static_cast<double>(i));
+        last             = stamp;
+        est.fuse_pose(stamp, pose_at(i), ODOM_FRAME);
+    }
+    const auto nav = est.estimated_navstate(last, "map");
+    ASSERT_(nav.has_value());
+    return nav->pose.mean.x();
+}
+
+/// Feeds NUM_POSES into an async instance, waits for the backend to catch up,
+/// and returns the final x in both the {map} and {odom} frames.
+std::pair<double, double> run_async()
+{
+    mola::state_estimation_smoother::StateEstimationSmoother est;
+    if (VERBOSE)
+    {
+        est.setMinLoggingLevel(mrpt::system::LVL_DEBUG);
+    }
+    est.initialize(mrpt::containers::yaml::FromText(params_yaml(true)));
+
+    mrpt::Clock::time_point last;
+    for (size_t i = 0; i < NUM_POSES; i++)
+    {
+        const auto stamp = mrpt::Clock::fromDouble(POSE_DT * static_cast<double>(i));
+        last             = stamp;
+        est.fuse_pose(stamp, pose_at(i), ODOM_FRAME);
+    }
+
+    // Poll until the backend has solved enough that the map-frame estimate
+    // reaches the expected endpoint (or time out).
+    double mapX  = std::nan("");
+    double odomX = std::nan("");
+    for (int iter = 0; iter < 800; iter++)  // up to ~4 s
+    {
+        const auto navMap = est.estimated_navstate(last, "map");
+        if (navMap.has_value())
+        {
+            mapX = navMap->pose.mean.x();
+            if (std::abs(mapX - EXPECTED_X) < 0.05)
+            {
+                const auto navOdom = est.estimated_navstate(last, ODOM_FRAME);
+                if (navOdom.has_value())
+                {
+                    odomX = navOdom->pose.mean.x();
+                    break;
+                }
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return {mapX, odomX};
+}
+
+void test_equivalence()
+{
+    const double syncX                 = run_sync();
+    const auto [asyncMapX, asyncOdomX] = run_async();
+
+    std::cout << "expected x:      " << EXPECTED_X << "\n";
+    std::cout << "sync map x:      " << syncX << "\n";
+    std::cout << "async map x:     " << asyncMapX << "\n";
+    std::cout << "async odom x:    " << asyncOdomX << "\n";
+
+    ASSERT_(std::isfinite(asyncMapX));
+    ASSERT_(std::isfinite(asyncOdomX));
+    // Async eventually reaches the correct fused pose...
+    ASSERT_LT_(std::abs(asyncMapX - EXPECTED_X), 0.05);
+    // ...and the frame-local {odom} path agrees too...
+    ASSERT_LT_(std::abs(asyncOdomX - EXPECTED_X), 0.10);
+    // ...and matches the synchronous estimator on the same input.
+    ASSERT_LT_(std::abs(asyncMapX - syncX), 0.05);
+}
+
+// Hammer fuse_*() from several threads while querying, to shake out deadlocks
+// and data races in the async ingest path.
+void test_concurrency()
+{
+    mola::state_estimation_smoother::StateEstimationSmoother est;
+    est.initialize(mrpt::containers::yaml::FromText(params_yaml(true)));
+
+    std::atomic<bool>   stop{false};
+    std::atomic<size_t> queries{0};
+    std::atomic<double> lastStampSec{0.0};
+
+    std::thread producer(
+        [&]
+        {
+            for (size_t i = 0; i < 400; i++)
+            {
+                const double tsec = POSE_DT * static_cast<double>(i);
+                est.fuse_pose(mrpt::Clock::fromDouble(tsec), pose_at(i), ODOM_FRAME);
+                lastStampSec.store(tsec);
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            stop = true;
+        });
+
+    std::thread consumer(
+        [&]
+        {
+            while (!stop.load())
+            {
+                const double tsec = lastStampSec.load();
+                if (tsec > 0.0)
+                {
+                    if (est.estimated_navstate(mrpt::Clock::fromDouble(tsec), "map").has_value())
+                    {
+                        queries++;
+                    }
+                }
+                std::this_thread::sleep_for(std::chrono::microseconds(200));
+            }
+        });
+
+    producer.join();
+    consumer.join();
+
+    std::cout << "concurrency: served " << queries.load() << " queries, no deadlock\n";
+    ASSERT_GT_(queries.load(), static_cast<size_t>(0));
+}
+
+}  // namespace
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+    try
+    {
+        test_equivalence();
+        test_concurrency();
+        std::cout << "✅ SUCCESS\n";
+        return 0;
+    }
+    catch (std::exception& e)
+    {
+        std::cerr << "❌ FAILED: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/mola_state_estimation_smoother/tests/test-async-navstate.cpp
+++ b/mola_state_estimation_smoother/tests/test-async-navstate.cpp
@@ -173,7 +173,6 @@ void test_concurrency()
                 lastStampSec.store(tsec);
                 std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
-            stop = true;
         });
 
     std::thread consumer(
@@ -194,6 +193,15 @@ void test_concurrency()
         });
 
     producer.join();
+
+    // The backend may still be catching up when the producer finishes; give the
+    // consumer a bounded window to land at least one successful query, so a slow
+    // CI host does not fail a correct implementation.
+    for (int i = 0; i < 400 && queries.load() == 0; i++)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    stop = true;
     consumer.join();
 
     std::cout << "concurrency: served " << queries.load() << " queries, no deadlock\n";

--- a/mola_state_estimation_smoother/tests/test-keyframe-decimation.cpp
+++ b/mola_state_estimation_smoother/tests/test-keyframe-decimation.cpp
@@ -1,0 +1,152 @@
+/* _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   test-keyframe-decimation.cpp
+ * @brief  Verifies odometry_min_sample_period merges high-rate wheel odometry
+ *         into fewer keyframes without losing motion.
+ * @author Jose Luis Blanco Claraco
+ */
+
+#include <mola_state_estimation_smoother/StateEstimationSmoother.h>
+#include <mrpt/core/get_env.h>
+#include <mrpt/obs/CObservationOdometry.h>
+#include <mrpt/poses/CPose2D.h>
+#include <mrpt/poses/CPose3D.h>
+
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <utility>
+
+using namespace std::string_literals;
+using namespace mrpt::literals;
+
+namespace
+{
+const bool VERBOSE = mrpt::get_env<bool>("VERBOSE", false);
+
+// High-rate odometry: 50 Hz for 2 s.
+constexpr double ODOM_DT      = 0.02;  // [s]  (50 Hz)
+constexpr double DURATION     = 2.0;  // [s]
+constexpr double VELOCITY_X   = 1.0;  // [m/s]
+constexpr double DECIM_PERIOD = 0.10;  // [s]  (target ~10 Hz keyframes)
+constexpr size_t NUM_READINGS = static_cast<size_t>(DURATION / ODOM_DT) + 1;  // 101
+
+std::string params_yaml(double odometryMinSamplePeriod)
+{
+    return
+        R"###(
+params:
+    vehicle_frame_name: "base_link"
+    reference_frame_name: "map"
+    link_first_pose_to_reference_origin_sigma: 1e-6
+    kinematic_model: KinematicModel::ConstantVelocity
+    sliding_window_length: 10.0
+    max_time_to_use_velocity_model: 2.0
+    sigma_random_walk_acceleration_linear: 2.0
+    sigma_random_walk_acceleration_angular: 1.0
+    sigma_integrator_position: 0.10
+    sigma_integrator_orientation: 0.10
+    estimate_geo_reference: false
+    odometry_min_sample_period: )###" +
+        std::to_string(odometryMinSamplePeriod) + "\n";
+}
+
+/// Feeds NUM_READINGS of constant-velocity wheel odometry and returns
+/// {number of kinematic links live in the graph, final estimated map-frame x}.
+std::pair<size_t, double> run(double odometryMinSamplePeriod)
+{
+    mola::state_estimation_smoother::StateEstimationSmoother est;
+    if (VERBOSE)
+    {
+        est.setMinLoggingLevel(mrpt::system::LVL_DEBUG);
+    }
+    est.initialize(mrpt::containers::yaml::FromText(params_yaml(odometryMinSamplePeriod)));
+
+    mrpt::Clock::time_point lastStamp;
+    for (size_t i = 0; i < NUM_READINGS; i++)
+    {
+        const double t     = ODOM_DT * static_cast<double>(i);
+        const auto   stamp = mrpt::Clock::fromDouble(t);
+        lastStamp          = stamp;
+
+        mrpt::obs::CObservationOdometry odom;
+        odom.timestamp = stamp;
+        odom.odometry  = mrpt::poses::CPose2D(VELOCITY_X * t, 0.0, 0.0);
+
+        est.fuse_odometry(odom, "wheels_odom");
+    }
+
+    // Query first: this flushes pending factors into the smoother so that
+    // const_vel_factor_links_for_testing() sees the final graph topology.
+    const auto   navOpt = est.estimated_navstate(lastStamp, "map");
+    const double finalX = navOpt.has_value() ? navOpt->pose.mean.x() : std::nan("");
+    const auto   links  = est.const_vel_factor_links_for_testing();
+
+    return {links.size(), finalX};
+}
+
+void run_test()
+{
+    // 1) No decimation: one keyframe per reading (minus the first, which only
+    //    seeds the anchor). Baseline for the ratio.
+    const auto [linksFull, finalXFull] = run(0.0);
+    // 2) Decimation at 0.10 s => ~10 Hz keyframes over the 2 s run.
+    const auto [linksDecim, finalXDecim] = run(DECIM_PERIOD);
+
+    std::cout << "links (no decimation): " << linksFull << "\n";
+    std::cout << "links (decimated):     " << linksDecim << "\n";
+    std::cout << "final x (no decim):    " << finalXFull << "\n";
+    std::cout << "final x (decimated):   " << finalXDecim << "\n";
+
+    // The final vehicle x must reach ~2.0 m regardless of decimation: the merge
+    // must not lose motion (this is the key correctness property). The decimated
+    // run is served by a coarser keyframe grid, so the single-step endpoint
+    // extrapolation is looser; a lost *merge* would drop whole 0.1 m segments
+    // and compound far beyond this, so this bound still guards the property.
+    ASSERT_(std::isfinite(finalXFull));
+    ASSERT_(std::isfinite(finalXDecim));
+    ASSERT_LT_(std::abs(finalXFull - DURATION * VELOCITY_X), 0.05);
+    ASSERT_LT_(std::abs(finalXDecim - DURATION * VELOCITY_X), 0.15);
+    // The two configurations must agree: decimation preserves the trajectory.
+    ASSERT_LT_(std::abs(finalXFull - finalXDecim), 0.15);
+
+    // No decimation: ~100 links (one per reading beyond the first).
+    ASSERT_GT_(linksFull, static_cast<size_t>(90));
+
+    // Decimated: ~ DURATION/DECIM_PERIOD = 20 links, a several-fold reduction.
+    ASSERT_LT_(linksDecim, static_cast<size_t>(30));
+    ASSERT_GT_(linksDecim, static_cast<size_t>(10));
+
+    // And it must be a real reduction vs the baseline (guards against a no-op).
+    ASSERT_LT_(linksDecim * 3, linksFull);
+}
+
+}  // namespace
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+    try
+    {
+        run_test();
+        std::cout << "✅ SUCCESS\n";
+        return 0;
+    }
+    catch (std::exception& e)
+    {
+        std::cerr << "❌ FAILED: " << e.what() << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
## Motivation

On a real multi-sensor run (LiDAR + IMU + wheel-odom + GNSS), the front end's
per-scan call to `estimated_navstate()` was measured at **~24 ms mean / 65 ms
max** — about **2x the cost of the ICP registration itself**. The reason is
structural: on every query, `estimated_navstate()` first runs a full iSAM2
window solve plus several `marginalCovariance()` calls under `stateMutex_`, on
the caller's thread.

This PR makes that query return in **microseconds**, mainly by moving the solve
off the query thread, and adds two smaller synchronous cost reductions that
stand on their own.

## What changed

**1. Profiler sub-entries** — `process_pending_gtsam_updates` is broken down
(iSAM2 update / calculateEstimate / writeback / georef & odom-frame marginals /
anchor marginals) so the per-query cost is attributable.

**2. High-rate same-sensor decimation** (new params `odometry_min_sample_period`,
`imu_min_sample_period`, both default `0` = off). A high-rate stream otherwise
creates one keyframe per reading. When set:
- wheel odometry is **merged**: a reading within the period of the last kept one
  is dropped without advancing the pose anchor, so the next kept reading fuses
  the whole accumulated increment + covariance (no motion lost);
- IMU is **skipped** (attitude/gravity are absolute).

**3. Skip finalized-georef marginals** — the convergence check re-ran a marginal
and re-published the same georeference on every solve after convergence; now
gated on the reference not yet being set.

**4. Async backend + lock-free FastPredictor** (`async_backend`, default `false`).
The iSAM2 solve runs in a dedicated thread; `estimated_navstate()` /
`spinOnce()` are served by a `FastPredictor` that extrapolates the latest solved
`Snapshot` with the configured kinematic model. A query then runs no solve and
never takes `stateMutex_`. The frame-local `{odom_i}` hardening is preserved
(a query anchors on that source's own last raw pose). The synchronous path is
byte-for-byte unchanged (deterministic offline/unit runs).

## Result

With `async_backend` + decimation on the same run:

| `estimated_navstate()` | before | after |
|---|---|---|
| mean | ~24 ms | **~15 µs** |
| max | ~65 ms | **~50 µs** |

No crashes; localization/trajectory quality unaffected.

## Tests

`colcon test` green (26/26), including:
- `test-keyframe-decimation`: a 50 Hz stream collapses from 99 to 15 kinematic
  links with the endpoint pose preserved.
- `test-async-navstate`: async reaches the correct fused pose and matches the
  synchronous estimator to <1 mm on the same input; the frame-local `{odom}`
  path agrees; 1600+ concurrent queries run against a producer with no deadlock.

All new behavior is opt-in and defaults off, so this is a no-op for existing
configurations.

## Notes / follow-ups

- `async_backend` ships default `false`; propose flipping after broader field
  validation.
- Next step (separate PR): publish `map->odom` directly from the graph variable
  and let the ROS bridge forward it verbatim (removes the REP-105 stale-odom
  composition), plus an optional high-rate `base_link_fused` TF.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional wheel-odometry and IMU sample decimation to reduce redundant processing while preserving trajectory estimates.
  * Added an optional asynchronous backend for responsive, lock-free navigation-state queries.
  * Added configurable prediction buffering and environment-based settings.

* **Bug Fixes**
  * Improved handling of closely spaced sensor readings and asynchronous estimate availability.

* **Tests**
  * Added coverage for sensor decimation, asynchronous estimates, concurrency, and trajectory consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->