### PR TITLE
feat(smoother): covariance-aware short-term extrapolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,16 @@ Key traits:
   genuine acceleration; the paired sigma defaults below are moderate enough that
   the two together match the smoothest sigma-only tuning while generalizing
   better than very tight sigmas.
+- Short-term extrapolation is covariance-aware: both the sync path and the
+  `FastPredictor` share `extrapolate_pose_pdf()` (`src/extrapolation.h`), which
+  returns the pose PDF of `anchor (+) Exp(twist*dt)` with first-order uncertainty
+  propagation -- the anchor pose covariance transported through the composition
+  (MRPT's `CPose3DPDFGaussian::operator+` Adjoint) plus the body-increment
+  covariance (current-velocity uncertainty over the interval + acceleration
+  process noise). The increment's tangent-to-pose Jacobian is approximated as
+  identity (exact in translation, first order in rotation) in the sub-second
+  extrapolation regime. This replaces the earlier mean-only extrapolation that
+  left the pose covariance ungrown.
 
 Sensor inputs:
 - `fuse_pose()` - localization / LiDAR odometry poses

--- a/mola_state_estimation_smoother/src/FastPredictor.cpp
+++ b/mola_state_estimation_smoother/src/FastPredictor.cpp
@@ -101,8 +101,12 @@ std::optional<NavState> FastPredictor::predict(
     // random-walk model over the extrapolation interval (mirrors the
     // synchronous estimated_navstate()).
     NavState ret = snap->anchor;
+
+    // Anchor twist covariance (before random-walk growth), reused as the
+    // current-velocity uncertainty of the pose increment below.
+    const mrpt::math::CMatrixDouble66 anchorTwistCov = snap->anchor.twist_inv_cov.inverse_LLt();
     {
-        auto twist_cov = ret.twist_inv_cov.inverse_LLt();
+        auto twist_cov = anchorTwistCov;
         for (int i = 0; i < 3; i++)
         {
             twist_cov(0 + i, 0 + i) +=
@@ -113,10 +117,13 @@ std::optional<NavState> FastPredictor::predict(
         ret.twist_inv_cov = twist_cov.inverse_LLt();
     }
 
-    // Reference ({map}) frame: extrapolate the anchor pose forward.
+    // Reference ({map}) frame: extrapolate the anchor pose forward, propagating
+    // covariance.
     if (frame_id == params.reference_frame_name)
     {
-        ret.pose.mean = ret.pose.mean + body_twist_delta(params, ret.twist, dt);
+        mrpt::poses::CPose3DPDFGaussian anchorPose;
+        anchorPose.copyFrom(ret.pose);
+        ret.pose.copyFrom(extrapolate_pose_pdf(params, anchorPose, ret.twist, anchorTwistCov, dt));
         return ret;
     }
 
@@ -141,10 +148,12 @@ std::optional<NavState> FastPredictor::predict(
         {
             return std::nullopt;
         }
-        ret.pose.mean = ret.pose.mean + body_twist_delta(params, ret.twist, dt);
-        mrpt::poses::CPose3DPDFGaussianInf posePdfFrame_wrt_map_inf;
-        posePdfFrame_wrt_map_inf.copyFrom(itFrame->second);
-        ret.pose = ret.pose - posePdfFrame_wrt_map_inf;
+        mrpt::poses::CPose3DPDFGaussian anchorPose;
+        anchorPose.copyFrom(ret.pose);
+        const auto mapPred =
+            extrapolate_pose_pdf(params, anchorPose, ret.twist, anchorTwistCov, dt);
+        // Transform the {map}-frame prediction into {odom_i}: pred (-) T_frame_wrt_map.
+        ret.pose.copyFrom(mapPred - itFrame->second);
         return ret;
     }
 
@@ -155,19 +164,8 @@ std::optional<NavState> FastPredictor::predict(
         return std::nullopt;
     }
 
-    mrpt::poses::CPose3DPDFGaussian pred;
-    pred.mean = rawAnchor.pose.mean + body_twist_delta(params, ret.twist, dtPred);
-
-    pred.cov         = rawAnchor.pose.cov;
-    const double adt = std::abs(dtPred);
-    for (int i = 0; i < 3; i++)
-    {
-        pred.cov(i, i) += mrpt::square(params.sigma_random_walk_acceleration_linear * adt * adt);
-        pred.cov(3 + i, 3 + i) +=
-            mrpt::square(params.sigma_random_walk_acceleration_angular * adt * adt);
-    }
-
-    ret.pose.copyFrom(pred);  // NavState.pose is CPose3DPDFGaussianInf
+    ret.pose.copyFrom(
+        extrapolate_pose_pdf(params, rawAnchor.pose, ret.twist, anchorTwistCov, dtPred));
 
     return ret;
 }

--- a/mola_state_estimation_smoother/src/FastPredictor.cpp
+++ b/mola_state_estimation_smoother/src/FastPredictor.cpp
@@ -102,72 +102,86 @@ std::optional<NavState> FastPredictor::predict(
     // synchronous estimated_navstate()).
     NavState ret = snap->anchor;
 
-    // Anchor twist covariance (before random-walk growth), reused as the
-    // current-velocity uncertainty of the pose increment below.
-    const mrpt::math::CMatrixDouble66 anchorTwistCov = snap->anchor.twist_inv_cov.inverse_LLt();
+    // The covariance propagation below (matrix inversions, information-form
+    // conversions and Gaussian pose composition) can throw on a non
+    // positive-definite covariance; estimated_navstate() delegates here directly
+    // in async mode, so absorb it and report "not ready yet" instead of letting
+    // it terminate the caller's thread.
+    try
     {
-        auto twist_cov = anchorTwistCov;
-        for (int i = 0; i < 3; i++)
+        // Anchor twist covariance (before random-walk growth), reused as the
+        // current-velocity uncertainty of the pose increment below.
+        const mrpt::math::CMatrixDouble66 anchorTwistCov = snap->anchor.twist_inv_cov.inverse_LLt();
         {
-            twist_cov(0 + i, 0 + i) +=
-                mrpt::square(params.sigma_random_walk_acceleration_linear * dt);
-            twist_cov(3 + i, 3 + i) +=
-                mrpt::square(params.sigma_random_walk_acceleration_angular * dt);
+            auto twist_cov = anchorTwistCov;
+            for (int i = 0; i < 3; i++)
+            {
+                twist_cov(0 + i, 0 + i) +=
+                    mrpt::square(params.sigma_random_walk_acceleration_linear * dt);
+                twist_cov(3 + i, 3 + i) +=
+                    mrpt::square(params.sigma_random_walk_acceleration_angular * dt);
+            }
+            ret.twist_inv_cov = twist_cov.inverse_LLt();
         }
-        ret.twist_inv_cov = twist_cov.inverse_LLt();
-    }
 
-    // Reference ({map}) frame: extrapolate the anchor pose forward, propagating
-    // covariance.
-    if (frame_id == params.reference_frame_name)
-    {
-        mrpt::poses::CPose3DPDFGaussian anchorPose;
-        anchorPose.copyFrom(ret.pose);
-        ret.pose.copyFrom(extrapolate_pose_pdf(params, anchorPose, ret.twist, anchorTwistCov, dt));
-        return ret;
-    }
+        // Reference ({map}) frame: extrapolate the anchor pose forward,
+        // propagating covariance.
+        if (frame_id == params.reference_frame_name)
+        {
+            mrpt::poses::CPose3DPDFGaussian anchorPose;
+            anchorPose.copyFrom(ret.pose);
+            ret.pose.copyFrom(
+                extrapolate_pose_pdf(params, anchorPose, ret.twist, anchorTwistCov, dt));
+            return ret;
+        }
 
-    // Odometry frame {odom_i}: resolve its numeric id.
-    const auto& str2id = snap->frameNames.getDirectMap();
-    const auto  itName = str2id.find(frame_id);
-    if (itName == str2id.end())
-    {
-        return std::nullopt;
-    }
-    const auto requestedFrameIdx = itName->second;
-
-    // Frame-local prediction: anchor on the source's OWN last raw pose in
-    // {odom_i} and extrapolate by the body-twist increment, so the prediction
-    // stays immune to {map} corrections (geo-ref / loop closure / per-solve
-    // jitter). Falls back to the global conversion before the first raw pose.
-    const auto itRaw = snap->lastRawPoseBySource.find(requestedFrameIdx);
-    if (itRaw == snap->lastRawPoseBySource.end())
-    {
-        const auto itFrame = snap->frameTransforms.find(requestedFrameIdx);
-        if (itFrame == snap->frameTransforms.end())
+        // Odometry frame {odom_i}: resolve its numeric id.
+        const auto& str2id = snap->frameNames.getDirectMap();
+        const auto  itName = str2id.find(frame_id);
+        if (itName == str2id.end())
         {
             return std::nullopt;
         }
-        mrpt::poses::CPose3DPDFGaussian anchorPose;
-        anchorPose.copyFrom(ret.pose);
-        const auto mapPred =
-            extrapolate_pose_pdf(params, anchorPose, ret.twist, anchorTwistCov, dt);
-        // Transform the {map}-frame prediction into {odom_i}: pred (-) T_frame_wrt_map.
-        ret.pose.copyFrom(mapPred - itFrame->second);
+        const auto requestedFrameIdx = itName->second;
+
+        // Frame-local prediction: anchor on the source's OWN last raw pose in
+        // {odom_i} and extrapolate by the body-twist increment, so the prediction
+        // stays immune to {map} corrections (geo-ref / loop closure / per-solve
+        // jitter). Falls back to the global conversion before the first raw pose.
+        const auto itRaw = snap->lastRawPoseBySource.find(requestedFrameIdx);
+        if (itRaw == snap->lastRawPoseBySource.end())
+        {
+            const auto itFrame = snap->frameTransforms.find(requestedFrameIdx);
+            if (itFrame == snap->frameTransforms.end())
+            {
+                return std::nullopt;
+            }
+            mrpt::poses::CPose3DPDFGaussian anchorPose;
+            anchorPose.copyFrom(ret.pose);
+            const auto mapPred =
+                extrapolate_pose_pdf(params, anchorPose, ret.twist, anchorTwistCov, dt);
+            // Transform the {map}-frame prediction into {odom_i}: pred (-) T_frame_wrt_map.
+            ret.pose.copyFrom(mapPred - itFrame->second);
+            return ret;
+        }
+
+        const auto&  rawAnchor = itRaw->second;
+        const double dtPred    = mrpt::system::timeDifference(rawAnchor.stamp, t_query);
+        if (std::abs(dtPred) > params.max_time_to_use_velocity_model)
+        {
+            return std::nullopt;
+        }
+
+        ret.pose.copyFrom(
+            extrapolate_pose_pdf(params, rawAnchor.pose, ret.twist, anchorTwistCov, dtPred));
+
         return ret;
     }
-
-    const auto&  rawAnchor = itRaw->second;
-    const double dtPred    = mrpt::system::timeDifference(rawAnchor.stamp, t_query);
-    if (std::abs(dtPred) > params.max_time_to_use_velocity_model)
+    catch (const std::exception&)
     {
+        // Under-constrained covariance: report "not ready yet".
         return std::nullopt;
     }
-
-    ret.pose.copyFrom(
-        extrapolate_pose_pdf(params, rawAnchor.pose, ret.twist, anchorTwistCov, dtPred));
-
-    return ret;
 }
 
 }  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -1110,101 +1110,116 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
 
     NavState ret = retKf;
 
-    // Anchor twist covariance (before random-walk growth), reused as the
-    // current-velocity uncertainty of the pose increment below.
-    const mrpt::math::CMatrixDouble66 anchorTwistCov = retKf.twist_inv_cov.inverse_LLt();
-
-    // Twist uncertainty growth due to the acceleration random walk:
+    // The covariance propagation below (matrix inversions, information-form
+    // conversions and Gaussian pose composition) can throw if a covariance is
+    // not positive definite (e.g. an under-constrained factor graph in the
+    // first instants of fusion). Treat that like the other "not ready yet"
+    // early returns rather than letting it take down the caller's thread.
+    try
     {
-        auto twist_cov = anchorTwistCov;
-        for (int i = 0; i < 3; i++)
+        // Anchor twist covariance (before random-walk growth), reused as the
+        // current-velocity uncertainty of the pose increment below.
+        const mrpt::math::CMatrixDouble66 anchorTwistCov = retKf.twist_inv_cov.inverse_LLt();
+
+        // Twist uncertainty growth due to the acceleration random walk:
         {
-            twist_cov(0 + i, 0 + i) +=
-                mrpt::square(params_.sigma_random_walk_acceleration_linear * closestFrameDtSigned);
+            auto twist_cov = anchorTwistCov;
+            for (int i = 0; i < 3; i++)
+            {
+                twist_cov(0 + i, 0 + i) += mrpt::square(
+                    params_.sigma_random_walk_acceleration_linear * closestFrameDtSigned);
 
-            twist_cov(3 + i, 3 + i) +=
-                mrpt::square(params_.sigma_random_walk_acceleration_angular * closestFrameDtSigned);
+                twist_cov(3 + i, 3 + i) += mrpt::square(
+                    params_.sigma_random_walk_acceleration_angular * closestFrameDtSigned);
+            }
+            ret.twist_inv_cov = twist_cov.inverse_LLt();
         }
-        ret.twist_inv_cov = twist_cov.inverse_LLt();
-    }
 
-    // Extrapolate the low-pass-filtered velocity instead of the boundary
-    // keyframe's raw (noisy) twist, when anchoring on the newest keyframe
-    // (mirrors the async fast-predictor path).
-    if (params_.predict_twist_filter_enabled && state_.filtered_predict_twist.has_value() &&
-        !state_.stamp2frame_index.empty() &&
-        *closesFrameIdx == state_.stamp2frame_index.getDirectMap().rbegin()->second)
-    {
-        ret.twist = *state_.filtered_predict_twist;
-    }
+        // Extrapolate the low-pass-filtered velocity instead of the boundary
+        // keyframe's raw (noisy) twist, when anchoring on the newest keyframe
+        // (mirrors the async fast-predictor path).
+        if (params_.predict_twist_filter_enabled && state_.filtered_predict_twist.has_value() &&
+            !state_.stamp2frame_index.empty() &&
+            *closesFrameIdx == state_.stamp2frame_index.getDirectMap().rbegin()->second)
+        {
+            ret.twist = *state_.filtered_predict_twist;
+        }
 
-    // 3) Produce the pose in the requested frame.
-    if (frame_id == params_.reference_frame_name)
-    {
-        // Reference ({map}) frame: extrapolate the closest keyframe pose forward
-        // with the configured kinematic model, propagating covariance.
-        mrpt::poses::CPose3DPDFGaussian anchorPose;
-        anchorPose.copyFrom(retKf.pose);
-        ret.pose.copyFrom(extrapolate_pose_pdf(
-            params_, anchorPose, ret.twist, anchorTwistCov, closestFrameDtSigned));
-        return ret;
-    }
+        // 3) Produce the pose in the requested frame.
+        if (frame_id == params_.reference_frame_name)
+        {
+            // Reference ({map}) frame: extrapolate the closest keyframe pose
+            // forward with the configured kinematic model, propagating covariance.
+            mrpt::poses::CPose3DPDFGaussian anchorPose;
+            anchorPose.copyFrom(retKf.pose);
+            ret.pose.copyFrom(extrapolate_pose_pdf(
+                params_, anchorPose, ret.twist, anchorTwistCov, closestFrameDtSigned));
+            return ret;
+        }
 
-    // The requested odometry frame may not have been registered yet (e.g. the
-    // very first query of a brand-new frame_id, before any fuse_pose()/
-    // fuse_odometry() call has registered it). Treat that as "not ready yet".
-    const auto it = state_.known_odom_frames.find_key(frame_id);
-    if (it == state_.known_odom_frames.getDirectMap().end())
-    {
-        MRPT_LOG_THROTTLE_WARN_FMT(
-            5.0, "[estimated_navstate] Requested unknown odometry frame_id='%s'", frame_id.c_str());
-        return {};
-    }
-    const auto requestedFrameIdx = it->second;
+        // The requested odometry frame may not have been registered yet (e.g.
+        // the very first query of a brand-new frame_id, before any fuse_pose()/
+        // fuse_odometry() call has registered it). Treat that as "not ready yet".
+        const auto it = state_.known_odom_frames.find_key(frame_id);
+        if (it == state_.known_odom_frames.getDirectMap().end())
+        {
+            MRPT_LOG_THROTTLE_WARN_FMT(
+                5.0, "[estimated_navstate] Requested unknown odometry frame_id='%s'",
+                frame_id.c_str());
+            return {};
+        }
+        const auto requestedFrameIdx = it->second;
 
-    // Non-reference odometry frame {odom_i}: anchor on the source's OWN last raw
-    // pose in {odom_i} and extrapolate by the body-twist increment, instead of
-    // reconstructing it globally as X(kf) (-) T_map_to_odom_i. The fixed-lag
-    // window keeps that global reconstruction's {map}-correction leak small here,
-    // but anchoring on the raw pose removes it and keeps the prediction immune to
-    // geo-ref / loop-closure / per-solve jitter.
-    const auto itRaw = state_.last_raw_pose_by_source.find(requestedFrameIdx);
-    if (itRaw == state_.last_raw_pose_by_source.end())
-    {
-        // No raw pose received from this source yet: fall back to the global
-        // conversion (correct while {map} and {odom_i} still coincide).
-        const auto itFrame = state_.last_estimated_frames.find(requestedFrameIdx);
-        if (itFrame == state_.last_estimated_frames.end())
+        // Non-reference odometry frame {odom_i}: anchor on the source's OWN last
+        // raw pose in {odom_i} and extrapolate by the body-twist increment,
+        // instead of reconstructing it globally as X(kf) (-) T_map_to_odom_i. The
+        // fixed-lag window keeps that global reconstruction's {map}-correction
+        // leak small here, but anchoring on the raw pose removes it and keeps the
+        // prediction immune to geo-ref / loop-closure / per-solve jitter.
+        const auto itRaw = state_.last_raw_pose_by_source.find(requestedFrameIdx);
+        if (itRaw == state_.last_raw_pose_by_source.end())
+        {
+            // No raw pose received from this source yet: fall back to the global
+            // conversion (correct while {map} and {odom_i} still coincide).
+            const auto itFrame = state_.last_estimated_frames.find(requestedFrameIdx);
+            if (itFrame == state_.last_estimated_frames.end())
+            {
+                return {};
+            }
+            mrpt::poses::CPose3DPDFGaussian anchorPose;
+            anchorPose.copyFrom(retKf.pose);
+            const auto mapPred = extrapolate_pose_pdf(
+                params_, anchorPose, ret.twist, anchorTwistCov, closestFrameDtSigned);
+            // Transform the {map}-frame prediction into {odom_i}: pred (-) T_frame_wrt_map.
+            ret.pose.copyFrom(mapPred - itFrame->second);
+            return ret;
+        }
+
+        // Frame-local extrapolation from the source's last raw pose in {odom_i}:
+        const auto&  rawAnchor = itRaw->second;
+        const double dtPred    = mrpt::system::timeDifference(rawAnchor.stamp, timestamp);
+
+        if (std::abs(dtPred) > params_.max_time_to_use_velocity_model)
         {
             return {};
         }
-        mrpt::poses::CPose3DPDFGaussian anchorPose;
-        anchorPose.copyFrom(retKf.pose);
-        const auto mapPred = extrapolate_pose_pdf(
-            params_, anchorPose, ret.twist, anchorTwistCov, closestFrameDtSigned);
-        // Transform the {map}-frame prediction into {odom_i}: pred (-) T_frame_wrt_map.
-        ret.pose.copyFrom(mapPred - itFrame->second);
+
+        // The anchor is the front end's own near-exact pose in {odom_i}, so
+        // prediction uncertainty is dominated by the one-step extrapolation, not
+        // the absolute {map}-frame keyframe covariance.
+        ret.pose.copyFrom(
+            extrapolate_pose_pdf(params_, rawAnchor.pose, ret.twist, anchorTwistCov, dtPred));
+
         return ret;
     }
-
-    // Frame-local extrapolation from the source's last raw pose in {odom_i}:
-    const auto&  rawAnchor = itRaw->second;
-    const double dtPred    = mrpt::system::timeDifference(rawAnchor.stamp, timestamp);
-
-    if (std::abs(dtPred) > params_.max_time_to_use_velocity_model)
+    catch (const std::exception& e)
     {
+        MRPT_LOG_DEBUG_FMT(
+            "[estimated_navstate] Covariance propagation not ready yet (factor graph likely "
+            "still under-constrained): %s",
+            e.what());
         return {};
     }
-
-    // Frame-local extrapolation from the source's own last raw pose in {odom_i},
-    // propagating covariance (anchor pose uncertainty + body increment). The
-    // anchor is the front end's own near-exact pose in {odom_i}, so prediction
-    // uncertainty is dominated by the one-step extrapolation, not the absolute
-    // {map}-frame keyframe covariance.
-    ret.pose.copyFrom(
-        extrapolate_pose_pdf(params_, rawAnchor.pose, ret.twist, anchorTwistCov, dtPred));
-
-    return ret;
 }
 
 std::set<std::string> StateEstimationSmoother::known_odometry_frame_ids()

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -1108,13 +1108,15 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
         return {};
     }
 
