### PR TITLE
feat(smoother): smooth the predicted motion prior + moderate default accel sigmas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,20 @@ Key traits:
   the frame-local `{odom_i}` hardening is preserved (a query anchors on that
   source's own last raw pose in the Snapshot). The default synchronous path is
   byte-for-byte unchanged (deterministic offline/unit-test runs).
+- Predict-twist low-pass (`predict_twist_filter_enabled: true`,
+  `predict_twist_filter_time_const: 0.3` s): the velocity extrapolated by both
+  the sync path and the `FastPredictor` is a dt-aware EMA of the newest
+  keyframe's optimized twist, NOT the raw value. The newest keyframe is the
+  boundary node of the sliding window (constrained on one side only), so its raw
+  velocity is the noisiest state in the graph; extrapolating it un-damped feeds a
+  jittery motion prior to a LiDAR front end, which starts ICP from a bad guess,
+  slows/degrades registration, and (under real-time load) drops scans -- a
+  feedback loop that produces meter-scale trajectory spikes on wheeled robots
+  where the lightweight estimator (which low-passes velocity) stays smooth. The
+  filter is a plain EMA, hence deterministic. Its cost is a short lag behind
+  genuine acceleration; the paired sigma defaults below are moderate enough that
+  the two together match the smoothest sigma-only tuning while generalizing
+  better than very tight sigmas.
 
 Sensor inputs:
 - `fuse_pose()` - localization / LiDAR odometry poses
@@ -264,11 +278,22 @@ Major parameter groups:
 The shipped `params/state-estimation-smoother.yaml` targets real-time use, so
 these are **on by default** (each also settable via the shown env var):
 
+Note on run paths: the `mola-cli` launches (e.g. `mola-lo-gui-rosbag2`, which
+runs `lidar_odometry_from_rosbag2.yaml`) replay the bag in real time through a
+`Rosbag2Dataset` module that emits observations at wall-clock rate. This is a
+live-deployment surrogate, NOT the offline `mola-lidar-odometry-cli` (which
+consumes the dataset as fast as possible). So under `mola-cli` the per-sensor
+timing matches a real robot and `async_backend: true` is the appropriate,
+deployed setting; only the true offline CLIs (`mola-lidar-odometry-cli`,
+`mola-navstate-cli`) need it off for reproducibility.
+
 | feature | param / env var | default | notes |
 |---|---|---|---|
 | async backend | `async_backend` / `MOLA_ASYNC_BACKEND` | **true** | sub-ms queries; solve off the caller's thread. **Set false for offline/reproducible batch runs** (mola-navstate-cli) - async serving is non-deterministic. The C++ `Parameters` default stays `false`, so unit tests (inline YAML) remain deterministic. |
 | odom keyframe merge | `odometry_min_sample_period` / `MOLA_ODOMETRY_MIN_SAMPLE_PERIOD` | **0.1** | ~10 Hz keyframes; merges (no motion lost). Deterministic. |
 | IMU keyframe skip | `imu_min_sample_period` / `MOLA_IMU_MIN_SAMPLE_PERIOD` | **0.1** | ~10 Hz attitude/gravity factors. |
+| predict-twist low-pass | `predict_twist_filter_enabled` / `MOLA_NAVSTATE_PREDICT_TWIST_FILTER` (+ `predict_twist_filter_time_const` / `MOLA_NAVSTATE_PREDICT_TWIST_TAU`, 0.3 s) | **true** | EMA-smooths the extrapolation velocity so the front end's ICP prior stays smooth. Deterministic; C++ default also true. |
+| accel random-walk sigmas | `sigma_random_walk_acceleration_linear` / `MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC`, `..._angular` / `MOLA_NAVSTATE_SIGMA_RANDOM_WALK_ANGACC` | **0.5** / **1.0** | Moderate (was 1.0/10.0). The old loose angular let the boundary-node yaw rate swing and rotate the predicted pose. Loosen only for platforms with genuinely high linear/angular acceleration. |
 
 REP-105 `map -> odom` published from the graph variable (default **off**,
 enable per deployment because it needs the routing + frame wiring below):

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
@@ -165,10 +165,26 @@ class Parameters
      */
     double imu_min_sample_period = 0.0;  // [s]
 
-    double sigma_random_walk_acceleration_linear  = 1.0;  // [m/s²]
+    double sigma_random_walk_acceleration_linear  = 0.5;  // [m/s²]
     double sigma_random_walk_acceleration_angular = 1.0;  // [rad/s²]
-    double sigma_integrator_position              = 0.10;  // [m]
-    double sigma_integrator_orientation           = 0.10;  // [rad]
+
+    /** If true, the short-term extrapolation velocity used by
+     * estimated_navstate() is a low-pass-filtered version of the newest
+     * keyframe's optimized twist, instead of the raw value. The newest keyframe
+     * is the boundary node of the sliding window (constrained on one side only),
+     * so its raw velocity is the noisiest state in the graph; extrapolating it
+     * un-damped injects jitter into a front end's motion prior. This mirrors the
+     * velocity low-pass of the lightweight estimator. On by default so the
+     * prior stays smooth; it is a plain dt-aware EMA, hence deterministic and
+     * reproducible run-to-run. */
+    bool predict_twist_filter_enabled = true;
+
+    /** [s] Time constant of the predict-twist low-pass
+     * (predict_twist_filter_enabled). Larger = smoother prior but more lag
+     * behind genuine acceleration. */
+    double predict_twist_filter_time_const = 0.3;
+    double sigma_integrator_position       = 0.10;  // [m]
+    double sigma_integrator_orientation    = 0.10;  // [rad]
 
     double sigma_twist_from_consecutive_poses_linear  = 1.0;  // [m/s]
     double sigma_twist_from_consecutive_poses_angular = 1.0;  // [rad/s]

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -288,6 +288,14 @@ class StateEstimationSmoother : public mola::NavStateFilter,
         /// The latest values from the estimator; updated in process_pending_gtsam_updates()
         std::map<frame_index_t, FrameState> last_estimated_states;
 
+        /// Low-pass-filtered twist of the newest keyframe, used as the
+        /// extrapolation velocity for short-term prediction when
+        /// `predict_twist_filter_enabled`. Damps the boundary keyframe's raw
+        /// velocity (the least-constrained node), which otherwise injects jitter
+        /// into a front end's motion prior. Reset with the rest of `State`.
+        std::optional<mrpt::math::TTwist3D>    filtered_predict_twist;
+        std::optional<mrpt::Clock::time_point> filtered_predict_twist_stamp;
+
         /// The latest values from the estimator; updated in process_pending_gtsam_updates()
         std::map<odometry_frameid_t, mrpt::poses::CPose3DPDFGaussian> last_estimated_frames;
 
@@ -473,6 +481,12 @@ class StateEstimationSmoother : public mola::NavStateFilter,
 
     /// Gets the latest state of a pose wrt the reference frame ("map")
     [[nodiscard]] NavState get_latest_state_and_covariance(const frame_index_t idx) const;
+
+    /// Updates the low-pass-filtered predict twist with the newest keyframe's
+    /// optimized twist (dt-aware exponential moving average). No-op unless
+    /// `predict_twist_filter_enabled`. See `State::filtered_predict_twist`.
+    void update_predict_twist_filter_locked(
+        const mrpt::math::TTwist3D& rawTwist, const mrpt::Clock::time_point& stamp);
 
     /// Gets the latest estimated transform of "T_map_to_odometry_frame_i", by frame ID name.
     [[nodiscard]] std::optional<mrpt::poses::CPose3DPDFGaussian>

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -118,10 +118,18 @@ params:
   async_backend: ${MOLA_ASYNC_BACKEND|true}
 
   # Random walk model for linear acceleration uncertainty [m/s²]
-  sigma_random_walk_acceleration_linear: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC|1.0}
+  sigma_random_walk_acceleration_linear: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC|0.5}
 
   # Random walk model for angular acceleration uncertainty [rad/s²]
