### PR TITLE
Smoother: MOLA_NAVSTATE_DUMP instrumentation and tunable integrator sigmas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,6 +326,19 @@ deployed setting; only the true offline CLIs (`mola-lidar-odometry-cli`,
 | predict-twist low-pass | `predict_twist_filter_enabled` / `MOLA_NAVSTATE_PREDICT_TWIST_FILTER` (+ `predict_twist_filter_time_const` / `MOLA_NAVSTATE_PREDICT_TWIST_TAU`, 0.3 s) | **true** | EMA-smooths the extrapolation velocity so the front end's ICP prior stays smooth. Deterministic; C++ default also true. |
 | accel random-walk sigmas | `sigma_random_walk_acceleration_linear` / `MOLA_NAVSTATE_SIGMA_RANDOM_WALK_LINACC`, `..._angular` / `MOLA_NAVSTATE_SIGMA_RANDOM_WALK_ANGACC` | **0.5** / **10.0** | Angular is loose on purpose: a tight value lets the constant-velocity factor override the per-keyframe gyro prior and average genuine fast rotations away (measured in-window: at 1.0 the optimized `W` kept only ~70% of the true rate at fast turns; at 10.0, ~98%). The boundary-node yaw variability this allows is damped by the predict-twist low-pass. |
 | gyro observations | `imu_angular_velocity_sigma` / `MOLA_IMU_ANGULAR_VELOCITY_SIGMA` | **0.10** | Direct (Huber-robust) prior on each keyframe's `W`, so a fast rotation reaches the graph immediately instead of only through the constant-velocity factor. 0 disables. Deliberately loose, see below. |
+| kinematic integrator sigmas | `sigma_integrator_position` / `MOLA_NAVSTATE_SIGMA_INTEGRATOR_POS`, `sigma_integrator_orientation` / `MOLA_NAVSTATE_SIGMA_INTEGRATOR_ANG` | **0.1** m / **1.0** rad | Noise of the trapezoidal position and angular-velocity integration factors tying two consecutive keyframe poses through the twist. **Not scaled by `dt`**, so their effective stiffness depends on the keyframe rate. The shipped orientation value is 10x looser than the C++ `Parameters` default (0.1 rad): at 1.0 rad (57 deg) that factor is close to free and attitude rests on the pose and IMU factors alone. |
+
+**Diagnosing the prior the front end actually receives.** Both estimators write
+the same CSV when `MOLA_NAVSTATE_DUMP=<path>` is set: one row per
+`estimated_navstate()` result, with the returned pose, twist, covariance and
+information matrix, plus `dt` (the extrapolation interval from the anchor). That
+is the object `mola_lidar_odometry` uses as the ICP initial guess *and*, when
+`cov_inv` is non-zero, as a prior factor inside the ICP solve -- so it is what to
+compare when `simple` and `smoother` disagree on a sequence. A **missing row**
+is as informative as a present one: it marks a query that returned nothing, i.e.
+a scan the front end registered with no motion model at all. In `async_backend`
+mode the `dt` column is the backend's solve lag and is a function of host load,
+not of the data.
 
 **Gyro priors vs. the constant-angular-velocity factor.** These two fight each
 other, and getting it wrong blows up the whole window. That factor's sigma is

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -151,11 +151,17 @@ params:
   predict_twist_filter_enabled: ${MOLA_NAVSTATE_PREDICT_TWIST_FILTER|true}
   predict_twist_filter_time_const: ${MOLA_NAVSTATE_PREDICT_TWIST_TAU|0.3}
 
+  # Uncertainty of the kinematic (numerical integration) factors that tie two
+  # consecutive keyframe poses through the twist. NOT scaled by dt: these are
+  # per-link sigmas, so their effective stiffness depends on the keyframe rate.
   # Integrator uncertainty for position [m]
-  sigma_integrator_position: 0.1
+  sigma_integrator_position: ${MOLA_NAVSTATE_SIGMA_INTEGRATOR_POS|0.1}
 
-  # Integrator uncertainty for orientation [rad]
-  sigma_integrator_orientation: 1.0
+  # Integrator uncertainty for orientation [rad]. Note this ships 10x looser
+  # than the class default (0.1 rad): at 1.0 rad (57 deg) the orientation
+  # integration factor is close to free, leaving attitude constrained only by
+  # the pose and IMU factors.
+  sigma_integrator_orientation: ${MOLA_NAVSTATE_SIGMA_INTEGRATOR_ANG|1.0}
 
   # Uncertainty for linear velocity estimated from consecutive poses [m/s]
   sigma_twist_from_consecutive_poses_linear: 1.0

--- a/mola_state_estimation_smoother/src/FastPredictor.cpp
+++ b/mola_state_estimation_smoother/src/FastPredictor.cpp
@@ -77,8 +77,8 @@ void FastPredictor::clear()
 }
 
 std::optional<NavState> FastPredictor::predict(
-    const mrpt::Clock::time_point& t_query, const std::string& frame_id,
-    const Parameters& params) const
+    const mrpt::Clock::time_point& t_query, const std::string& frame_id, const Parameters& params,
+    mrpt::Clock::time_point* anchorStampOut) const
 {
     std::shared_ptr<const Snapshot> snap;
     {
@@ -88,6 +88,10 @@ std::optional<NavState> FastPredictor::predict(
     if (!snap || !snap->valid)
     {
         return std::nullopt;
+    }
+    if (anchorStampOut)
+    {
+        *anchorStampOut = snap->anchorStamp;
     }
 
     // dt from the anchor (newest solved keyframe) to the requested time.

--- a/mola_state_estimation_smoother/src/FastPredictor.h
+++ b/mola_state_estimation_smoother/src/FastPredictor.h
@@ -70,9 +70,13 @@ class FastPredictor
     /// Extrapolates the snapshot anchor to `t_query` in `frame_id`. nullopt if
     /// there is no valid snapshot, the frame is unknown, or `t_query` is beyond
     /// `max_time_to_use_velocity_model`.
+    /** \param anchorStampOut If not null, receives the stamp of the snapshot
+     *  anchor this very prediction was extrapolated from. Reading it from a
+     *  second snapshot() call instead would race the backend thread, which may
+     *  publish a newer snapshot in between. */
     [[nodiscard]] std::optional<NavState> predict(
         const mrpt::Clock::time_point& t_query, const std::string& frame_id,
-        const Parameters& params) const;
+        const Parameters& params, mrpt::Clock::time_point* anchorStampOut = nullptr) const;
 
     /// Drops the snapshot and the observation-stamp tracking (used on reset()).
     void clear();

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -70,6 +70,7 @@
 #include <chrono>
 #include <fstream>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 
@@ -158,6 +159,11 @@ void navstate_dump_row(
     {
         return;
     }
+
+    // estimated_navstate() is callable concurrently and, in async mode, holds no
+    // lock of its own, so two queries could otherwise interleave halves of a row.
+    static std::mutex           s_dumpMutex;
+    std::lock_guard<std::mutex> lck(s_dumpMutex);
 
     const auto& m = ns.pose.mean;
     (*st) << mrpt::format("%.6f", mrpt::Clock::toDouble(timestamp)) << "," << dt << ","  //
@@ -1177,18 +1183,16 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
     // a solve or taking stateMutex_ (the backend thread may be holding it).
     if (params_.async_backend)
     {
-        auto ret = fastPredictor_->predict(timestamp, frame_id, params_);
+        mrpt::Clock::time_point anchorStamp;
+        auto ret = fastPredictor_->predict(timestamp, frame_id, params_, &anchorStamp);
         if (ret.has_value())
         {
             // Extrapolation interval, i.e. how far behind the query the backend's
             // last completed solve sits. In this path it is a function of host
-            // load, not of the data.
-            double dtAnchor = 0;
-            if (const auto snap = fastPredictor_->snapshot(); snap && snap->valid)
-            {
-                dtAnchor = mrpt::system::timeDifference(snap->anchorStamp, timestamp);
-            }
-            navstate_dump_row(timestamp, dtAnchor, *ret);
+            // load, not of the data. Taken from the very snapshot this prediction
+            // used, not from a second snapshot() call that could race the backend.
+            navstate_dump_row(
+                timestamp, mrpt::system::timeDifference(anchorStamp, timestamp), *ret);
         }
         return ret;
     }
@@ -1343,6 +1347,7 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
                 params_, anchorPose, ret.twist, anchorTwistCov, closestFrameDtSigned);
             // Transform the {map}-frame prediction into {odom_i}: pred (-) T_frame_wrt_map.
             ret.pose.copyFrom(mapPred - itFrame->second);
+            navstate_dump_row(timestamp, closestFrameDtSigned, ret);
             return ret;
         }
 
@@ -1360,6 +1365,7 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
         // the absolute {map}-frame keyframe covariance.
         ret.pose.copyFrom(
             extrapolate_pose_pdf(params_, rawAnchor.pose, ret.twist, anchorTwistCov, dtPred));
+        navstate_dump_row(timestamp, dtPred, ret);
 
         return ret;
     }

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -68,6 +68,9 @@
 // std:
 #include <algorithm>
 #include <chrono>