-    MRPT_TODO("Implement probabilistic extrapolation");
-    // For now, approximate extrapolation only:
     NavState ret = retKf;
 
-    // Approximate twist uncertainty growth due to random walk:
+    // Anchor twist covariance (before random-walk growth), reused as the
+    // current-velocity uncertainty of the pose increment below.
+    const mrpt::math::CMatrixDouble66 anchorTwistCov = retKf.twist_inv_cov.inverse_LLt();
+
+    // Twist uncertainty growth due to the acceleration random walk:
     {
-        auto twist_cov = ret.twist_inv_cov.inverse_LLt();
+        auto twist_cov = anchorTwistCov;
         for (int i = 0; i < 3; i++)
         {
             twist_cov(0 + i, 0 + i) +=
@@ -1140,8 +1142,11 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
     if (frame_id == params_.reference_frame_name)
     {
         // Reference ({map}) frame: extrapolate the closest keyframe pose forward
-        // with the configured kinematic model.
-        ret.pose.mean = ret.pose.mean + body_twist_delta(params_, ret.twist, closestFrameDtSigned);
+        // with the configured kinematic model, propagating covariance.
+        mrpt::poses::CPose3DPDFGaussian anchorPose;
+        anchorPose.copyFrom(retKf.pose);
+        ret.pose.copyFrom(extrapolate_pose_pdf(
+            params_, anchorPose, ret.twist, anchorTwistCov, closestFrameDtSigned));
         return ret;
     }
 
@@ -1173,10 +1178,12 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
         {
             return {};
         }
-        ret.pose.mean = ret.pose.mean + body_twist_delta(params_, ret.twist, closestFrameDtSigned);
-        mrpt::poses::CPose3DPDFGaussianInf posePdfFrame_wrt_map_inf;
-        posePdfFrame_wrt_map_inf.copyFrom(itFrame->second);
-        ret.pose = ret.pose - posePdfFrame_wrt_map_inf;
+        mrpt::poses::CPose3DPDFGaussian anchorPose;
+        anchorPose.copyFrom(retKf.pose);
+        const auto mapPred = extrapolate_pose_pdf(
+            params_, anchorPose, ret.twist, anchorTwistCov, closestFrameDtSigned);
+        // Transform the {map}-frame prediction into {odom_i}: pred (-) T_frame_wrt_map.
+        ret.pose.copyFrom(mapPred - itFrame->second);
         return ret;
     }
 
@@ -1189,22 +1196,13 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
         return {};
     }
 
