### PR TITLE
StateEstimationSimple: apply params.initial_twist (MOLA_INITIAL_VX)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,10 +58,16 @@ Key traits:
   feeding this estimator from concurrent sensor threads stays reproducible.
 - `params.initial_twist` (`MOLA_INITIAL_VX` in the shipped YAML) seeds
   `state_.last_twist` on `initialize()`/`reset()`, for datasets that start
-  already in motion (e.g. highway-speed KITTI). The seed survives the very
-  first `fuse_pose()` call (which would otherwise reset the twist, having no
-  per-source pose history yet) but is discarded unconditionally as soon as any
-  real velocity measurement is fused (`state_.twist_is_unconsumed_seed`).
+  already in motion (e.g. highway-speed KITTI). `fuse_pose()`'s "distrust the
+  twist" reset only fires when the reporting source DID have a prior pose but
+  the new one is unusable (backwards or stale `dt`); a source's first-ever
+  pose leaves any twist already held untouched, so the seed (or any real
+  measurement fused via `fuse_odometry()`/`fuse_imu()`/`fuse_twist()` before
+  that first pose) survives instead of being wiped. `initial_twist_sigma_lin`/
+  `_ang` (`MOLA_INITIAL_TWIST_SIGMA_LIN`/`_ANG`) size the seed's covariance;
+  `Parameters::loadFrom()` rejects a non-finite or non-positive sigma when
+  `initial_twist` is non-zero, since that would otherwise build a singular
+  `last_twist_cov` that later throws out of `inverse_LLt()`.
 
 ### 2. `mola_state_estimation_smoother`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,12 @@ Key traits:
   of interest, fuses everything buffered. So the estimate for a given time is a
   function of the measurement timestamps, not of the delivery order: a pipeline
   feeding this estimator from concurrent sensor threads stays reproducible.
+- `params.initial_twist` (`MOLA_INITIAL_VX` in the shipped YAML) seeds
+  `state_.last_twist` on `initialize()`/`reset()`, for datasets that start
+  already in motion (e.g. highway-speed KITTI). The seed survives the very
+  first `fuse_pose()` call (which would otherwise reset the twist, having no
+  per-source pose history yet) but is discarded unconditionally as soon as any
+  real velocity measurement is fused (`state_.twist_is_unconsumed_seed`).
 
 ### 2. `mola_state_estimation_smoother`
 

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/Parameters.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/Parameters.h
@@ -43,7 +43,19 @@ class Parameters
      * last incorporated observation. */
     double max_time_to_use_velocity_model = 2.0;  // [s]
 
+    /** Optional initial guess for the twist, used only until the first real
+     *  velocity measurement is fused (a second fuse_pose(), or any
+     *  fuse_odometry()/fuse_imu()/fuse_twist() call), which overwrites it
+     *  unconditionally. Useful for datasets that start already in motion
+     *  (e.g. a highway-speed KITTI sequence), where waiting for two ICP
+     *  poses to derive velocity would give the first scan's ICP prior no
+     *  usable motion guess. */
     mrpt::math::TTwist3D initial_twist;
+
+    /// Uncertainty of initial_twist, expressed as a one-sigma value applied
+    /// to its linear (vx,vy,vz) and angular (wx,wy,wz) components.
+    double initial_twist_sigma_lin = 20.0;  // [m/s]
+    double initial_twist_sigma_ang = 3.0;  // [rad/s]
 
     double sigma_random_walk_acceleration_linear  = 1.0;  // [m/s²]
     double sigma_random_walk_acceleration_angular = 10.0;  // [rad/s²]

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/Parameters.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/Parameters.h
@@ -43,13 +43,15 @@ class Parameters
      * last incorporated observation. */
     double max_time_to_use_velocity_model = 2.0;  // [s]
 
