### PR TITLE
Fuse IMU readings by timestamp, not on arrival

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,14 @@ Key traits:
 - Fuses pose, odometry, IMU and twist; ignores GNSS.
 - Not frame-aware (ignores `frame_id`).
 - Supports optional planar-motion enforcement (`enforce_planar_motion`).
+- `fuse_imu()` only **buffers** the reading (`state_.pending_imu`). It is fused
+  by `fuse_pending_imu_up_to()`, called at the start of every method that
+  carries a time of interest (`estimated_navstate()`, `fuse_pose()`,
+  `fuse_twist()`, `fuse_odometry*()`), which fuses exactly the readings not
+  newer than that time, in timestamp order. `get_last_twist()`, having no time
+  of interest, fuses everything buffered. So the estimate for a given time is a
+  function of the measurement timestamps, not of the delivery order: a pipeline
+  feeding this estimator from concurrent sensor threads stays reproducible.
 
 ### 2. `mola_state_estimation_smoother`
 

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
@@ -144,7 +144,11 @@ class StateEstimationSimple : public mola::NavStateFilter
     std::optional<NavState> estimated_navstate(
         const mrpt::Clock::time_point& timestamp, const std::string& frame_id) override;
 
-    std::optional<mrpt::math::TTwist3D> get_last_twist() const;
+    /** Returns the twist after fusing every IMU reading received so far,
+     *  irrespective of its timestamp (see fuse_imu() on why IMU readings are
+     *  buffered). Prefer estimated_navstate() whenever the time of interest is
+     *  known. */
+    std::optional<mrpt::math::TTwist3D> get_last_twist();
 
     /** @} */
 
@@ -189,6 +193,18 @@ class StateEstimationSimple : public mola::NavStateFilter
         };
         std::map<std::string, SourceState> per_source;
 
+        // Angular velocity (already rotated into the vehicle frame) of an IMU
+        // reading that has been received but not fused yet. See fuse_imu().
+        struct PendingImu
+        {
+            double wx = 0;
+            double wy = 0;
+            double wz = 0;
+        };
+
+        // IMU readings waiting to be fused, keyed and ordered by timestamp.
+        std::map<mrpt::Clock::time_point, PendingImu> pending_imu;
+
         // To be built from parameters strings when changed.
         RegexCache do_process_imu_labels_re;
         RegexCache do_process_odometry_labels_re;
@@ -209,6 +225,15 @@ class StateEstimationSimple : public mola::NavStateFilter
     void update_vel_filter(
         const std::array<double, 6>& z, const std::array<double, 6>& R_diag,
         const mrpt::Clock::time_point& tim, const std::string& caller = "");
+
+    /** Fuses the buffered IMU readings with a timestamp not newer than `upTo`,
+     *  in timestamp order, and drops them from the buffer.
+     *  Must be called with state_mtx_ already held. */
+    void fuse_pending_imu_up_to(const mrpt::Clock::time_point& upTo);
+
+    /** Fuses every buffered IMU reading, whatever its timestamp.
+     *  Must be called with state_mtx_ already held. */
+    void fuse_all_pending_imu();
 
     State state_;
 

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
@@ -202,8 +202,11 @@ class StateEstimationSimple : public mola::NavStateFilter
             double wz = 0;
         };
 
-        // IMU readings waiting to be fused, keyed and ordered by timestamp.
-        std::map<mrpt::Clock::time_point, PendingImu> pending_imu;
+        // IMU readings waiting to be fused, ordered by timestamp. A multimap,
+        // so that two readings sharing a timestamp are both kept: which of them
+        // is "the" reading for that instant is undecidable, and dropping one
+        // would silently discard data that used to be fused.
+        std::multimap<mrpt::Clock::time_point, PendingImu> pending_imu;
 
         // To be built from parameters strings when changed.
         RegexCache do_process_imu_labels_re;

--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -445,7 +445,8 @@ void StateEstimationSimple::fuse_imu(const mrpt::obs::CObservationIMU& imu)
     // timestamps alone, and no longer of how many IMU readings happened to be
     // delivered first, which is what makes concurrent sensor inputs
     // reproducible.