-    mrpt::poses::CPose3DPDFGaussian pred;
-    pred.mean = rawAnchor.pose.mean + body_twist_delta(params_, ret.twist, dtPred);
-
-    // Frame-local covariance: the anchor is the front end's own (near-exact) pose
-    // in {odom_i}, so prediction uncertainty is dominated by the one-step
-    // extrapolation, not the absolute {map}-frame keyframe covariance.
-    pred.cov         = rawAnchor.pose.cov;
-    const double adt = std::abs(dtPred);
-    for (int i = 0; i < 3; i++)
-    {
-        pred.cov(i, i) += mrpt::square(params_.sigma_random_walk_acceleration_linear * adt * adt);
-        pred.cov(3 + i, 3 + i) +=
-            mrpt::square(params_.sigma_random_walk_acceleration_angular * adt * adt);
-    }
-
-    ret.pose.copyFrom(pred);  // NavState.pose is CPose3DPDFGaussianInf
+    // Frame-local extrapolation from the source's own last raw pose in {odom_i},
+    // propagating covariance (anchor pose uncertainty + body increment). The
+    // anchor is the front end's own near-exact pose in {odom_i}, so prediction
+    // uncertainty is dominated by the one-step extrapolation, not the absolute
+    // {map}-frame keyframe covariance.
+    ret.pose.copyFrom(
+        extrapolate_pose_pdf(params_, rawAnchor.pose, ret.twist, anchorTwistCov, dtPred));
 
     return ret;
 }