-    /** Optional initial guess for the twist, used only until the first real
-     *  velocity measurement is fused (a second fuse_pose(), or any
-     *  fuse_odometry()/fuse_imu()/fuse_twist() call), which overwrites it
-     *  unconditionally. Useful for datasets that start already in motion
-     *  (e.g. a highway-speed KITTI sequence), where waiting for two ICP
-     *  poses to derive velocity would give the first scan's ICP prior no
-     *  usable motion guess. */
+    /** Optional initial guess for the twist. The seed stays in effect until it
+     *  is overwritten by an accepted velocity update: fuse_odometry(),
+     *  fuse_imu(), fuse_twist(), or a second fuse_pose() only consume it when
+     *  their data actually yields a valid, time-bearing velocity update
+     *  within the velocity-model window (see max_time_to_use_velocity_model);
+     *  otherwise the seed remains available. Useful for datasets that start
+     *  already in motion (e.g. a highway-speed KITTI sequence), where waiting
+     *  for two ICP poses to derive velocity would give the first scan's ICP
+     *  prior no usable motion guess. */
     mrpt::math::TTwist3D initial_twist;
 
     /// Uncertainty of initial_twist, expressed as a one-sigma value applied

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
@@ -174,13 +174,6 @@ class StateEstimationSimple : public mola::NavStateFilter
         std::optional<mrpt::math::CMatrixDouble66>     last_twist_cov;
         bool                                           pose_already_updated_with_odom = false;
 
-        // True while last_twist still holds params.initial_twist and has not
-        // yet been overwritten by a real velocity measurement. Protects the
-        // seed from fuse_pose()'s "no velocity data for this source yet"
-        // reset, which would otherwise fire on the very first fuse_pose()
-        // call (see fuse_pose()).
-        bool twist_is_unconsumed_seed = false;
-
         // Per-component variance for the velocity Kalman filter.
         // Indices 0-2: linear (vx,vy,vz), 3-5: angular (wx,wy,wz).
         std::array<double, 6> vel_filter_P = {1e4, 1e4, 1e4, 1e4, 1e4, 1e4};