+#include <fstream>
+#include <memory>
+#include <string>
 #include <utility>
 
 // arguments: class_name, parent_class, class namespace
@@ -112,6 +115,70 @@ void enforce_planar_twist(mrpt::math::TTwist3D& tw)
 double key_stamp_seconds(const mrpt::Clock::time_point& t)
 {
     return std::chrono::duration<double>(t.time_since_epoch()).count();
+}
+
+// Debug instrumentation: dumps every estimated_navstate() result (the pose +
+// covariance that LIO uses as ICP initial guess AND prior, plus the returned
+// twist) so the prior-vs-data weighting and the velocity feedback can be
+// analyzed offline. Same file format and same env var as the lightweight
+// estimator's, so one script reads both. Disabled unless MOLA_NAVSTATE_DUMP is
+// set to a path.
+std::ofstream* navstate_dump_stream()
+{
+    static std::unique_ptr<std::ofstream> s_stream = []() -> std::unique_ptr<std::ofstream>
+    {
+        const std::string path = mrpt::get_env<std::string>("MOLA_NAVSTATE_DUMP");
+        if (path.empty())
+        {
+            return nullptr;
+        }
+        auto st = std::make_unique<std::ofstream>(path, std::ios::out | std::ios::trunc);
+        if (!st->is_open())
+        {
+            return nullptr;
+        }
+        (*st) << "tim,dt,"
+                 "x,y,z,yaw,pitch,roll,"
+                 "tw_vx,tw_vy,tw_vz,tw_wx,tw_wy,tw_wz,"
+                 "cov_x,cov_y,cov_z,cov_yaw,cov_pitch,cov_roll,"
+                 "covinv_x,covinv_y,covinv_z,covinv_yaw,covinv_pitch,covinv_roll\n";
+        return st;
+    }();
+    return s_stream.get();
+}
+
+// One row of the CSV above. `dt` is the extrapolation interval from the anchor
+// keyframe; a row is written only when a state was actually produced, so a gap
+// in the file marks a scan the front end ran with no motion model at all.
+void navstate_dump_row(
+    const mrpt::Clock::time_point& timestamp, double dt, const mola::NavState& ns)
+{
+    std::ofstream* st = navstate_dump_stream();
+    if (!st)
+    {
+        return;
+    }
+
+    const auto& m = ns.pose.mean;
+    (*st) << mrpt::format("%.6f", mrpt::Clock::toDouble(timestamp)) << "," << dt << ","  //
+          << m.x() << "," << m.y() << "," << m.z() << "," << m.yaw() << "," << m.pitch() << ","
+          << m.roll();
+
+    const auto& tw = ns.twist;
+    (*st) << "," << tw.vx << "," << tw.vy << "," << tw.vz << "," << tw.wx << "," << tw.wy << ","
+          << tw.wz;
+
+    const mrpt::math::CMatrixDouble66 cov = ns.pose.cov_inv.inverse_LLt();
+    for (int i = 0; i < 6; i++)
+    {
+        (*st) << "," << cov(i, i);
+    }
+    for (int i = 0; i < 6; i++)
+    {
+        (*st) << "," << ns.pose.cov_inv(i, i);
+    }
+    (*st) << "\n";
+    st->flush();
 }
 
 }  // namespace
