### PR TITLE
StateEstimationSimple: don't let the twist seed get clobbered on first fuse

### DIFF
--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/StateEstimationSimple.h
@@ -178,6 +178,14 @@ class StateEstimationSimple : public mola::NavStateFilter
         // Indices 0-2: linear (vx,vy,vz), 3-5: angular (wx,wy,wz).
         std::array<double, 6> vel_filter_P = {1e4, 1e4, 1e4, 1e4, 1e4, 1e4};
 
+        // Whether each component's vel_filter_P above came from
+        // seedInitialTwistFromParams() rather than the uninformative default.
+        // Needed to tell apart, on a component's first-ever observation,
+        // whether it must blend with a real seed or bootstrap outright: once
+        // ANY component has been observed, state_.last_twist itself is no
+        // longer a reliable "was this seeded" signal for the OTHER components.
+        std::array<bool, 6> vel_filter_seeded = {false, false, false, false, false, false};
+
         // Per-component last-update time. Each velocity component keeps its own
         // clock so sources with very different rates and timestamp conventions
         // do not starve each other: a source only advances the clock of the

--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -285,12 +285,29 @@ void StateEstimationSimple::update_vel_filter(
             continue;
         }
 
-        // Bootstrap this component on its first observation (or after a twist
-        // reset cleared the per-component clocks).
-        if (!state_.vel_filter_last_tim[i].has_value() || !state_.last_twist.has_value())
+        // True bootstrap: nothing seeded and nothing observed yet for this
+        // component, so there is nothing to blend with.
+        if (!state_.last_twist.has_value())
         {
             v[i]                          = z[i];
             state_.vel_filter_P[i]        = R_diag[i];
+            state_.vel_filter_last_tim[i] = tim;
+            continue;
+        }
+
+        // Seeded (params.initial_twist) but never observed: blend this first
+        // real measurement with the seed via its own covariance instead of
+        // overwriting it outright. No process-noise growth is applied since
+        // the seed carries no observation time to measure its age from.
+        if (!state_.vel_filter_last_tim[i].has_value())
+        {
+            const double denom = state_.vel_filter_P[i] + R_diag[i];
+            if (denom > kEps)
+            {
+                const double K = state_.vel_filter_P[i] / denom;
+                v[i] += K * (z[i] - v[i]);
+                state_.vel_filter_P[i] *= (1.0 - K);
+            }
             state_.vel_filter_last_tim[i] = tim;
             continue;
         }

--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -120,7 +120,8 @@ void StateEstimationSimple::seedInitialTwistFromParams()
         cov(i, i) = var_ang;
     }
 
-    state_.vel_filter_P = {var_lin, var_lin, var_lin, var_ang, var_ang, var_ang};
+    state_.vel_filter_P      = {var_lin, var_lin, var_lin, var_ang, var_ang, var_ang};
+    state_.vel_filter_seeded = {true, true, true, true, true, true};
 }
 
 namespace
@@ -285,9 +286,13 @@ void StateEstimationSimple::update_vel_filter(
             continue;
         }
 