@@ -245,9 +238,8 @@ class StateEstimationSimple : public mola::NavStateFilter
         const mrpt::obs::CObservationRobotPose& obs, const std::string& odomName);
 
     /** If params.initial_twist is non-zero, seeds state_.last_twist (and its
-     *  covariance) with it, marking it as an unconsumed seed. Called from
-     *  initialize() and reset(). Must be called with state_mtx_ already
-     *  held. */
+     *  covariance) with it. Called from initialize() and reset(). Must be
+     *  called with state_mtx_ already held. */
     void seedInitialTwistFromParams();
 
     /** Applies a scalar Kalman predict+update step to each velocity component.

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
@@ -174,6 +174,13 @@ class StateEstimationSimple : public mola::NavStateFilter
         std::optional<mrpt::math::CMatrixDouble66>     last_twist_cov;
         bool                                           pose_already_updated_with_odom = false;
 
+        // True while last_twist still holds params.initial_twist and has not
+        // yet been overwritten by a real velocity measurement. Protects the
+        // seed from fuse_pose()'s "no velocity data for this source yet"
+        // reset, which would otherwise fire on the very first fuse_pose()
+        // call (see fuse_pose()).
+        bool twist_is_unconsumed_seed = false;
+
         // Per-component variance for the velocity Kalman filter.
         // Indices 0-2: linear (vx,vy,vz), 3-5: angular (wx,wy,wz).
         std::array<double, 6> vel_filter_P = {1e4, 1e4, 1e4, 1e4, 1e4, 1e4};
@@ -236,6 +243,12 @@ class StateEstimationSimple : public mola::NavStateFilter
     // the LiDAR ICP timestamp used for dt validation and pose extrapolation.
     void fuse_odometry_3d_pose(
         const mrpt::obs::CObservationRobotPose& obs, const std::string& odomName);
+
+    /** If params.initial_twist is non-zero, seeds state_.last_twist (and its
+     *  covariance) with it, marking it as an unconsumed seed. Called from
+     *  initialize() and reset(). Must be called with state_mtx_ already
+     *  held. */
+    void seedInitialTwistFromParams();
 
     /** Applies a scalar Kalman predict+update step to each velocity component.
      *  When velocity_filter_enabled is false this is a plain write-through.

--- a/mola_state_estimation_simple/src/Parameters.cpp
+++ b/mola_state_estimation_simple/src/Parameters.cpp
@@ -21,6 +21,8 @@
 
 #include <mola_state_estimation_simple/Parameters.h>
 
+#include <cmath>
+
 namespace mola::state_estimation_simple
 {
 
@@ -64,6 +66,15 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
 
     MCP_LOAD_OPT(cfg, initial_twist_sigma_lin);
     MCP_LOAD_OPT(cfg, initial_twist_sigma_ang);
+
+    if (initial_twist != mrpt::math::TTwist3D())
+    {
+        // A zero, negative, or non-finite sigma would build a singular
+        // last_twist_cov, which later throws out of inverse_LLt() in
+        // estimated_navstate(). Catch it here, at config-load time, instead.
+        ASSERT_(std::isfinite(initial_twist_sigma_lin) && initial_twist_sigma_lin > 0);
+        ASSERT_(std::isfinite(initial_twist_sigma_ang) && initial_twist_sigma_ang > 0);
+    }
 }
 
 }  // namespace mola::state_estimation_simple

--- a/mola_state_estimation_simple/src/Parameters.cpp
+++ b/mola_state_estimation_simple/src/Parameters.cpp
@@ -61,6 +61,9 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
             tw[i] = seq.at(i).as<double>();
         }
     }
+
+    MCP_LOAD_OPT(cfg, initial_twist_sigma_lin);
+    MCP_LOAD_OPT(cfg, initial_twist_sigma_ang);
 }
 
 }  // namespace mola::state_estimation_simple

--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -121,8 +121,6 @@ void StateEstimationSimple::seedInitialTwistFromParams()
     }
 
     state_.vel_filter_P = {var_lin, var_lin, var_lin, var_ang, var_ang, var_ang};
-
-    state_.twist_is_unconsumed_seed = true;
 }
 
 namespace
@@ -203,8 +201,6 @@ void StateEstimationSimple::update_vel_filter(
 
     auto write_twist_and_cov = [&](const std::array<double, 6>& v, const std::array<double, 6>& P)
     {
-        state_.twist_is_unconsumed_seed = false;
-
         auto& tw = state_.last_twist.emplace();
         tw.vx    = v[0];
         tw.vy    = v[1];
@@ -786,12 +782,16 @@ void StateEstimationSimple::fuse_pose(
 
         update_vel_filter(z, R_diag, timestamp, "fuse_pose");
     }
-    else if (!state_.twist_is_unconsumed_seed)
+    else if (src.last_pose.has_value())
     {
-        // Don't wipe out params.initial_twist here: this branch also fires on
-        // the very first fuse_pose() call ever (src.last_pose has no prior
-        // value yet), which is exactly when that seed is needed the most, as
-        // no other source has provided a velocity yet either.
+        // dt <= 0 or dt >= max_time_to_use_velocity_model for a source that DID
+        // have a prior pose: a genuine reason to distrust whatever twist is
+        // currently held. When src.last_pose has no value at all (the very
+        // first fuse_pose() call ever for this source), there is simply
+        // nothing new to compute here, so any twist already held -- from
+        // params.initial_twist, or from a real fuse_twist()/fuse_odometry()/
+        // fuse_imu() measurement fused before this source's first pose -- is
+        // left untouched instead of being wiped out.
         MRPT_LOG_DEBUG_STREAM("fuse_pose(): resetting twist");
         state_.last_twist.reset();
         state_.last_twist_cov.reset();

--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -65,6 +65,8 @@ void StateEstimationSimple::initialize(const mrpt::containers::yaml& cfg)
     // Load params:
     params.loadFrom(cfg["params"]);
 
+    seedInitialTwistFromParams();
+
     // Initialize parent:
     mola::NavStateFilter::initialize(cfg);
 }
@@ -91,7 +93,36 @@ void StateEstimationSimple::reset()
 
     state_.pending_imu = std::move(pendingImu);
 
+    seedInitialTwistFromParams();
+
     MRPT_LOG_INFO_STREAM("reset() called");
+}
+
+void StateEstimationSimple::seedInitialTwistFromParams()
+{
+    if (params.initial_twist == mrpt::math::TTwist3D())
+    {
+        return;  // nothing configured, keep the legacy "unknown velocity" state
+    }
+
+    state_.last_twist = params.initial_twist;
+
+    auto&        cov     = state_.last_twist_cov.emplace();
+    const double var_lin = mrpt::square(params.initial_twist_sigma_lin);
+    const double var_ang = mrpt::square(params.initial_twist_sigma_ang);
+    cov.setZero();
+    for (int i = 0; i < 3; i++)
+    {
+        cov(i, i) = var_lin;
+    }
+    for (int i = 3; i < 6; i++)
+    {
+        cov(i, i) = var_ang;
+    }
+
+    state_.vel_filter_P = {var_lin, var_lin, var_lin, var_ang, var_ang, var_ang};
+
+    state_.twist_is_unconsumed_seed = true;
 }
 
 namespace
@@ -172,6 +203,8 @@ void StateEstimationSimple::update_vel_filter(
 
     auto write_twist_and_cov = [&](const std::array<double, 6>& v, const std::array<double, 6>& P)
     {
+        state_.twist_is_unconsumed_seed = false;
+
         auto& tw = state_.last_twist.emplace();
         tw.vx    = v[0];
         tw.vy    = v[1];
@@ -753,8 +786,12 @@ void StateEstimationSimple::fuse_pose(
 
         update_vel_filter(z, R_diag, timestamp, "fuse_pose");
     }
-    else
+    else if (!state_.twist_is_unconsumed_seed)
     {
+        // Don't wipe out params.initial_twist here: this branch also fires on
+        // the very first fuse_pose() call ever (src.last_pose has no prior
+        // value yet), which is exactly when that seed is needed the most, as
+        // no other source has provided a velocity yet either.
         MRPT_LOG_DEBUG_STREAM("fuse_pose(): resetting twist");
         state_.last_twist.reset();
         state_.last_twist_cov.reset();

--- a/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
+++ b/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
@@ -1250,6 +1250,143 @@ params:
     std::cout << "OK\n";
 }
 
+// --------------------------------------------------------------------------
+// Test: real measurements fused before the very first fuse_pose() must survive
+// --------------------------------------------------------------------------
+// fuse_pose()'s "this source has no pose history yet" branch fires on the
+// very first fuse_pose() call ever, regardless of whether a real velocity was
+// already established by another path. It must only discard the twist when
+// this source DID have a prior pose but the new one is unusable (backwards or
+// stale dt) -- never merely because this is the first pose ever seen.
+void test_real_measurement_survives_first_fuse_pose()
+{
+    std::cout << "[Test] Real measurement survives the first fuse_pose()... ";
+
+    // (a) fuse_twist() before any fuse_pose() at all.
+    {
+        mola::state_estimation_simple::StateEstimationSimple est;
+        est.initialize(get_default_config());
+
+        auto twistCov = mrpt::math::CMatrixDouble66::Identity();
+        twistCov *= 0.01;
+        est.fuse_twist(
+            mrpt::Clock::fromDouble(0.0), mrpt::math::TTwist3D(3.0, 0, 0, 0, 0, 0), twistCov);
+
+        auto tw = est.get_last_twist();
+        ASSERT_(tw.has_value());
+        ASSERT_NEAR_(tw->vx, 3.0, 1e-6);
+
+        // First-ever fuse_pose(): must not wipe out the fuse_twist() result.
+        est.fuse_pose(
+            mrpt::Clock::fromDouble(0.0),
+            mrpt::poses::CPose3DPDFGaussian(
+                mrpt::poses::CPose3D::Identity(), mrpt::math::CMatrixDouble66::Identity()),
+            "map");
+
+        tw = est.get_last_twist();
+        ASSERT_(tw.has_value());
+        ASSERT_NEAR_(tw->vx, 3.0, 1e-6);
+
+        auto s = est.estimated_navstate(mrpt::Clock::fromDouble(0.5), "map");
+        ASSERT_(s.has_value());
+        ASSERT_NEAR_(s->pose.mean.x(), 1.5, 1e-3);
+    }
+
+    // (b) fuse_imu() buffered before any fuse_pose(): the buffered reading is
+    // fused by fuse_pending_imu_up_to() at the TOP of this same, first-ever
+    // fuse_pose() call, so the reset branch below it must not immediately
+    // erase what was just fused.
+    {
+        mola::state_estimation_simple::StateEstimationSimple est;
+        est.initialize(get_default_config());
+
+        mrpt::obs::CObservationIMU imu;
+        imu.timestamp = mrpt::Clock::fromDouble(0.0);
+        imu.set(mrpt::obs::IMU_WX, 0.0);
+        imu.set(mrpt::obs::IMU_WY, 0.0);
+        imu.set(mrpt::obs::IMU_WZ, 2.0);
+        imu.sensorPose = mrpt::poses::CPose3D::Identity();
+        est.fuse_imu(imu);
+
+        // Note: fuse_imu() only buffers, it does not fuse the reading itself
+        // (that happens below, inside fuse_pose()); get_last_twist() is not
+        // queried here because it would fuse the buffered reading on its own,
+        // which is not the scenario under test.
+
+        est.fuse_pose(
+            mrpt::Clock::fromDouble(0.0),
+            mrpt::poses::CPose3DPDFGaussian(
+                mrpt::poses::CPose3D::Identity(), mrpt::math::CMatrixDouble66::Identity()),
+            "map");
+
+        auto tw = est.get_last_twist();
+        ASSERT_(tw.has_value());
+        ASSERT_NEAR_(tw->wz, 2.0, 1e-6);
+
+        auto s = est.estimated_navstate(mrpt::Clock::fromDouble(1.0), "map");
+        ASSERT_(s.has_value());
+        double y, p, r;
+        s->pose.mean.getYawPitchRoll(y, p, r);
+        ASSERT_NEAR_(y, 2.0, 1e-3);
+    }
+
+    std::cout << "OK\n";
+}
+
+// --------------------------------------------------------------------------
+// Test: invalid initial_twist_sigma_lin/ang are rejected
+// --------------------------------------------------------------------------
+// A zero, negative, or non-finite sigma would build a singular last_twist_cov
+// in seedInitialTwistFromParams(), which would later throw out of
+// inverse_LLt() in estimated_navstate(). Parameters::loadFrom() must reject
+// it up front instead, at config-load time.
+void test_initial_twist_invalid_sigma_rejected()
+{
+    std::cout << "[Test] Invalid initial_twist sigma rejected... ";
+
+    const auto expect_throw = [](const std::string& sigma_lin_yaml)
+    {
+        const std::string yaml_text =
+            "params:\n"
+            "    max_time_to_use_velocity_model: 2.0\n"
+            "    sigma_relative_pose_linear: 0.1\n"
+            "    sigma_relative_pose_angular: 0.1\n"
+            "    initial_twist: [5.0, 0.0, 0.0, 0.0, 0.0, 0.0]\n"
+            "    initial_twist_sigma_lin: " +
+            sigma_lin_yaml + "\n";
+
+        mola::state_estimation_simple::StateEstimationSimple est;
+        bool                                                 threw = false;
+        try
+        {
+            est.initialize(mrpt::containers::yaml::FromText(yaml_text));
+        }
+        catch (const std::exception&)
+        {
+            threw = true;
+        }
+        ASSERT_(threw);
+    };
+
+    expect_throw("0.0");  // zero -> singular covariance
+    expect_throw("-1.0");  // negative
+
+    // A config with a sane sigma must NOT throw (sanity check on the helper).
+    {
+        mola::state_estimation_simple::StateEstimationSimple est;
+        est.initialize(
+            mrpt::containers::yaml::FromText("params:\n"
+                                             "    max_time_to_use_velocity_model: 2.0\n"
+                                             "    sigma_relative_pose_linear: 0.1\n"
+                                             "    sigma_relative_pose_angular: 0.1\n"
+                                             "    initial_twist: [5.0, 0.0, 0.0, 0.0, 0.0, 0.0]\n"
+                                             "    initial_twist_sigma_lin: 20.0\n"));
+        ASSERT_(est.get_last_twist().has_value());
+    }
+
+    std::cout << "OK\n";
+}
+
 #if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_TRANSFORM_FRAME)
 // A change of the map frame must not disturb an odometry source, whose
 // observations keep arriving in their own, untouched, reference frame.
@@ -1361,6 +1498,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
         test_imu_arrival_order_independence();
         test_imu_survives_reset();
         test_initial_twist_seed();
+        test_real_measurement_survives_first_fuse_pose();
+        test_initial_twist_invalid_sigma_rejected();
 #if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)
         test_gnss_rtk_pulls_anchor();
         test_gnss_gated_out();

--- a/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
+++ b/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
@@ -1166,6 +1166,90 @@ void test_imu_survives_reset()
     std::cout << "OK\n";
 }
 
+// --------------------------------------------------------------------------
+// Test: initial_twist seed (MOLA_INITIAL_VX)
+// --------------------------------------------------------------------------
+// A dataset that starts already in motion (e.g. a highway-speed KITTI
+// sequence) configures params.initial_twist so the very first ICP prior
+// already assumes forward motion, instead of waiting for two ICP poses to
+// derive a velocity. Regression covered here: initial_twist used to be parsed
+// but never applied to state_.last_twist, and even when seeded, the very
+// first fuse_pose() call unconditionally reset the twist to "unknown" (it has
+// no per-source pose history yet), wiping the seed out before it could ever
+// be used to extrapolate.
+void test_initial_twist_seed()
+{
+    std::cout << "[Test] initial_twist seed (MOLA_INITIAL_VX)... ";
+
+    const char* yaml_text = R"###(
+params:
+    max_time_to_use_velocity_model: 2.0
+    sigma_random_walk_acceleration_linear: 1.0
+    sigma_random_walk_acceleration_angular: 1.0
+    sigma_relative_pose_linear: 0.1
+    sigma_relative_pose_angular: 0.1
+    sigma_imu_angular_velocity: 0.05
+    enforce_planar_motion: false
+    initial_twist: [5.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+)###";
+
+    mola::state_estimation_simple::StateEstimationSimple est;
+    est.initialize(mrpt::containers::yaml::FromText(yaml_text));
+
+    // (a) Right after initialize(), the seed must be visible with no
+    // observations fused at all.
+    {
+        auto tw = est.get_last_twist();
+        ASSERT_(tw.has_value());
+        ASSERT_NEAR_(tw->vx, 5.0, 1e-9);
+    }
+
+    // (b) The FIRST fuse_pose() call ever must not wipe out the seed: this
+    // source has no prior pose of its own yet, which is exactly the branch
+    // that used to unconditionally reset the twist.
+    est.fuse_pose(
+        mrpt::Clock::fromDouble(0.0),
+        mrpt::poses::CPose3DPDFGaussian(
+            mrpt::poses::CPose3D::Identity(), mrpt::math::CMatrixDouble66::Identity()),
+        "map");
+    {
+        auto tw = est.get_last_twist();
+        ASSERT_(tw.has_value());
+        ASSERT_NEAR_(tw->vx, 5.0, 1e-9);
+    }
+
+    // (c) estimated_navstate() extrapolates using the seeded twist from the
+    // single known pose: x = 0 + 5.0 * 0.5 = 2.5.
+    {
+        auto s = est.estimated_navstate(mrpt::Clock::fromDouble(0.5), "map");
+        ASSERT_(s.has_value());
+        ASSERT_NEAR_(s->pose.mean.x(), 2.5, 1e-3);
+    }
+
+    // (d) Once a real velocity measurement arrives (second ICP pose, true
+    // speed 2.0 m/s), it must overwrite the seed unconditionally.
+    est.fuse_pose(
+        mrpt::Clock::fromDouble(1.0),
+        mrpt::poses::CPose3DPDFGaussian(
+            mrpt::poses::CPose3D(2.0, 0, 0), mrpt::math::CMatrixDouble66::Identity()),
+        "map");
+    {
+        auto tw = est.get_last_twist();
+        ASSERT_(tw.has_value());
+        ASSERT_NEAR_(tw->vx, 2.0, 1e-3);
+    }
+
+    // (e) reset() must re-seed the initial twist (params are not cleared).
+    est.reset();
+    {
+        auto tw = est.get_last_twist();
+        ASSERT_(tw.has_value());
+        ASSERT_NEAR_(tw->vx, 5.0, 1e-9);
+    }
+
+    std::cout << "OK\n";
+}
+
 #if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_TRANSFORM_FRAME)
 // A change of the map frame must not disturb an odometry source, whose
 // observations keep arriving in their own, untouched, reference frame.
@@ -1276,6 +1360,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
         test_multirate_interleaved_velocity();
         test_imu_arrival_order_independence();
         test_imu_survives_reset();
+        test_initial_twist_seed();
 #if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)
         test_gnss_rtk_pulls_anchor();
         test_gnss_gated_out();


### PR DESCRIPTION
## Summary
- `Parameters::initial_twist` (set via `MOLA_INITIAL_VX` in the shipped YAML) was parsed but never consulted by `StateEstimationSimple`, so a configured initial velocity was silently ignored and every run started with no velocity prior at all.
- Seed `state_.last_twist`/`last_twist_cov` from `params.initial_twist` on `initialize()`/`reset()`.
- Protect the seed from `fuse_pose()`'s "no pose history for this source yet" reset branch, which otherwise fires unconditionally on the very first `fuse_pose()` call ever, wiping the seed before it can be used.
- The seed is discarded unconditionally as soon as any real velocity measurement is fused (odometry, IMU, twist, or a second ICP pose).
- Adds `initial_twist_sigma_lin`/`initial_twist_sigma_ang` parameters (defaults 20.0 m/s / 3.0 rad/s, matching `mola_state_estimation_smoother`'s equivalent knobs) to control the seed's uncertainty.

## Test plan
- [x] Added `test_initial_twist_seed()` covering: seed visible right after `initialize()`, seed survives the first `fuse_pose()`, `estimated_navstate()` extrapolates using the seed, a real measurement overwrites it, and `reset()` re-seeds it.
- [x] `clang-format-14` applied to all touched files.
- [ ] Not rebuilt/retested locally in this session (per explicit request); CI should validate the full `mola_state_estimation_simple` test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable uncertainty values for the optional initial velocity estimate.
  * Configured initial motion is now available immediately after startup and reset.
  * The initial estimate remains active through the first pose update and supports motion extrapolation.
  * It is replaced automatically once a measured velocity is received.

* **Bug Fixes**
  * Prevented the first pose update from incorrectly clearing the configured initial motion estimate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->