@@ -1110,7 +1177,20 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
     // a solve or taking stateMutex_ (the backend thread may be holding it).
     if (params_.async_backend)
     {
-        return fastPredictor_->predict(timestamp, frame_id, params_);
+        auto ret = fastPredictor_->predict(timestamp, frame_id, params_);
+        if (ret.has_value())
+        {
+            // Extrapolation interval, i.e. how far behind the query the backend's
+            // last completed solve sits. In this path it is a function of host
+            // load, not of the data.
+            double dtAnchor = 0;
+            if (const auto snap = fastPredictor_->snapshot(); snap && snap->valid)
+            {
+                dtAnchor = mrpt::system::timeDifference(snap->anchorStamp, timestamp);
+            }
+            navstate_dump_row(timestamp, dtAnchor, *ret);
+        }
+        return ret;
     }
 
     auto lck = mrpt::lockHelper(stateMutex_);
@@ -1224,6 +1304,7 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
             anchorPose.copyFrom(retKf.pose);
             ret.pose.copyFrom(extrapolate_pose_pdf(
                 params_, anchorPose, ret.twist, anchorTwistCov, closestFrameDtSigned));
+            navstate_dump_row(timestamp, closestFrameDtSigned, ret);
             return ret;
         }
 


### PR DESCRIPTION
Diagnostic + tuning enablement for the smoother, opened while attributing why
`cfg-02`/`cfg-04` (the smoother evaluation configs) diverge on whole dataset
families where `simple` does not.

