### PR TITLE
Publish map->odom from the estimator's own graph variable (+ optional base_link_fused)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,8 +208,27 @@ colcon test-result --verbose
 ## ROS 2 integration
 
 The smoother integrates with ROS 2 via the `mola_launcher` node and a ROS 2
-bridge. It publishes `map -> base_link` on `/tf` (does **not** follow REP 105's
-`map -> odom -> base_link` chain by default).
+bridge. By default it advertises the fused `map -> base_link` pose (the bridge
+publishes it to `/tf`, either directly or, in its REP-105 mode, composed into
+`map -> odom`).
+
+Optional additional TF outputs (both default off, additive, distinct
+`method` suffixes so the bridge's TF/odometry source filters route them
+independently):
+
+- `publish_map_to_odom_tf`: advertise `map -> odom` (method `/map_odom`) taken
+  directly from the estimator's own `T_map_to_odom` graph variable. It is smooth
+  and time-consistent, so the bridge forwards it to `/tf` verbatim (its
+  `child_frame != base_link` path), avoiding the stale
+  `(map->base_link)*(odom->base_link)^-1` composition that otherwise injects
+  motion-correlated jitter. Point the bridge's TF source filter at the
+  `/map_odom` method. `map_to_odom_frame_name` selects the odometry frame
+  (auto if exactly one is known).
+- `publish_fused_vehicle_tf`: advertise the fused vehicle pose in a distinct
+  child frame `fused_vehicle_frame_name` (default `base_link_fused`, method
+  `/fused`) at the module rate. A distinct child never collides with an
+  `odom -> base_link` chain, giving consumers a high-rate fused pose outside the
+  canonical robot tree.
 
 ROS 2 launch file:
 `mola_state_estimation_smoother/ros2-launchs/ros2-state-estimator.launch.py`

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
@@ -61,6 +61,36 @@ class Parameters
     /// The ENU geo-reference frame. See the docs online.
     std::string enu_frame_name = "enu";
 