--- a/mola_state_estimation_smoother/src/extrapolation.h
+++ b/mola_state_estimation_smoother/src/extrapolation.h
@@ -21,9 +21,12 @@
 #pragma once
 
 #include <mola_state_estimation_smoother/Parameters.h>
+#include <mrpt/core/bits_math.h>  // mrpt::square
+#include <mrpt/math/CMatrixFixed.h>
 #include <mrpt/math/CVectorFixed.h>
 #include <mrpt/math/TTwist3D.h>
 #include <mrpt/poses/CPose3D.h>
+#include <mrpt/poses/CPose3DPDFGaussian.h>
 #include <mrpt/poses/Lie/SE.h>
 
 #include <cmath>
@@ -73,6 +76,45 @@ inline mrpt::poses::CPose3D body_twist_delta(
             return mrpt::poses::CPose3D(mrpt::poses::Lie::SE<3>::exp(twistDt));
         }
     }
+}
+
+/** Covariance-aware short-term pose extrapolation: returns the pose PDF of
+ *  `anchorPose` (+) Exp(twist*dt) with first-order uncertainty propagation.
+ *
+ *  Two sources of uncertainty are combined:
+ *   - the anchor pose covariance, transported through the composition (handled
+ *     exactly by MRPT's CPose3DPDFGaussian::operator+, i.e. the Adjoint term);
+ *   - the body-frame increment covariance: the current-velocity uncertainty
+ *     `twistCov` carried over the interval (dt^2 * twistCov), plus an
+ *     acceleration process-noise term (~ 0.5*a*dt^2 position/attitude drift).
+ *
+ *  The increment covariance is expressed in the body tangent [vx vy vz wx wy wz]
+ *  (the ordering of NavState::twist_inv_cov) and mapped to the increment's
+ *  [x y z yaw pitch roll] covariance with J = d(pose)/d(tangent) ~= I for the
+ *  small increments in this regime (exact in the translation channel, first
+ *  order in rotation). Swap in the exact SE(3) exp Jacobian if the rotation
+ *  channel ever needs it.
+ */
+inline mrpt::poses::CPose3DPDFGaussian extrapolate_pose_pdf(
+    const Parameters& params, const mrpt::poses::CPose3DPDFGaussian& anchorPose,
+    const mrpt::math::TTwist3D& twist, const mrpt::math::CMatrixDouble66& twistCov, double dt)
+{
+    mrpt::poses::CPose3DPDFGaussian deltaPdf;
+    deltaPdf.mean = body_twist_delta(params, twist, dt);
+
+    mrpt::math::CMatrixDouble66 incrCov = twistCov;
+    incrCov *= mrpt::square(dt);
+
+    const double halfDt2 = 0.5 * dt * dt;
+    for (int i = 0; i < 3; i++)
+    {
+        incrCov(i, i) += mrpt::square(params.sigma_random_walk_acceleration_linear * halfDt2);
+        incrCov(3 + i, 3 + i) +=
+            mrpt::square(params.sigma_random_walk_acceleration_angular * halfDt2);
+    }
+    deltaPdf.cov = incrCov;
+
+    return anchorPose + deltaPdf;
 }
 
 }  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/src/extrapolation.h