**1. `MOLA_NAVSTATE_DUMP` for the smoother.**
`StateEstimationSimple` has written a per-query CSV since the velocity-filter
work. The smoother had none, so the one object that decides how a run behaves --
the pose, twist and information matrix returned by `estimated_navstate()`, which
`mola_lidar_odometry` uses as the ICP initial guess *and*, when `cov_inv` is
non-zero, as a prior factor inside the ICP solve -- could not be compared
between the two estimators on the same sequence.

Same env var, same columns, so one script reads either. Both serving paths are
covered. Two details worth knowing when reading the file:

- in `async_backend` mode the `dt` column is the **backend's solve lag**, i.e. how
  far behind the query the last completed iSAM2 solve sits. That is a function of
  host load, not of the data.
- a **missing row** is as informative as a present one: it marks a query that
  returned nothing, so the front end registered that scan with no motion model.

**2. `sigma_integrator_position` / `sigma_integrator_orientation` as env vars.**
They were the only two factor sigmas in the shipped YAML with no `${...}`
override, so they could not be swept. Noted in passing, not changed here: the
shipped orientation value is `1.0` rad against the `Parameters` default of
`0.10`, and neither sigma is scaled by `dt`, so their effective stiffness
depends on the keyframe rate.

No behavior change: the dump is a no-op unless the env var is set, and both
defaults are unchanged. `colcon test`: 34/34 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-variable overrides for integrator position and orientation uncertainty settings.
  * Added optional CSV diagnostics for inspecting navigation-state estimates, including timing, pose, motion, and covariance data.

* **Documentation**
  * Documented uncertainty defaults, scaling behavior, orientation settings, and navigation-state diagnostic output.
  * Added guidance for interpreting missing estimates and asynchronous timing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->