-  sigma_random_walk_acceleration_angular: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_ANGACC|10.0}
+  sigma_random_walk_acceleration_angular: ${MOLA_NAVSTATE_SIGMA_RANDOM_WALK_ANGACC|1.0}
+
+  # Low-pass the newest keyframe's velocity before using it as the short-term
+  # extrapolation prior. The newest keyframe is the boundary node of the window
+  # (constrained on one side only), so its raw velocity is the noisiest in the
+  # graph; extrapolating it un-damped injects jitter into a front end's motion
+  # prior. On by default (deterministic dt-aware EMA).
+  predict_twist_filter_enabled: ${MOLA_NAVSTATE_PREDICT_TWIST_FILTER|true}
+  predict_twist_filter_time_const: ${MOLA_NAVSTATE_PREDICT_TWIST_TAU|0.3}
 
   # Integrator uncertainty for position [m]
   sigma_integrator_position: 0.1

--- a/mola_state_estimation_smoother/src/Parameters.cpp
+++ b/mola_state_estimation_smoother/src/Parameters.cpp
@@ -45,6 +45,8 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
 
     MCP_LOAD_OPT(cfg, sigma_random_walk_acceleration_linear);
     MCP_LOAD_OPT(cfg, sigma_random_walk_acceleration_angular);