+++ b/mola_state_estimation_smoother/src/extrapolation.h
@@ -29,6 +29,7 @@
 #include <mrpt/poses/CPose3DPDFGaussian.h>
 #include <mrpt/poses/Lie/SE.h>
 
+#include <array>
 #include <cmath>
 
 namespace mola::state_estimation_smoother
@@ -88,12 +89,15 @@ inline mrpt::poses::CPose3D body_twist_delta(
  *     `twistCov` carried over the interval (dt^2 * twistCov), plus an
  *     acceleration process-noise term (~ 0.5*a*dt^2 position/attitude drift).
  *
- *  The increment covariance is expressed in the body tangent [vx vy vz wx wy wz]
- *  (the ordering of NavState::twist_inv_cov) and mapped to the increment's
- *  [x y z yaw pitch roll] covariance with J = d(pose)/d(tangent) ~= I for the
- *  small increments in this regime (exact in the translation channel, first
- *  order in rotation). Swap in the exact SE(3) exp Jacobian if the rotation
- *  channel ever needs it.
+ *  The increment covariance is first built in the body tangent [vx vy vz wx wy
+ *  wz] (the ordering of NavState::twist_inv_cov) and then mapped to the
+ *  increment's CPose3DPDFGaussian ordering [x y z yaw pitch roll] with
+ *  J = d(pose)/d(tangent). To first order at a small increment J reduces to a
+ *  coordinate relabeling: identity on translation, and the body angular rates
+ *  map to the Euler rates as yaw<-wz, pitch<-wy, roll<-wx. The residual
+ *  Jacobian curvature is the higher-order term neglected in this sub-second
+ *  regime; swap in the exact SE(3) exp Jacobian if the rotation channel ever
+ *  needs it.
  */
 inline mrpt::poses::CPose3DPDFGaussian extrapolate_pose_pdf(
     const Parameters& params, const mrpt::poses::CPose3DPDFGaussian& anchorPose,
@@ -112,7 +116,18 @@ inline mrpt::poses::CPose3DPDFGaussian extrapolate_pose_pdf(
         incrCov(3 + i, 3 + i) +=
             mrpt::square(params.sigma_random_walk_acceleration_angular * halfDt2);
     }
-    deltaPdf.cov = incrCov;
+
+    // Relabel from the body tangent [vx vy vz wx wy wz] to the pose-covariance
+    // ordering [x y z yaw pitch roll] (yaw<-wz, pitch<-wy, roll<-wx). This is a
+    // permutation of the angular block, exact at first order.
+    constexpr std::array<int, 6> tangentOfPoseParam = {0, 1, 2, 5, 4, 3};
+    for (int i = 0; i < 6; i++)
+    {
+        for (int j = 0; j < 6; j++)
+        {
+            deltaPdf.cov(i, j) = incrCov(tangentOfPoseParam[i], tangentOfPoseParam[j]);
+        }
+    }
 
     return anchorPose + deltaPdf;
 }

--- a/mola_state_estimation_smoother/tests/test-navstate-basic.cpp
+++ b/mola_state_estimation_smoother/tests/test-navstate-basic.cpp
@@ -360,6 +360,44 @@ void test_unregistered_odom_frame_does_not_throw()
     ASSERT_(ret2.has_value());
 }
 
