### PR TITLE
Keep buffered IMU readings across reset()

### DIFF
--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -78,8 +78,18 @@ void StateEstimationSimple::reset()
 {
     auto lck = std::scoped_lock(state_mtx_);
 
+    // Buffered-but-unfused IMU readings survive the reset. They are sensor data
+    // for instants the filter has not reached yet, not part of the past this
+    // call exists to forget, and the next query consumes exactly the ones its
+    // own timestamp covers. Discarding them here would instead make the
+    // estimate depend on how many readings happened to be delivered before the
+    // reset ran, i.e. on thread scheduling rather than on the input.
+    auto pendingImu = std::move(state_.pending_imu);
+
     // reset:
     state_ = State();
+
+    state_.pending_imu = std::move(pendingImu);
 
     MRPT_LOG_INFO_STREAM("reset() called");
 }

--- a/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
+++ b/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
@@ -1075,6 +1075,97 @@ void test_imu_arrival_order_independence()
     std::cout << "OK\n";
 }
 
+// --------------------------------------------------------------------------
+// reset() must not discard buffered, not-yet-fused IMU readings
+// --------------------------------------------------------------------------
+// reset() forgets the estimated past: the pose and twist history. Readings that
+// have been received but not yet fused are not part of that past, they describe
+// instants the filter has not reached yet. Discarding them would make the
+// estimate depend on whether a reading happened to be delivered just before or
+// just after the reset, which in a live system is decided by thread scheduling
+// rather than by the data.
+void test_imu_survives_reset()
+{
+    std::cout << "[Test] IMU buffered across reset()... ";
+
+    const std::vector<std::pair<double, double>> imuSamples = {
+        {1.1, 1.0}, {1.2, 2.0}, {1.3, 3.0}, {1.4, 4.0}};
+
+    const double queryTime = 1.25;  // in between the 2nd and the 3rd reading
+
+    const auto makeImu = [](double t, double wz)
+    {
+        mrpt::obs::CObservationIMU imu;
+        imu.timestamp = mrpt::Clock::fromDouble(t);
+        imu.set(mrpt::obs::IMU_WX, 0.0);
+        imu.set(mrpt::obs::IMU_WY, 0.0);
+        imu.set(mrpt::obs::IMU_WZ, wz);
+        imu.sensorPose = mrpt::poses::CPose3D::Identity();
+        return imu;
+    };
+
+    // Same readings and same query either way; the only difference is whether
+    // they were delivered before or after reset():
+    const auto run = [&](bool deliverBeforeReset)
+    {
+        mola::state_estimation_simple::StateEstimationSimple estimator;
+        estimator.initialize(get_default_config());
+
+        const auto feedImu = [&]()
+        {
+            for (const auto& [t, wz] : imuSamples)
+            {
+                estimator.fuse_imu(makeImu(t, wz));
+            }
+        };
+
+        if (deliverBeforeReset)
+        {
+            feedImu();
+        }
+
+        estimator.reset();
+
+        if (!deliverBeforeReset)
+        {
+            feedImu();
+        }
+
+        // Seeded after the reset, so both arms share the same pose history:
+        estimator.fuse_pose(
+            mrpt::Clock::fromDouble(0.0),
+            mrpt::poses::CPose3DPDFGaussian(
+                mrpt::poses::CPose3D::Identity(), mrpt::math::CMatrixDouble66::Identity()),
+            "map");
+        estimator.fuse_pose(
+            mrpt::Clock::fromDouble(1.0),
+            mrpt::poses::CPose3DPDFGaussian(
+                mrpt::poses::CPose3D(2.0, 0, 0), mrpt::math::CMatrixDouble66::Identity()),
+            "map");
+
+        auto st = estimator.estimated_navstate(mrpt::Clock::fromDouble(queryTime), "map");
+        ASSERT_(st.has_value());
+        return *st;
+    };
+
+    const auto deliveredBefore = run(true);
+    const auto deliveredAfter  = run(false);
+
+    ASSERTMSG_(
+        deliveredBefore.twist.wz == deliveredAfter.twist.wz,
+        "reset() discarded IMU readings that had been received but not yet fused");
+    ASSERTMSG_(
+        deliveredBefore.pose.mean == deliveredAfter.pose.mean,
+        "reset() changed the extrapolated pose");
+
+    // Sanity: the readings were actually used, so the check above is not
+    // trivially comparing two untouched zeros.
+    ASSERT_GT_(deliveredBefore.twist.wz, 1.0);
+    ASSERT_LT_(deliveredBefore.twist.wz, 2.0);
+
+    std::cout << "OK\n";
+}
+
 }  // namespace
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
@@ -1091,6 +1182,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
         test_velocity_kalman_filter();
         test_multirate_interleaved_velocity();
         test_imu_arrival_order_independence();
+        test_imu_survives_reset();
 #if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)
         test_gnss_rtk_pulls_anchor();
         test_gnss_gated_out();


### PR DESCRIPTION
## The bug

`reset()` forgets the estimated past: the pose and twist history. It was also wiping `pending_imu`, the readings that have been **received but not yet fused**. Those are not part of that past — they describe instants the filter has not reached yet, and the next query consumes exactly the ones its own timestamp covers.

Discarding them makes the estimate depend on how many readings happened to be delivered before the reset ran. In LiDAR odometry that is a race: `LidarOdometry::handleInitialLocalizationDoInitFromPose()` calls `navstate_fuse->reset()` from the **LiDAR worker thread** during initial localization, while the **input thread** is concurrently delivering IMU readings into the same buffer. Whether the first reading survived was decided by thread scheduling, i.e. by machine load.

This is the same invariant #53 established — that the estimate is a function of the measurement timestamps and not of delivery timing — applied to `reset()`, which #53 did not cover.

## Evidence

`oxford-spires` `keble-college-03`, full sequence (2867 scans), `lidar3d-default` + `state-estimation-simple`, offline CLI, host under sustained load (12 concurrent runs):

| | consensus runs | outlier runs |
|---|---|---|
| IMU readings fused for scan 2 | 19 | **18** |
| oldest buffered reading | `…034.073483` | `…034.075973` (first one gone) |
| runs (n=12) | 10 | 2 |

The reading count correlated with the final trajectory md5 **12/12**.

One missing reading moves the filtered angular velocity by 1.7e-6. That twist is extrapolated into the **ICP initial guess**, so the two cases take different linearization points and follow different trajectories — **0.64 m apart** by the end of the sequence.

Before: 2 distinct trajectories over 12 loaded runs. After: **12/12 byte-identical**.

## Note for downstream

The output changes: the first scans now fuse the IMU data they should always have had. Stored trajectory baselines need regenerating.

## Test

`test_imu_survives_reset` feeds the same readings and issues the same query, differing only in whether delivery happened before or after `reset()`. Without the fix it fails with:

```
reset() discarded IMU readings that had been received but not yet fused
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved buffered, unfused IMU readings when resetting state estimation.
  * Ensured pending sensor data continues contributing to consistent estimates after reset.

* **Tests**
  * Added regression coverage verifying buffered IMU readings remain available and produce equivalent estimates after reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->