-        // True bootstrap: nothing seeded and nothing observed yet for this
-        // component, so there is nothing to blend with.
-        if (!state_.last_twist.has_value())
+        // True bootstrap: this component was neither seeded by
+        // params.initial_twist nor observed yet, so there is nothing to
+        // blend with. Checked per-component (not via state_.last_twist,
+        // which becomes non-empty as soon as ANY component is observed and
+        // would otherwise make sibling, still-unseeded components blend with
+        // an uninformative default instead of bootstrapping outright).
+        if (!state_.vel_filter_seeded[i] && !state_.vel_filter_last_tim[i].has_value())
         {
             v[i]                          = z[i];
             state_.vel_filter_P[i]        = R_diag[i];
@@ -299,7 +304,7 @@ void StateEstimationSimple::update_vel_filter(
         // real measurement with the seed via its own covariance instead of
         // overwriting it outright. No process-noise growth is applied since
         // the seed carries no observation time to measure its age from.
-        if (!state_.vel_filter_last_tim[i].has_value())
+        if (state_.vel_filter_seeded[i] && !state_.vel_filter_last_tim[i].has_value())
         {
             const double denom = state_.vel_filter_P[i] + R_diag[i];
             if (denom > kEps)
@@ -812,7 +817,8 @@ void StateEstimationSimple::fuse_pose(
         MRPT_LOG_DEBUG_STREAM("fuse_pose(): resetting twist");
         state_.last_twist.reset();
         state_.last_twist_cov.reset();
-        state_.vel_filter_P = State().vel_filter_P;
+        state_.vel_filter_P      = State().vel_filter_P;
+        state_.vel_filter_seeded = State().vel_filter_seeded;
         for (auto& t : state_.vel_filter_last_tim)
         {
             t.reset();

--- a/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
+++ b/mola_state_estimation_simple/tests/test-state-estimation-simple.cpp
@@ -1308,16 +1308,22 @@ params:
     }
 
     // (d) Once a real velocity measurement arrives (second ICP pose, true
-    // speed 2.0 m/s), it must overwrite the seed unconditionally.
+    // speed 2.0 m/s), it is blended with the seed via their respective
+    // covariances rather than overwritten outright. With the default seed
+    // sigma (20 m/s, i.e. var=400) versus the measurement's var=0.01, the
+    // seed carries almost no weight, so the blended result lands extremely
+    // close to the raw measurement: K = 400/(400+0.01), vx = 5.0 + K*(2.0-5.0).
     est.fuse_pose(
         mrpt::Clock::fromDouble(1.0),
         mrpt::poses::CPose3DPDFGaussian(
             mrpt::poses::CPose3D(2.0, 0, 0), mrpt::math::CMatrixDouble66::Identity()),
         "map");
     {
-        auto tw = est.get_last_twist();
+        const double K        = 400.0 / (400.0 + 0.01);
+        const double expected = 5.0 + K * (2.0 - 5.0);
+        auto         tw       = est.get_last_twist();
         ASSERT_(tw.has_value());
-        ASSERT_NEAR_(tw->vx, 2.0, 1e-3);
+        ASSERT_NEAR_(tw->vx, expected, 1e-6);
     }
 
     // (e) reset() must re-seed the initial twist (params are not cleared).
@@ -1327,6 +1333,58 @@ params:
         ASSERT_(tw.has_value());
         ASSERT_NEAR_(tw->vx, 5.0, 1e-9);
     }
+
+    std::cout << "OK\n";
+}
+
+// --------------------------------------------------------------------------
+// Test: an unseeded component's first observation bootstraps, even after a
+// sibling component has already been observed
+// --------------------------------------------------------------------------
+// Regression: update_vel_filter() used to decide "true bootstrap vs. blend
+// with seed" from state_.last_twist.has_value(), which becomes true as soon
+// as ANY component is observed. A component that was never configured via
+// params.initial_twist and never observed would then wrongly take the
+// "blend" path using the uninformative default P (1e4) as if it had been
+// seeded, instead of bootstrapping outright from its own measurement.
+void test_partial_observation_bootstraps_independently()
+{
+    std::cout << "[Test] Partial observation bootstraps each component independently... ";
+
+    mola::state_estimation_simple::StateEstimationSimple est;
+    est.initialize(get_default_config());  // no initial_twist configured
+
+    // Only vx observed: bootstraps vx, and makes state_.last_twist non-empty.
+    {
+        mrpt::math::CMatrixDouble66 cov;
+        cov.setZero();
+        for (int i = 0; i < 6; i++)
+        {
+            cov(i, i) = 1e8;
+        }
+        cov(0, 0) = 0.01;
+        est.fuse_twist(mrpt::Clock::fromDouble(0.0), mrpt::math::TTwist3D(5.0, 0, 0, 0, 0, 0), cov);
+    }
+
+    // Only wz observed for the first time, with a comparatively large (i.e.
+    // imprecise) measurement noise. A correct bootstrap takes the measurement
+    // outright (K=1); the buggy blend-with-default-P path would instead
+    // average it down towards the previous (zero) value.
+    {
+        mrpt::math::CMatrixDouble66 cov;
+        cov.setZero();
+        for (int i = 0; i < 6; i++)
+        {
+            cov(i, i) = 1e8;
+        }
+        cov(5, 5) = 5000.0;
+        est.fuse_twist(mrpt::Clock::fromDouble(1.0), mrpt::math::TTwist3D(0, 0, 0, 0, 0, 3.0), cov);
+    }
+
+    auto tw = est.get_last_twist();
+    ASSERT_(tw.has_value());
+    ASSERT_NEAR_(tw->vx, 5.0, 1e-6);
+    ASSERT_NEAR_(tw->wz, 3.0, 1e-6);
 
     std::cout << "OK\n";
 }
@@ -1580,6 +1638,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
         test_imu_arrival_order_independence();
         test_imu_survives_reset();
         test_initial_twist_seed();
+        test_partial_observation_bootstraps_independently();
         test_real_measurement_survives_first_fuse_pose();
         test_initial_twist_invalid_sigma_rejected();
 #if defined(MOLA_KERNEL_NAVSTATE_FILTER_HAS_GEO_REFERENCE)


### PR DESCRIPTION
update_vel_filter() bootstrapped on any component whose vel_filter_last_tim was unset, which is also true right after seedInitialTwistFromParams() seeds params.initial_twist (that path never touches vel_filter_last_tim). So the very first velocity measurement fused after startup/reset -- e.g. LidarOdometry's fake-evolution reset step, which fuses a near-zero-dt, zero-motion pose pair -- overwrote the seed outright instead of blending with it, silently discarding MOLA_INITIAL_VX.

Split the bootstrap check: a true first-ever observation still overwrites, but a seeded-and-unobserved component now blends the first real measurement with the seed's own covariance, keyed off that measurement's own timestamp rather than wall-clock time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved velocity estimation startup when an initial twist is provided.
  * Blends the first measured velocity with the configured initial value for a smoother transition.
  * Preserves direct initialization behavior for components without a configured starting value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->