+// --------------------------------------
+// Probabilistic extrapolation: the extrapolated pose covariance must grow with
+// the extrapolation horizon (the {map} path previously left it constant).
+void test_extrapolation_covariance_grows()
+{
+    const auto& _ = Data::Instance();
+
+    mola::state_estimation_smoother::StateEstimationSmoother nav;
+    nav.initialize(mrpt::containers::yaml::FromText(navStateParams));
+
+    const auto t0 = mrpt::Clock::fromDouble(0.0);
+    const auto t1 = mrpt::Clock::fromDouble(0.5);
+
+    nav.fuse_pose(t0, _.pdf0, "map");  // (0,0,0)
+    nav.fuse_pose(t1, _.pdf1, "map");  // (0.5,0,0) -> forward velocity ~1 m/s
+
+    // Extrapolate the {map} frame at growing horizons past the last keyframe:
+    const auto qNear = nav.estimated_navstate(mrpt::Clock::fromDouble(0.6), "map");
+    const auto qFar  = nav.estimated_navstate(mrpt::Clock::fromDouble(1.0), "map");
+    ASSERT_(qNear.has_value());
+    ASSERT_(qFar.has_value());
+
+    const auto traceOf = [](const auto& s)
+    {
+        mrpt::poses::CPose3DPDFGaussian g;
+        g.copyFrom(s.pose);
+        return g.cov.asEigen().trace();
+    };
+
+    const double trNear = traceOf(*qNear);
+    const double trFar  = traceOf(*qFar);
+
+    std::cout << "pose cov trace: near=" << trNear << " far=" << trFar << std::endl;
+
+    ASSERT_GT_(trNear, 0.0);
+    ASSERT_GT_(trFar, trNear);
+}
+
 }  // namespace
 
 int main(int argc, char** argv)