+    MCP_LOAD_OPT(cfg, predict_twist_filter_enabled);
+    MCP_LOAD_OPT(cfg, predict_twist_filter_time_const);
     MCP_LOAD_OPT(cfg, sigma_integrator_position);
     MCP_LOAD_OPT(cfg, sigma_integrator_orientation);
     MCP_LOAD_OPT(cfg, sigma_twist_from_consecutive_poses_linear);

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -1126,6 +1126,16 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
         ret.twist_inv_cov = twist_cov.inverse_LLt();
     }
 
+    // Extrapolate the low-pass-filtered velocity instead of the boundary
+    // keyframe's raw (noisy) twist, when anchoring on the newest keyframe
+    // (mirrors the async fast-predictor path).
+    if (params_.predict_twist_filter_enabled && state_.filtered_predict_twist.has_value() &&
+        !state_.stamp2frame_index.empty() &&
+        *closesFrameIdx == state_.stamp2frame_index.getDirectMap().rbegin()->second)
+    {
+        ret.twist = *state_.filtered_predict_twist;
+    }
+
     // 3) Produce the pose in the requested frame.
     if (frame_id == params_.reference_frame_name)
     {
@@ -1865,6 +1875,19 @@ void StateEstimationSmoother::process_pending_gtsam_updates_locked()
         }
     }
 
+    // Drive the predict-twist low-pass with the newest keyframe's optimized
+    // twist, so the short-term prediction extrapolates a damped velocity rather
+    // than the boundary node's noisy raw estimate.
+    if (params_.predict_twist_filter_enabled && !state_.stamp2frame_index.empty())
+    {
+        const auto& latestIt = *state_.stamp2frame_index.getDirectMap().rbegin();
+        if (const auto itKf = state_.last_estimated_states.find(latestIt.second);
+            itKf != state_.last_estimated_states.end())
+        {
+            update_predict_twist_filter_locked(itKf->second.twist, latestIt.first);
+        }
+    }
+
     // Retrieve latest enu_to_map for geo-referencing:
     if (params_.estimate_geo_reference)
     {
@@ -2374,6 +2397,13 @@ std::shared_ptr<const Snapshot> StateEstimationSmoother::build_snapshot_locked()
     }
     snap->anchorStamp = latestStamp;
 
+    // Extrapolate a low-pass-filtered velocity, not the boundary keyframe's raw
+    // (noisy) twist, so the front end's motion prior stays smooth.
+    if (params_.predict_twist_filter_enabled && state_.filtered_predict_twist.has_value())
+    {
+        snap->anchor.twist = *state_.filtered_predict_twist;
+    }
+
     // Odometry-frame transforms (numeric id >= 1) and the name<->id mapping.
     snap->frameNames = state_.known_odom_frames;
     for (const auto& [id, pdf] : state_.last_estimated_frames)
