### PR TITLE
fix(smoother): preserve predict-twist EMA history on same-stamp solves

### DIFF
--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -2506,11 +2506,12 @@ void StateEstimationSmoother::update_predict_twist_filter_locked(
 
     const double dt = mrpt::system::timeDifference(*state_.filtered_predict_twist_stamp, stamp);
 
-    // Out-of-order or same-stamp solve: just refresh, don't run the filter.
+    // Out-of-order or same-stamp solve (the solver can re-run several times
+    // while the newest keyframe stamp is unchanged): keep the smoothed state as
+    // is. Overwriting it with rawTwist here would wipe the EMA history and let
+    // the raw boundary twist through, i.e. exactly the jitter this filter damps.
     if (dt <= 0)
     {
-        state_.filtered_predict_twist       = rawTwist;
-        state_.filtered_predict_twist_stamp = stamp;
         return;
     }
 


### PR DESCRIPTION
Follow-up to #47, addressing a Critical review finding from CodeRabbit.

## Bug

`update_predict_twist_filter_locked()` overwrote the smoothed filter state with the raw boundary twist whenever `dt <= 0`. Because the solver can execute multiple times while the newest keyframe timestamp stays the same (`dt == 0`), this frequently wiped the EMA history and let the raw, un-damped boundary velocity through — the exact jitter the low-pass is meant to suppress.

## Fix

On `dt <= 0`, leave the smoothed state untouched; only advance the EMA when time increases. Bootstrap behavior (first sample) is unchanged.

## Re-validation

New default (0.5/1.0 + filter), 120 s wheeled-robot replay, buggy vs fixed:

| dataset | metric | buggy filter | fixed filter |
|---|---|---|---|
| HQ | mean jerk | 65 | **50** |
| HQ | skipped scans | 8.5 | **5** |
| HQ | path (true ≈75 m) | 90 | **83** |
| sletvej | mean jerk | 17 | **8.4** (simple ≈5) |
| sletvej | path (true ≈67 m) | 76 | **68** |

`26/26` unit tests pass; `clang-format-14` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved twist filtering for out-of-order or duplicate-timestamp updates.
  * Preserved the existing filtered state instead of resetting it with boundary data, resulting in more consistent estimation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->