### PR TITLE
StateEstimationSimple: implement transform_frame()

### DIFF
--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
@@ -197,6 +197,14 @@ class StateEstimationSimple : public mola::NavStateFilter
         {
             std::optional<mrpt::poses::CPose3DPDFGaussian> last_pose;
             std::optional<mrpt::Clock::time_point>         last_obs_tim;
+
+            // Which frame `last_pose` is expressed in. Localization sources
+            // (fuse_pose) are in the map frame; 3D odometry sources keep their
+            // own, potentially offset, odometry frame. A change of the map
+            // frame must only be applied to the former: the latter keeps
+            // receiving observations in its original frame, and rebasing the
+            // stored anchor would corrupt the next delta.
+            bool in_map_frame = true;
         };
         std::map<std::string, SourceState> per_source;
 

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
@@ -131,6 +131,13 @@ class StateEstimationSimple : public mola::NavStateFilter
     std::optional<mola::Georeferencing> get_geo_reference() const override;
 #endif
 
+#if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_TRANSFORM_FRAME)
+    /** Re-expresses the stored poses in a new reference frame (`p` -> `b + p`).
+     *  Every velocity held here is in the vehicle's own frame, so a change of
+     *  the map frame leaves the twist and its covariance untouched. */
+    bool transform_frame(const mrpt::poses::CPose3D& b) override;
+#endif
+
     /** Integrates new twist estimation (in the odom frame) */
     void fuse_twist(
         const mrpt::Clock::time_point& timestamp, const mrpt::math::TTwist3D& twist,

--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -352,7 +352,8 @@ void StateEstimationSimple::fuse_odometry_3d_pose(
         sensedPose = sensedPose + mrpt::poses::CPose3DPDFGaussian(-obs.sensorPose);
     }
 
-    auto& src = state_.per_source[odomName];
+    auto& src        = state_.per_source[odomName];
+    src.in_map_frame = false;
 
     // Compute and apply the incremental delta to last_pose, keeping it in the
     // LiDAR SLAM frame rather than replacing it with the absolute odom pose
@@ -707,7 +708,8 @@ void StateEstimationSimple::fuse_pose(
     // so that the derived twist reflects true ICP-to-ICP motion even when
     // fuse_odometry() / fuse_odometry_3d_pose() have modified last_pose in
     // between ICP scans.
-    auto& src = state_.per_source[frame_id];
+    auto& src        = state_.per_source[frame_id];
+    src.in_map_frame = true;
 
     double dt = 0;
     if (src.last_obs_tim)
@@ -821,25 +823,37 @@ bool StateEstimationSimple::transform_frame(const mrpt::poses::CPose3D& b)
     auto lck = std::scoped_lock(state_mtx_);
 
     // Everything expressed in the map frame: the fused pose and the per-source
-    // last poses used to derive velocity from consecutive observations.
+    // last poses of map-frame sources, used to derive velocity from
+    // consecutive observations.
     if (state_.last_pose)
     {
         state_.last_pose->changeCoordinatesReference(b);
     }
     for (auto& [name, src] : state_.per_source)
     {
-        if (src.last_pose)
+        if (!src.in_map_frame || !src.last_pose)
         {
-            src.last_pose->changeCoordinatesReference(b);
+            continue;
         }
+        src.last_pose->changeCoordinatesReference(b);
     }
+
+#if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)
+    // The ENU-to-map transform ends in the map frame, so it must follow it.
+    // The geodetic datum (geo_coord) is a property of the Earth, not of the
+    // map frame, hence left untouched.
+    if (geo_reference_)
+    {
+        geo_reference_->T_enu_to_map.changeCoordinatesReference(b);
+    }
+#endif
 
     // Deliberately NOT touched: last_twist / last_twist_cov / vel_filter_P and
     // the buffered IMU readings. All of them live in the vehicle's own frame
     // (fuse_pose() derives velocity from `pose - previous_pose`, and
     // estimated_navstate() extrapolates by right-composition), which a change
     // of the map frame leaves invariant. Wheel-odometry readings are likewise
-    // in their own frame.
+    // in their own frame, and so are the odometry-frame entries skipped above.
 
     MRPT_LOG_INFO_STREAM("transform_frame(): applied reference-frame change " << b);
 

--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -815,6 +815,38 @@ void StateEstimationSimple::fuse_twist(
     MRPT_LOG_DEBUG_STREAM("fuse_twist(): twist_cov= " << state_.last_twist_cov->asString());
 }
 
+#if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_TRANSFORM_FRAME)
+bool StateEstimationSimple::transform_frame(const mrpt::poses::CPose3D& b)
+{
+    auto lck = std::scoped_lock(state_mtx_);
+
+    // Everything expressed in the map frame: the fused pose and the per-source
+    // last poses used to derive velocity from consecutive observations.
+    if (state_.last_pose)
+    {
+        state_.last_pose->changeCoordinatesReference(b);
+    }
+    for (auto& [name, src] : state_.per_source)
+    {
+        if (src.last_pose)
+        {
+            src.last_pose->changeCoordinatesReference(b);
+        }
+    }
+
+    // Deliberately NOT touched: last_twist / last_twist_cov / vel_filter_P and
+    // the buffered IMU readings. All of them live in the vehicle's own frame
+    // (fuse_pose() derives velocity from `pose - previous_pose`, and
+    // estimated_navstate() extrapolates by right-composition), which a change
+    // of the map frame leaves invariant. Wheel-odometry readings are likewise
+    // in their own frame.
+
+    MRPT_LOG_INFO_STREAM("transform_frame(): applied reference-frame change " << b);
+
+    return true;
+}
+#endif
+
 std::optional<NavState> StateEstimationSimple::estimated_navstate(
     const mrpt::Clock::time_point& timestamp, [[maybe_unused]] const std::string& frame_id)
 {

--- a/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
+++ b/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
@@ -1166,6 +1166,99 @@ void test_imu_survives_reset()
     std::cout << "OK\n";
 }
 
+#if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_TRANSFORM_FRAME)
+// A change of the map frame must not disturb an odometry source, whose
+// observations keep arriving in their own, untouched, reference frame.
+void test_transform_frame_leaves_odometry_frame_alone()
+{
+    std::cout << "[Test] transform_frame() keeps odometry-frame sources... ";
+
+    mola::state_estimation_simple::StateEstimationSimple est;
+    est.initialize(get_default_config());
+
+    const auto cov = mrpt::math::CMatrixDouble66::Identity();
+
+    auto send_wheel_odom = [&](double t, double x)
+    {
+        auto obs         = mrpt::obs::CObservationRobotPose::Create();
+        obs->timestamp   = mrpt::Clock::fromDouble(t);
+        obs->sensorLabel = "wheel_odom";
+        obs->pose        = mrpt::poses::CPose3DPDFGaussian(mrpt::poses::CPose3D(x, 0, 0), cov);
+        est.onNewObservation(obs);
+    };
+
+    // Two static observations, so that a (zero) twist exists and the state is
+    // queryable.
+    for (const double t : {0.0, 0.5})
+    {
+        est.fuse_pose(
+            mrpt::Clock::fromDouble(t),
+            mrpt::poses::CPose3DPDFGaussian(mrpt::poses::CPose3D::Identity(), cov), "map");
+        send_wheel_odom(t, 0.0);
+    }
+
+    // Change the map frame, then let odometry advance 1 m in its own frame.
+    // The fused pose must move by exactly that 1 m as seen in the new map
+    // frame, i.e. no extra offset leaks in from `b`.
+    const auto b = mrpt::poses::CPose3D(1, 2, 3, 25.0_deg, 0.0_deg, 10.0_deg);
+    ASSERT_(est.transform_frame(b));
+
+    auto before = est.estimated_navstate(mrpt::Clock::fromDouble(0.5), "map");
+    ASSERT_(before.has_value());
+
+    send_wheel_odom(1.0, 1.0);
+
+    auto after = est.estimated_navstate(mrpt::Clock::fromDouble(1.0), "map");
+    ASSERT_(after.has_value());
+
+    const auto delta = after->pose.mean - before->pose.mean;
+    ASSERT_NEAR_(delta.x(), 1.0, 1e-6);
+    ASSERT_NEAR_(delta.y(), 0.0, 1e-6);
+    ASSERT_NEAR_(delta.z(), 0.0, 1e-6);
+
+    std::cout << "OK\n";
+}
+
+#if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)
+// The ENU-to-map transform ends in the map frame, so a change of that frame
+// must carry it along; otherwise later GNSS fixes land in the stale frame.
+void test_transform_frame_updates_geo_reference()
+{
+    std::cout << "[Test] transform_frame() rebases the geo-reference... ";
+
+    mola::state_estimation_simple::StateEstimationSimple est;
+    est.initialize(gnss_config());
+    est.set_geo_reference(identity_georef());
+
+    const auto b = mrpt::poses::CPose3D(1, 2, 3, 30.0_deg, 0.0_deg, 0.0_deg);
+    ASSERT_(est.transform_frame(b));
+
+    const auto g = est.get_geo_reference();
+    ASSERT_(g.has_value());
+    // The datum is a property of the Earth and must be untouched.
+    ASSERT_NEAR_(g->geo_coord.lat.decimal_value, kDatumLat, 1e-12);
+    ASSERT_NEAR_(g->geo_coord.lon.decimal_value, kDatumLon, 1e-12);
+    // T_enu_to_map was identity, so it must now be exactly `b`.
+    ASSERT_NEAR_(g->T_enu_to_map.mean.x(), b.x(), 1e-9);
+    ASSERT_NEAR_(g->T_enu_to_map.mean.y(), b.y(), 1e-9);
+    ASSERT_NEAR_(g->T_enu_to_map.mean.z(), b.z(), 1e-9);
+    ASSERT_NEAR_(g->T_enu_to_map.mean.yaw(), b.yaw(), 1e-9);
+
+    // A GNSS fix at the datum must therefore be placed at the origin of the
+    // NEW map frame, i.e. at `b`'s translation.
+    seed_anchor(est, mrpt::poses::CPose3D(20, 20, 20), 100.0);
+    est.fuse_gnss(make_gps(kDatumLat, kDatumLon, kDatumAlt, 0.05, 0.10, 0.1));
+
+    auto s = est.estimated_navstate(mrpt::Clock::fromDouble(0.05), "map");
+    ASSERT_(s.has_value());
+    ASSERT_NEAR_(s->pose.mean.x(), b.x(), 0.3);
+    ASSERT_NEAR_(s->pose.mean.y(), b.y(), 0.3);
+
+    std::cout << "OK\n";
+}
+#endif
+#endif
+
 }  // namespace
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
@@ -1192,6 +1285,12 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
         test_gnss_disabled_ignores();
         test_gnss_bad_covariance_rejected();
         test_gnss_significant_3d_lever_arm();
+#endif
+#if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_TRANSFORM_FRAME)
+        test_transform_frame_leaves_odometry_frame_alone();
+#if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)
+        test_transform_frame_updates_geo_reference();
+#endif
 #endif
 
         std::cout << "\nAll StateEstimationSimple tests passed!\n";


### PR DESCRIPTION
Implements `NavStateFilter::transform_frame()` (added in MOLAorg/mola#192),
re-expressing the stored map-frame poses under a new reference frame,
`p -> b + p`, so a one-off gauge change of the map frame does not have to
discard estimator state.

The twist is deliberately left alone. It is derived from consecutive poses and
extrapolated by right-composition, so it is a body-frame quantity and is
invariant under a change of the map frame. Rotating it would be a bug, not an
omission.

Depends on MOLAorg/mola#192. Consumed by mola_lidar_odometry's map-frame
leveling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for transforming estimated poses into a new reference frame.
  * Map-frame poses and fused estimates are updated consistently during the transformation.
  * Odometry-frame poses retain their original reference frame.
  * Existing geographic references are rebased while preserving datum coordinates.
  * Vehicle-frame velocities, covariances, and buffered sensor data remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->