+    /** If true, `spinOnce()` additionally advertises the REP-105 correction
+     * `reference_frame -> map_to_odom_frame_name` (i.e. `map -> odom`), taken
+     * directly from the estimator's own `T_map_to_odom_i` graph variable. This
+     * is time-consistent and smooth by construction, so the ROS bridge can
+     * forward it to `/tf` verbatim instead of composing it from
+     * `(map->base_link) * (odom->base_link)^-1` (that composition samples the
+     * two factors at mismatched timestamps and injects motion-correlated
+     * jitter). The primary `reference_frame -> vehicle_frame` update is still
+     * advertised, so the high-rate vehicle-pose topic is unchanged. The extra
+     * update carries a distinct `method` suffix (`/map_odom`) so the bridge's
+     * TF/odometry source filters can route it independently. Default off. */
+    bool publish_map_to_odom_tf = false;
+
+    /** The odometry frame_id whose `T_map_to_odom` is published when
+     * `publish_map_to_odom_tf` is true. Empty = auto-select when exactly one
+     * odometry source is known (the common single-wheel-odometry case);
+     * required if several odometry sources exist. */
+    std::string map_to_odom_frame_name;
+
+    /** If true, `spinOnce()` additionally advertises the fused vehicle pose in a
+     * separate child frame `fused_vehicle_frame_name` (default `base_link_fused`)
+     * at the module rate. Because it is a distinct child frame it never collides
+     * with a `odom -> base_link` chain on `/tf`, so it gives consumers a
+     * high-rate fused pose without touching the canonical robot tree (no sensor
+     * frames hang off it). Default off. */
+    bool publish_fused_vehicle_tf = false;
+
+    /// Child frame name for `publish_fused_vehicle_tf`.
+    std::string fused_vehicle_frame_name = "base_link_fused";
+
     /** @}  */
 
     /** @name Kinematic factors and keyframe creation (motion model)

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -443,6 +443,10 @@ class StateEstimationSmoother : public mola::NavStateFilter,
 
     void publishEstimatedGeoreferencing();
 
+    /// Advertises the REP-105 correction reference_frame -> {odom} from the
+    /// estimator's own T_map_to_odom_i (see publish_map_to_odom_tf).
+    void publishMapToOdom(const mrpt::Clock::time_point& stamp, const std::string& methodLabel);
+
     using pair_nearby_frame_iterators_t = std::pair<
         std::map<mrpt::Clock::time_point, frame_index_t>::const_iterator,
         std::map<mrpt::Clock::time_point, frame_index_t>::const_iterator>;

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -27,6 +27,23 @@ params:
   # The ENU geo-reference frame
   enu_frame_name: "enu"
 
+  # If true, also advertise the REP-105 correction map->odom taken directly from
+  # the estimator's own T_map_to_odom graph variable (smooth, time-consistent),
+  # so the ROS bridge forwards it to /tf verbatim instead of composing it from
+  # (map->base_link)*(odom->base_link)^-1 (that composition injects jitter). The
+  # extra update uses the method suffix "/map_odom" for independent routing.
+  # Requires the bridge's TF source filter to point at that method. Default off.
+  publish_map_to_odom_tf: ${MOLA_PUBLISH_MAP_TO_ODOM_TF|false}
+  # Which odometry frame_id's T_map_to_odom to publish. Empty = auto-select when
+  # exactly one odometry source is known; required if there are several.
+  map_to_odom_frame_name: "${MOLA_MAP_TO_ODOM_FRAME|}"
+
+  # If true, also advertise the fused vehicle pose in a distinct child frame
+  # (below) at the module rate: a high-rate fused pose that never collides with
+  # an odom->base_link chain on /tf. Default off.
+  publish_fused_vehicle_tf: ${MOLA_PUBLISH_FUSED_VEHICLE_TF|false}
+  fused_vehicle_frame_name: "${MOLA_TF_BASE_LINK_FUSED|base_link_fused}"
+
   # --------------------------------------------------------------------------
   # Kinematic Model & Motion Factors
   # --------------------------------------------------------------------------

--- a/mola_state_estimation_smoother/src/Parameters.cpp
+++ b/mola_state_estimation_smoother/src/Parameters.cpp
@@ -31,6 +31,10 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
     MCP_LOAD_REQ(cfg, vehicle_frame_name);
     MCP_LOAD_REQ(cfg, reference_frame_name);
     MCP_LOAD_OPT(cfg, enu_frame_name);
+    MCP_LOAD_OPT(cfg, publish_map_to_odom_tf);
+    MCP_LOAD_OPT(cfg, map_to_odom_frame_name);
+    MCP_LOAD_OPT(cfg, publish_fused_vehicle_tf);
+    MCP_LOAD_OPT(cfg, fused_vehicle_frame_name);
 
     // Kinematic factors and keyframe creation (motion model)
     // -------------------------------------------------------

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -321,24 +321,89 @@ void StateEstimationSmoother::spinOnce()
         return;
     }
 
-    LocalizationUpdate lu;
-    lu.child_frame     = params_.vehicle_frame_name;
-    lu.reference_frame = params_.reference_frame_name;
-
     // Use just the YAML label part of the module instance name
     // (e.g. "state_estimation" from "FullClassName:state_estimation"),
     // since this string is used as a ROS topic prefix and filter key:
-    const auto& fullName = getModuleInstanceName();
-    const auto  colonPos = fullName.rfind(':');
-    lu.method    = (colonPos != std::string::npos) ? fullName.substr(colonPos + 1) : fullName;
-    lu.quality   = 1;
-    lu.timestamp = *tNowOpt;
-    lu.pose      = nv->pose.getPoseMean().asTPose();
-    lu.cov       = nv->pose.cov_inv.inverse();
+    const auto&       fullName = getModuleInstanceName();
+    const auto        colonPos = fullName.rfind(':');
+    const std::string methodLabel =
+        (colonPos != std::string::npos) ? fullName.substr(colonPos + 1) : fullName;
+
+    // Primary output: the fused vehicle pose in the reference ({map}) frame.
+    LocalizationUpdate lu;
+    lu.child_frame     = params_.vehicle_frame_name;
+    lu.reference_frame = params_.reference_frame_name;
+    lu.method          = methodLabel;
+    lu.quality         = 1;
+    lu.timestamp       = *tNowOpt;
+    lu.pose            = nv->pose.getPoseMean().asTPose();
+    lu.cov             = nv->pose.cov_inv.inverse();
 
     MRPT_LOG_DEBUG_FMT(
         "[spinOnce] Publishing timely pose estimate: t=%f pose=%s", mrpt::Clock::toDouble(*tNowOpt),
         lu.pose.asString().c_str());
+
+    advertiseUpdatedLocalization(lu);
+
+    // Optional REP-105 output: publish map->odom directly from the estimator's
+    // own T_map_to_odom_i, so the bridge forwards it verbatim (no stale-odom
+    // composition). Distinct method suffix so TF/odom source filters route it.
+    if (params_.publish_map_to_odom_tf)
+    {
+        publishMapToOdom(*tNowOpt, methodLabel);
+    }
+
+    // Optional high-rate fused pose in a distinct child frame (never collides
+    // with an odom->base_link chain on /tf).
+    if (params_.publish_fused_vehicle_tf)
+    {
+        LocalizationUpdate fu = lu;
+        fu.child_frame        = params_.fused_vehicle_frame_name;
+        fu.method             = methodLabel + "/fused";
+        advertiseUpdatedLocalization(fu);
+    }
+}
+
+void StateEstimationSmoother::publishMapToOdom(
+    const mrpt::Clock::time_point& stamp, const std::string& methodLabel)
+{
+    // Resolve which odometry frame is the REP-105 {odom}: the configured one, or
+    // the single known source when unambiguous.
+    std::string odomFrame = params_.map_to_odom_frame_name;
+    if (odomFrame.empty())
+    {
+        const auto frames = known_odometry_frame_ids();
+        if (frames.size() == 1)
+        {
+            odomFrame = *frames.begin();
+        }
+        else
+        {
+            MRPT_LOG_THROTTLE_WARN_FMT(
+                5.0,
+                "[publishMapToOdom] map_to_odom_frame_name is empty and %zu odometry frames are "
+                "known; cannot pick one. Set the parameter explicitly.",
+                frames.size());
+            return;
+        }
+    }
+
+    const auto T_map_to_odom = estimated_T_map_to_odometry_frame(odomFrame);
+    if (!T_map_to_odom.has_value())
+    {
+        MRPT_LOG_THROTTLE_WARN_FMT(
+            5.0, "[publishMapToOdom] No estimate yet for odometry frame '%s'", odomFrame.c_str());
+        return;
+    }
+
+    LocalizationUpdate lu;
+    lu.child_frame     = odomFrame;
+    lu.reference_frame = params_.reference_frame_name;
+    lu.method          = methodLabel + "/map_odom";
+    lu.quality         = 1;
+    lu.timestamp       = stamp;
+    lu.pose            = T_map_to_odom->mean.asTPose();
+    lu.cov             = T_map_to_odom->cov;
 
     advertiseUpdatedLocalization(lu);
 }

--- a/mola_state_estimation_smoother/tests/CMakeLists.txt
+++ b/mola_state_estimation_smoother/tests/CMakeLists.txt
@@ -76,3 +76,10 @@ mola_add_test(
     mola::mola_state_estimation_smoother
 )
 
+mola_add_test(
+  TARGET  test-publish-map-to-odom
+  SOURCES test-publish-map-to-odom.cpp
+  LINK_LIBRARIES
+    mola::mola_state_estimation_smoother
+)
+

--- a/mola_state_estimation_smoother/tests/test-publish-map-to-odom.cpp
+++ b/mola_state_estimation_smoother/tests/test-publish-map-to-odom.cpp
@@ -1,0 +1,169 @@
+/* _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   test-publish-map-to-odom.cpp
+ * @brief  spinOnce() emits the optional map->odom and base_link_fused updates.
+ * @author Jose Luis Blanco Claraco
+ */
+
+#include <mola_state_estimation_smoother/StateEstimationSmoother.h>
+#include <mrpt/obs/CObservationOdometry.h>
+#include <mrpt/poses/CPose2D.h>
+#include <mrpt/poses/CPose3D.h>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+constexpr double POSE_DT    = 0.05;
+constexpr double VELOCITY_X = 1.0;
+constexpr size_t NUM_POSES  = 40;
+const char*      ODOM_FRAME = "odom";
+
+std::string params_yaml(bool mapToOdom, bool fused)
+{
+    return
+        R"###(
+params:
+    vehicle_frame_name: "base_link"
+    reference_frame_name: "map"
+    link_first_pose_to_reference_origin_sigma: 1e-6
+    kinematic_model: KinematicModel::ConstantVelocity
+    sliding_window_length: 10.0
+    max_time_to_use_velocity_model: 5.0
+    sigma_random_walk_acceleration_linear: 2.0
+    sigma_random_walk_acceleration_angular: 1.0
+    sigma_integrator_position: 0.10
+    sigma_integrator_orientation: 0.10
+    estimate_geo_reference: false
+    publish_map_to_odom_tf: )###" +
+        std::string(mapToOdom ? "true" : "false") +
+        R"###(
+    publish_fused_vehicle_tf: )###" +
+        std::string(fused ? "true" : "false") + "\n";
+}
+
+using LU = mola::LocalizationSourceBase::LocalizationUpdate;
+
+std::vector<LU> feed_and_spin(bool mapToOdom, bool fused)
+{
+    mola::state_estimation_smoother::StateEstimationSmoother est;
+    est.initialize(mrpt::containers::yaml::FromText(params_yaml(mapToOdom, fused)));
+
+    std::vector<LU> got;
+    est.subscribeToLocalizationUpdates([&got](const LU& l) { got.push_back(l); });
+
+    for (size_t i = 0; i < NUM_POSES; i++)
+    {
+        const auto stamp = mrpt::Clock::fromDouble(POSE_DT * static_cast<double>(i));
+
+        // Feed odometry via fuse_pose in the {odom} frame, so an odometry frame
+        // and its T_map_to_odom estimate exist.
+        mrpt::poses::CPose3DPDFGaussian p;
+        p.mean = mrpt::poses::CPose3D(VELOCITY_X * POSE_DT * static_cast<double>(i), 0, 0, 0, 0, 0);
+        p.cov.setDiagonal(0.01);
+        est.fuse_pose(stamp, p, ODOM_FRAME);
+    }
+
+    // spinOnce publishes only when it has a "now" stamp and a subscriber (both
+    // true here). Call a few times; each publishes the current estimate.
+    for (int i = 0; i < 3; i++)
+    {
+        est.spinOnce();
+    }
+    return got;
+}
+
+size_t count_child(const std::vector<LU>& v, const std::string& child)
+{
+    size_t n = 0;
+    for (const auto& l : v)
+    {
+        if (l.child_frame == child)
+        {
+            n++;
+        }
+    }
+    return n;
+}
+
+void run_test()
+{
+    // Baseline: only the primary map->base_link update is advertised.
+    {
+        const auto got = feed_and_spin(false, false);
+        std::cout << "baseline updates: " << got.size() << "\n";
+        ASSERT_GT_(count_child(got, "base_link"), 0U);
+        ASSERT_EQUAL_(count_child(got, "odom"), 0U);
+        ASSERT_EQUAL_(count_child(got, "base_link_fused"), 0U);
+    }
+
+    // map->odom enabled: an extra update with child="odom", method ".../map_odom".
+    {
+        const auto got = feed_and_spin(true, false);
+        std::cout << "map_odom updates: " << got.size() << "\n";
+        ASSERT_GT_(count_child(got, "base_link"), 0U);
+        ASSERT_GT_(count_child(got, "odom"), 0U);
+        bool sawMethod = false;
+        for (const auto& l : got)
+        {
+            if (l.child_frame == "odom")
+            {
+                ASSERT_EQUAL_(l.reference_frame, std::string("map"));
+                if (l.method.find("/map_odom") != std::string::npos)
+                {
+                    sawMethod = true;
+                }
+            }
+        }
+        ASSERT_(sawMethod);
+    }
+
+    // base_link_fused enabled: an extra update with that child and method ".../fused".
+    {
+        const auto got = feed_and_spin(false, true);
+        std::cout << "fused updates: " << got.size() << "\n";
+        ASSERT_GT_(count_child(got, "base_link"), 0U);
+        ASSERT_GT_(count_child(got, "base_link_fused"), 0U);
+        bool sawMethod = false;
+        for (const auto& l : got)
+        {
+            if (l.child_frame == "base_link_fused" && l.method.find("/fused") != std::string::npos)
+            {
+                sawMethod = true;
+            }
+        }
+        ASSERT_(sawMethod);
+    }
+}
+
+}  // namespace
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+    try
+    {
+        run_test();
+        std::cout << "✅ SUCCESS\n";
+        return 0;
+    }
+    catch (std::exception& e)
+    {
+        std::cerr << "❌ FAILED: " << e.what() << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
## Motivation

Follow-up to #45. When a downstream controller consumes `map->base_link` via
`/tf`, the ROS bridge (in its REP-105 mode) builds `map->odom` by composing
`(map->base_link)(t) * (odom->base_link)^-1`. The two factors are sampled at
mismatched timestamps — the localizer publishes a pose extrapolated to *now*,
but `odom->base_link` only exists up to *now minus sensor latency* — so the exact
TF lookup misses and the bridge falls back to a stale odom transform. The
resulting `map->odom` carries motion-correlated jitter (worst mid-turn, amplified
by the lever arm from the map origin), even though the estimator's own pose is
accurate.

The estimator already tracks `T_map_to_odom` as a graph variable, which is smooth
and time-consistent by construction. Publishing it directly lets the bridge
forward it to `/tf` verbatim, with no composition and no stale lookup.

## What changed

Two **additive** TF outputs from `spinOnce()`, both **default off** (no behavior
change for existing configs):

- **`publish_map_to_odom_tf`** — advertise the REP-105 correction `map->odom`
  taken directly from the estimator's own `T_map_to_odom` variable, under a
  distinct `method` suffix (`/map_odom`). The bridge forwards it verbatim (its
  `child_frame != base_link` path already does this — no bridge change needed for
  the happy path). `map_to_odom_frame_name` selects the odometry frame
  (auto-selected when exactly one is known). The primary `map->base_link` update
  is still advertised, so the high-rate vehicle-pose topic is unchanged.
- **`publish_fused_vehicle_tf`** — advertise the fused vehicle pose in a distinct
  child frame (default `base_link_fused`, method `/fused`) at the module rate.
  A distinct child never collides with an `odom->base_link` chain on `/tf`, so it
  gives consumers a high-rate fused pose outside the canonical robot tree.

Both use separate method suffixes so the bridge's independent TF/odometry source
filters (`publish_tf_from_slam_source`, `publish_odometry_msgs_from_slam_source`)
can route them.

## Tests

`colcon test` green (28/28). New `test-publish-map-to-odom` drives `spinOnce()`
with a subscriber and asserts the emitted updates per mode: baseline emits only
`map->base_link`; `publish_map_to_odom_tf` adds a `child=odom`,
`method=.../map_odom` update; `publish_fused_vehicle_tf` adds a
`child=base_link_fused`, `method=.../fused` update.

## Notes / follow-ups

- To route `map->odom` onto `/tf`, point the bridge's TF source filter at the
  `/map_odom` method (documented in AGENTS.md and the params YAML).
- Small defensive hardening of `mola_bridge_ros2` (hard-warn instead of the
  60 s-throttled silent stale-odom fallback; warn if two publishers feed
  `odom->base_link`) is a separate PR in that repo.
- End-to-end REP-105 validation with the bridge routing configured is a
  follow-up (this PR's unit tests cover the emission logic).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional publication of a smoothed `map → odom` transform for more consistent localization.
  * Added optional high-rate fused vehicle pose output in a separate, configurable frame.
  * Added configuration options for enabling these outputs and selecting their frame names.
  * Improved publication labels to distinguish standard, map-to-odom, and fused pose updates.

* **Documentation**
  * Clarified smoother bridge behavior and documented the new transform outputs.

* **Tests**
  * Added coverage for default behavior and both optional transform publications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->