-    state_.pending_imu[imu.timestamp] = {imuReading.wx, imuReading.wy, imuReading.wz};
+    state_.pending_imu.emplace(
+        imu.timestamp, State::PendingImu{imuReading.wx, imuReading.wy, imuReading.wz});
 
     // Keep the buffer bounded in case nothing ever asks for an estimate:
     const auto oldestToKeep =

--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -29,6 +29,7 @@
 #include <mrpt/topography/conversions.h>
 
 #include <Eigen/Dense>
+#include <chrono>
 #include <fstream>
 #include <memory>
 
@@ -37,6 +38,15 @@ IMPLEMENTS_MRPT_OBJECT(StateEstimationSimple, mola::ExecutableBase, mola::state_
 
 namespace mola::state_estimation_simple
 {
+
+namespace
+{
+/// Age [s], relative to the newest buffered reading, beyond which an unfused
+/// IMU reading is discarded. Only reached if nothing ever asks the estimator
+/// for a state, since any query or measurement drains everything older than
+/// its own timestamp.
+constexpr double kPendingImuMaxAge = 1.0;
+}  // namespace
 
 StateEstimationSimple::StateEstimationSimple() = default;
 
@@ -275,6 +285,8 @@ void StateEstimationSimple::fuse_odometry(
 {
     auto lck = std::scoped_lock(state_mtx_);
 
+    fuse_pending_imu_up_to(odom.timestamp);
+
     // Advance last_pose by the incremental 2D odometry delta:
     if (state_.last_odom_obs && state_.last_pose)
     {
@@ -320,6 +332,8 @@ void StateEstimationSimple::fuse_odometry_3d_pose(
     const mrpt::obs::CObservationRobotPose& obs, const std::string& odomName)
 {
     auto lck = std::scoped_lock(state_mtx_);
+
+    fuse_pending_imu_up_to(obs.timestamp);
 
     // Apply sensor-to-base correction if the sensor is not at the origin:
     auto sensedPose = obs.pose;
@@ -417,35 +431,67 @@ void StateEstimationSimple::fuse_imu(const mrpt::obs::CObservationIMU& imu)
     // Do not predict a new pose for this timestamp, so we can use the last *real*
     // call to fuse_pose() from an outter source.
 
-    // and now overwrite twist (wx,wy,wz) part from IMU data:
+    // Angular velocity, transformed from the IMU frame to the vehicle frame:
     mrpt::math::TTwist3D imuReading;
     imuReading.wx = imu.get(mrpt::obs::TIMUDataIndex::IMU_WX);
     imuReading.wy = imu.get(mrpt::obs::TIMUDataIndex::IMU_WY);
     imuReading.wz = imu.get(mrpt::obs::TIMUDataIndex::IMU_WZ);
-
-    // Transform frames: IMU -> vehicle:
     imuReading.rotate(imu.sensorPose.asTPose());
 
+    // The reading is buffered, not fused right away: it is fused once some
+    // other call establishes the time of interest (a query or another
+    // measurement), and only if it is not newer than that time. The estimate
+    // returned for a given time is then a function of the measurement
+    // timestamps alone, and no longer of how many IMU readings happened to be
+    // delivered first, which is what makes concurrent sensor inputs
+    // reproducible.
+    state_.pending_imu[imu.timestamp] = {imuReading.wx, imuReading.wy, imuReading.wz};
+
+    // Keep the buffer bounded in case nothing ever asks for an estimate:
+    const auto oldestToKeep =
+        state_.pending_imu.rbegin()->first - std::chrono::duration_cast<mrpt::Clock::duration>(
+                                                 std::chrono::duration<double>(kPendingImuMaxAge));
+    state_.pending_imu.erase(
+        state_.pending_imu.begin(), state_.pending_imu.lower_bound(oldestToKeep));
+}
+
+void StateEstimationSimple::fuse_pending_imu_up_to(const mrpt::Clock::time_point& upTo)
+{
     // IMU only observes angular velocity: preserve linear (vx,vy,vz) from the
     // last fuse_pose(). Pass a very large R for the linear components so the
     // filter gain for them is ~0 (no new information from this IMU reading).
     const double no_info = 1e9;
     const double var_ang = mrpt::square(params.sigma_imu_angular_velocity);
 
-    const double cur_vx = state_.last_twist.has_value() ? state_.last_twist->vx : 0.0;
-    const double cur_vy = state_.last_twist.has_value() ? state_.last_twist->vy : 0.0;
-    const double cur_vz = state_.last_twist.has_value() ? state_.last_twist->vz : 0.0;
-
-    const std::array<double, 6> z = {
-        cur_vx, cur_vy, cur_vz, imuReading.wx, imuReading.wy, imuReading.wz,
-    };
     const std::array<double, 6> R_diag = {
         no_info, no_info, no_info, var_ang, var_ang, var_ang,
     };
 
-    update_vel_filter(z, R_diag, imu.timestamp, "fuse_imu");
+    const auto itEnd = state_.pending_imu.upper_bound(upTo);
+    for (auto it = state_.pending_imu.begin(); it != itEnd; ++it)
+    {
+        const double cur_vx = state_.last_twist.has_value() ? state_.last_twist->vx : 0.0;
+        const double cur_vy = state_.last_twist.has_value() ? state_.last_twist->vy : 0.0;
+        const double cur_vz = state_.last_twist.has_value() ? state_.last_twist->vz : 0.0;
 
-    MRPT_LOG_DEBUG_STREAM("fuse_imu(): new twist: " << state_.last_twist->asString());
+        const std::array<double, 6> z = {
+            cur_vx, cur_vy, cur_vz, it->second.wx, it->second.wy, it->second.wz,
+        };
+
+        update_vel_filter(z, R_diag, it->first, "fuse_imu");
+
+        MRPT_LOG_DEBUG_STREAM("fuse_imu(): new twist: " << state_.last_twist->asString());
+    }
+    state_.pending_imu.erase(state_.pending_imu.begin(), itEnd);
+}
+
+void StateEstimationSimple::fuse_all_pending_imu()
+{
+    if (state_.pending_imu.empty())
+    {
+        return;
+    }
+    fuse_pending_imu_up_to(state_.pending_imu.rbegin()->first);
 }
 
 #if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)
@@ -632,6 +678,10 @@ void StateEstimationSimple::fuse_pose(
 {
     auto lck = std::scoped_lock(state_mtx_);
 
+    // The IMU readings up to this measurement's own time belong before it in
+    // the filter; newer ones stay buffered (see fuse_imu()):
+    fuse_pending_imu_up_to(timestamp);
+
     // Numerical sanity: variances >= 0 (== 0 allowed for some components only)
     for (int i = 0; i < 6; i++) ASSERT_GE_(pose.cov(i, i), .0);
     ASSERT_GT_(pose.cov.trace(), .0);
@@ -737,6 +787,8 @@ void StateEstimationSimple::fuse_twist(
 {
     auto lck = std::scoped_lock(state_mtx_);
 
+    fuse_pending_imu_up_to(timestamp);
+
     std::array<double, 6> z = {
         twist.vx, twist.vy, twist.vz, twist.wx, twist.wy, twist.wz,
     };
@@ -756,6 +808,10 @@ std::optional<NavState> StateEstimationSimple::estimated_navstate(
     const mrpt::Clock::time_point& timestamp, [[maybe_unused]] const std::string& frame_id)
 {
     auto lck = std::scoped_lock(state_mtx_);
+
+    // Bring the filter up to the queried time, using only the IMU readings that
+    // precede it (see fuse_imu()):
+    fuse_pending_imu_up_to(timestamp);
 
     if (!state_.last_pose_obs_tim)
     {
@@ -953,9 +1009,12 @@ void StateEstimationSimple::onNewObservation(const CObservation::ConstPtr& o)
     }
 }
 
-std::optional<mrpt::math::TTwist3D> StateEstimationSimple::get_last_twist() const
+std::optional<mrpt::math::TTwist3D> StateEstimationSimple::get_last_twist()
 {
     auto lck = std::scoped_lock(state_mtx_);
+
+    // No time of interest is given here, so everything received is fused:
+    fuse_all_pending_imu();
 
     return state_.last_twist;
 }

--- a/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
+++ b/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
@@ -1058,6 +1058,15 @@ void test_imu_arrival_order_independence()
     expectSameAs(alsoFuture, "Readings newer than the query time changed the estimate");
     expectSameAs(reversedArrival, "The delivery order changed the estimate");
 
+    // Two readings sharing a timestamp must both be fused, not one silently
+    // dropped in favor of the other:
+    auto withDuplicate = imuSamples;
+    withDuplicate.push_back(imuSamples[1]);
+    const auto duplicated = run(withDuplicate);
+    ASSERTMSG_(
+        duplicated.twist.wz != onlyPast.twist.wz,
+        "A reading sharing a timestamp with another one was dropped");
+
     // Sanity: the estimate did track the readings it was supposed to use, and
     // only those. The filter approaches, but does not reach, the measurement.
     ASSERT_GT_(onlyPast.twist.wz, 1.0);

--- a/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
+++ b/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
@@ -32,6 +32,8 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <utility>
+#include <vector>
 
 using namespace std::string_literals;
 using namespace mrpt::literals;
@@ -976,6 +978,94 @@ void test_gnss_significant_3d_lever_arm()
 }
 #endif
 
+// --------------------------------------------------------------------------
+// Test: IMU arrival order must not change the estimate
+// --------------------------------------------------------------------------
+// The estimate returned for a given time must be a function of the measurement
+// timestamps, never of the order in which the measurements were delivered, nor
+// of how many later ones happened to arrive first. That is what makes a
+// pipeline feeding this estimator from several concurrent sensor threads
+// reproducible.
+void test_imu_arrival_order_independence()
+{
+    std::cout << "[Test] IMU arrival-order independence... ";
+
+    // Angular rate of each of the readings, all of them around Z:
+    const std::vector<std::pair<double, double>> imuSamples = {
+        {1.1, 1.0}, {1.2, 2.0}, {1.3, 3.0}, {1.4, 4.0}};
+
+    const double queryTime = 1.25;  // in between the 2nd and the 3rd reading
+
+    const auto makeImu = [](double t, double wz)
+    {
+        mrpt::obs::CObservationIMU imu;
+        imu.timestamp = mrpt::Clock::fromDouble(t);
+        imu.set(mrpt::obs::IMU_WX, 0.0);
+        imu.set(mrpt::obs::IMU_WY, 0.0);
+        imu.set(mrpt::obs::IMU_WZ, wz);
+        imu.sensorPose = mrpt::poses::CPose3D::Identity();
+        return imu;
+    };
+
+    // Feeds the given readings, in the given order, and queries at queryTime:
+    const auto run = [&](const std::vector<std::pair<double, double>>& deliveryOrder)
+    {
+        mola::state_estimation_simple::StateEstimationSimple estimator;
+        estimator.initialize(get_default_config());
+
+        // Seed a pose (and hence a twist) at a constant 2 m/s along X:
+        estimator.fuse_pose(
+            mrpt::Clock::fromDouble(0.0),
+            mrpt::poses::CPose3DPDFGaussian(
+                mrpt::poses::CPose3D::Identity(), mrpt::math::CMatrixDouble66::Identity()),
+            "map");
+        estimator.fuse_pose(
+            mrpt::Clock::fromDouble(1.0),
+            mrpt::poses::CPose3DPDFGaussian(
+                mrpt::poses::CPose3D(2.0, 0, 0), mrpt::math::CMatrixDouble66::Identity()),
+            "map");
+
+        for (const auto& [t, wz] : deliveryOrder)
+        {
+            estimator.fuse_imu(makeImu(t, wz));
+        }
+
+        auto st = estimator.estimated_navstate(mrpt::Clock::fromDouble(queryTime), "map");
+        ASSERT_(st.has_value());
+        return *st;
+    };
+
+    // (a) Only the readings older than the query time were delivered:
+    const auto onlyPast = run({imuSamples[0], imuSamples[1]});
+
+    // (b) The later readings were delivered too, before the query:
+    const auto alsoFuture = run(imuSamples);
+
+    // (c) Same set as (b), delivered in reverse order:
+    auto reversed = imuSamples;
+    std::reverse(reversed.begin(), reversed.end());
+    const auto reversedArrival = run(reversed);
+
+    const auto expectSameAs = [&](const mola::NavState& other, const char* what)
+    {
+        ASSERTMSG_(onlyPast.twist.wx == other.twist.wx, what);
+        ASSERTMSG_(onlyPast.twist.wy == other.twist.wy, what);
+        ASSERTMSG_(onlyPast.twist.wz == other.twist.wz, what);
+        ASSERTMSG_(onlyPast.twist.vx == other.twist.vx, what);
+        ASSERTMSG_(onlyPast.pose.mean == other.pose.mean, what);
+    };
+
+    expectSameAs(alsoFuture, "Readings newer than the query time changed the estimate");
+    expectSameAs(reversedArrival, "The delivery order changed the estimate");
+
+    // Sanity: the estimate did track the readings it was supposed to use, and
+    // only those. The filter approaches, but does not reach, the measurement.
+    ASSERT_GT_(onlyPast.twist.wz, 1.0);
+    ASSERT_LT_(onlyPast.twist.wz, 2.0);
+
+    std::cout << "OK\n";
+}
+
 }  // namespace
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
@@ -991,6 +1081,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
         test_icp_and_3d_odometry_fusion();
         test_velocity_kalman_filter();
         test_multirate_interleaved_velocity();
+        test_imu_arrival_order_independence();
 #if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)
         test_gnss_rtk_pulls_anchor();
         test_gnss_gated_out();


### PR DESCRIPTION
## Problem

`mola-lidar-odometry-cli` run offline is not bit-reproducible when an IMU is
used: two runs of the same sequence, same binary, same arguments, produce
different trajectories. Without the IMU input the same two runs are
byte-identical, so the divergence enters through the IMU.

Instrumenting a LiDAR-odometry run showed exactly where. At the scan where the
two runs first differ, the de-skewed point cloud handed to ICP is bit-identical
(same point count, same checksum), and the only thing that differs is what
`estimated_navstate()` returned:

```
DESKEW t=1710256148.456232 n=57764 chk=-112454.228831782   (identical in both runs)
NAVST  A: wx=-0.056314125 wy=-0.520067119 wz=-0.862166445
NAVST  B: wx=-0.055252760 wy=-0.520418972 wz=-0.962710275
```

`wz` differs by 0.1 rad/s, i.e. a whole extra IMU reading had been fused in one
run and not the other.

The cause is that `fuse_imu()` applied every reading to the velocity filter as
soon as it was delivered. The LiDAR front-end queries the estimator from its own
worker thread while a sensor thread keeps feeding IMU data, so
`estimated_navstate(t)` returned a twist built from however many readings
happened to have arrived by then, including readings *newer than `t`*. The
answer for a given `t` was decided by thread scheduling.

There is a second, related asymmetry: the velocity filter keeps a per-component
clock and rejects samples older than it. A reading newer than a subsequent
`fuse_pose()` call advanced the angular clock past that pose's timestamp, so the
pose's own angular update was then rejected as backwards in time.

## The fix

`fuse_imu()` now only buffers the reading, keyed by timestamp. The readings are
fused by `fuse_pending_imu_up_to()`, called at the start of every method that
carries a time of interest:

| caller | fuses readings up to |
|---|---|
| `estimated_navstate(t)` | `t` |
| `fuse_pose(t, ...)` | `t` |
| `fuse_twist(t, ...)` | `t` |
| `fuse_odometry(obs)` / `fuse_odometry_3d_pose(obs)` | `obs.timestamp` |

Each fuses exactly the readings not newer than its own time, in timestamp order.
Readings newer than that stay buffered for whoever asks next. The estimate for a
given time is therefore a function of the measurement timestamps, never of the
delivery order or of how many readings won a race.

`get_last_twist()` names no time of interest, so it fuses everything received.
That is why it is no longer `const`. The buffer is capped by age (1 s relative to
the newest reading held) in case nothing ever queries the estimator; any query or
measurement drains everything older than its own timestamp, so that cap is only
reached when the estimator is fed IMU and nothing else.

### Why a timestamp gate and not a fixed delay

Delaying one stream relative to the other was considered and rejected. A delay
only shrinks the window in which the race can be lost: whether it was enough
still depends on machine load, so runs stay irreproducible and the failure just
becomes rarer and harder to diagnose. It also adds latency online, which
selecting by timestamp does not.

## Evidence

Sequence: Oxford Spires `2024-03-12-keble-college-03`, full replay, default
pipeline, `state-estimation-simple`. Paired with
MOLAorg/mola_lidar_odometry#129 (the front-end must hold a scan until the
IMU covering its span has arrived, otherwise a reading that has not been
delivered yet is simply missed instead of being fused late).

md5 of the output `.tum`, two runs each:

| configuration | run A | run B |
|---|---|---|
| before, with IMU | `7770ad95c06607d0972241bcf98769fa` | `c07c8005caf26faefe02432fa6732de0` |
| after, with IMU | `c2a3c952ac66dc459d9353ca046af8c7` | `c2a3c952ac66dc459d9353ca046af8c7` |
| after, no IMU (regression guard) | `a42c29b537c737a1089ba9dfc5b23e44` | `a42c29b537c737a1089ba9dfc5b23e44` |

The no-IMU md5 is unchanged from before this work, so nothing about the IMU-free
path moved. All runs process 2867 `onLidar` calls and emit 2867 poses, with no
dropped scans. (Before, we had also seen runs emitting only 2866 poses, one scan
mid-run failing to produce one; that no longer happens.)

Accuracy is essentially unchanged, as expected for a change that only fixes
*which* readings are used and not how:

```
evo_ape ... --align --t_max_diff 0.01
before, with IMU:  RMSE 0.280 m / 0.303 m  (the two differing runs)
after,  with IMU:  RMSE 0.327 m
```

## Tests

New `test_imu_arrival_order_independence` in
`tests/test-state-estimation-simple.cpp`. It seeds a twist from two poses, then
feeds the same four IMU readings three ways and queries at a time in the middle
of them:

- only the readings older than the query time,
- all of them, including two newer than the query,
- all of them in reverse delivery order,

and requires all three to return the identical `NavState`. Deterministic: no
threads, no timing.

Verified that it fails on `develop` (`Readings newer than the query time changed
the estimate`) and passes with this change. The whole suite passes.

## Limitations

- Order-independence holds for readings that have been *delivered*. A reading
  older than the query time that has not arrived yet is still missed; nothing
  inside the estimator can help that, which is why the front-end gate in the
  companion PR is needed to make the offline pipeline reproducible end to end.
- `get_last_twist()` changing from `const` to non-`const` is a source-level API
  break for any out-of-tree caller holding a `const` reference. Nothing in-tree
  does, and every in-tree use is in the unit tests.
- `mola_state_estimation_smoother` is not touched. It does not have this
  particular bug (it inserts IMU data as timestamp-keyed graph factors rather
  than overwriting a single "latest" twist), but I have not measured its
  run-to-run determinism and am not claiming it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IMU readings are now processed according to their timestamps rather than delivery order.
  * State queries use only measurements available up to the relevant timestamp, improving estimate consistency.
  * Recent pending IMU readings are retained within a bounded time window.

* **Tests**
  * Added coverage verifying consistent navigation estimates when IMU readings arrive out of order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->