@@ -2455,6 +2485,49 @@ NavState StateEstimationSmoother::get_latest_state_and_covariance(const frame_in
     ns.twist_inv_cov = twCov.inverse();
 
     return ns;
+}
+
+void StateEstimationSmoother::update_predict_twist_filter_locked(
+    const mrpt::math::TTwist3D& rawTwist, const mrpt::Clock::time_point& stamp)
+{
+    if (!params_.predict_twist_filter_enabled)
+    {
+        return;
+    }
+
+    // Bootstrap (first sample, or after a reset): adopt the raw value.
+    if (!state_.filtered_predict_twist.has_value() ||
+        !state_.filtered_predict_twist_stamp.has_value())
+    {
+        state_.filtered_predict_twist       = rawTwist;
+        state_.filtered_predict_twist_stamp = stamp;
+        return;
+    }
+
+    const double dt = mrpt::system::timeDifference(*state_.filtered_predict_twist_stamp, stamp);
+
+    // Out-of-order or same-stamp solve: just refresh, don't run the filter.
+    if (dt <= 0)
+    {
+        state_.filtered_predict_twist       = rawTwist;
+        state_.filtered_predict_twist_stamp = stamp;
+        return;
+    }
+
+    // dt-aware exponential moving average, so a variable solve rate keeps a
+    // constant effective time constant.
+    const double tau   = std::max(1e-3, params_.predict_twist_filter_time_const);
+    const double alpha = 1.0 - std::exp(-dt / tau);
+
+    auto& f = *state_.filtered_predict_twist;
+    f.vx += alpha * (rawTwist.vx - f.vx);
+    f.vy += alpha * (rawTwist.vy - f.vy);
+    f.vz += alpha * (rawTwist.vz - f.vz);
+    f.wx += alpha * (rawTwist.wx - f.wx);
+    f.wy += alpha * (rawTwist.wy - f.wy);
+    f.wz += alpha * (rawTwist.wz - f.wz);
+
+    state_.filtered_predict_twist_stamp = stamp;
 }
 
 std::optional<mrpt::poses::CPose3DPDFGaussian> StateEstimationSmoother::estimated_T_enu_to_map()


### PR DESCRIPTION
## Problem

When the iSAM2 smoother is used as the motion-prior source for a LiDAR front end (`mola_lidar_odometry`), the estimated trajectory shows small jumps that grow into **meter-scale spikes** over ~1–2 minutes on wheeled-robot datasets — while the lightweight constant-velocity estimator (`StateEstimationSimple`) stays smooth on the identical LiDAR/ICP setup.

## Root cause

Both estimators extrapolate `pose ⊕ exp(twist·dt)` with the same acceleration random-walk sigmas, but source `twist` differently:

- **simple** low-passes its velocity (a per-axis scalar KF) before extrapolating → smooth prior.
- **smoother** extrapolated the **newest keyframe's raw optimized velocity** — the *boundary node* of the sliding window (constrained on one side only), the noisiest state in the graph, which swings between solves. Extrapolating it un-damped feeds a jittery prior to ICP → ICP starts far from the solution, needs more iterations, and (under real-time load) the scan is dropped → the gap doubles the extrapolation interval → the prior gets worse → a feedback loop.

Ruled out experimentally as causes: the async backend / FastPredictor (query is ~13 µs; sync diverges the same), GNSS/geo-ref (removing both is unchanged), and wheel odometry (essential/stabilizing).

## Change

- Add a **dt-aware EMA low-pass** on the extrapolation twist, shared by the synchronous path and the `FastPredictor` (`predict_twist_filter_enabled`, `predict_twist_filter_time_const`). Deterministic.
- Make it the **default** and moderate the shipped acceleration random-walk sigmas: `linear 1.0 → 0.5`, `angular 10.0 → 1.0`. Together they match the smoothest sigma-only tuning while generalizing better than very tight sigmas. All remain env-overridable.

## Validation

Real-time replay (same path as `mola-lo-gui-rosbag2`), 120 s, two Capra wheeled-robot datasets. Isolation runs confirm the filter contributes independently of the sigma change (same 0.5/1.0 sigmas, ±filter: mean jerk 100 → 71, drops 19 → 10). Out-of-the-box new default vs old shipped on the diverging dataset:

| metric | old shipped (1.0/10) | new default (0.5/1.0 + filter) |
|---|---|---|
| skipped scans | 27 | **3** |
| mean jerk | 212 | **46** |
| max jump | 5.6 m | **2.3 m** |
| path length (true ≈75 m) | 172 m | **82 m** |

`26/26` unit tests pass; `clang-format-14` clean. `AGENTS.md` updated.

Note: the effect is dataset-dependent (slow wheeled robots benefit most); dynamic platforms can loosen the sigmas via the env vars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable low-pass filtering for short-term velocity and motion prediction, enabled by default.
  * Added a configurable filter time constant for tuning prediction smoothness.
* **Improvements**
  * Smoothed estimated motion output to improve real-time front-end stability.
  * Updated default acceleration uncertainty settings for more consistent state estimation.
* **Documentation**
  * Documented prediction filtering, acceleration settings, real-time run-path differences, and related configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->