@@ -372,7 +410,9 @@ int main(int argc, char** argv)
         {"test_2_poses_too_late", test_2_poses_too_late},
         {"test_3_poses", test_3_poses},
         {"test_noisy_straight", test_noisy_straight},
-        {"test_unregistered_odom_frame_does_not_throw", test_unregistered_odom_frame_does_not_throw},
+        {"test_unregistered_odom_frame_does_not_throw",
+         test_unregistered_odom_frame_does_not_throw},
+        {"test_extrapolation_covariance_grows", test_extrapolation_covariance_grows},
     };
 
     int runOnlyIdx = -1;


### PR DESCRIPTION
## Summary

Implements the long-standing `MRPT_TODO("Implement probabilistic extrapolation")` in the smoother's `estimated_navstate()`. The previous short-term extrapolation advanced only the pose **mean** (`ret.pose.mean + body_twist_delta(...)`) and left the extrapolated pose **covariance** ungrown in the `{map}` path, or grew it with an ad-hoc diagonal bump in the `{odom_i}` paths. Neither transported the anchor uncertainty through the composition, nor injected the twist uncertainty into the pose.

This was **not** covered by the async fast pose publisher: `FastPredictor` solved query *latency*, but deliberately mirrored the same approximate extrapolation.

## What changed

A new shared helper `extrapolate_pose_pdf()` (`src/extrapolation.h`) returns the pose PDF of `anchor (+) Exp(twist*dt)` with first-order uncertainty propagation:

- **anchor pose covariance** transported through the composition — exactly, via MRPT's `CPose3DPDFGaussian::operator+` (the Adjoint term);
- **body-increment covariance** = current-velocity uncertainty carried over the interval (`dt² · twistCov`) + acceleration process noise (`~(½·a·dt²)²`).

The increment's tangent→pose Jacobian is approximated as identity (exact in translation, first order in rotation) in the sub-second extrapolation regime; the code notes where to swap in the exact SE(3) exp Jacobian if the rotation channel ever needs it.

Both the synchronous path and `FastPredictor::predict` now route all three frame branches (`{map}`, `{odom_i}` raw-anchored, `{odom_i}` global fallback) through the same helper, consolidating what were two separate ad-hoc covariance models into one.

## Notes

- The pose **mean** is unchanged in every branch (composition mean = `anchor.mean + body_twist_delta(...)`), so deterministic offline/unit-test trajectories are preserved.
- Twist covariance growth (acceleration random walk) is byte-for-byte identical to before.

## Tests

- New `test_extrapolation_covariance_grows` asserts the extrapolated pose covariance trace grows with the horizon (near=0.14 → far=0.76), which the old `{map}` path left flat.
- Full suite green: **28/28** tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D99vpvgmemdrkJ2sSbFq3e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved short-term pose predictions by propagating uncertainty through motion extrapolation.
  * Pose covariance now accounts for motion uncertainty and grows appropriately over longer prediction intervals.
  * Applied consistent covariance-aware predictions across reference and odometry frames.

* **Tests**
  * Added coverage verifying that predicted pose covariance increases with the extrapolation horizon.

* **Documentation**
  * Documented covariance-aware short-term pose extrapolation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->