### PR TITLE
Smoother: optional relative BetweenFactors for wheel odometry

### DIFF
--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
@@ -219,6 +219,16 @@ class Parameters
      * A relative factor is skipped, rather than forced, when the previous
      * odometry keyframe has already been marginalized out: a factor on a
      * variable the smoother no longer holds would resurrect it as a free state.
+     *
+     * Off by default on a measured trade, not out of caution. It is the better
+     * of the two ways to fuse on real data (BotanicGarden, better APE on 5 of 7
+     * sequences than the absolute-only formulation), but it costs
+     * geo-referencing: the ENU->map rotation error in
+     * test-navstate-odom-gnss-fusion grows past that test's 5 deg gate, where
+     * the absolute-only formulation stays inside it. Asserting the dead-reckoned
+     * pose absolutely, however weakly, is apparently what makes that yaw well
+     * observed. Enable this if you fuse wheel odometry and do not estimate
+     * geo-referencing.
      */
     bool odometry_relative_factors = false;
 

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
@@ -204,17 +204,21 @@ class Parameters
      * states exactly that, with exactly the covariance the motion model
      * computes for it, and nothing accumulates.
      *
-     * The two are not independent (the absolute factor is roughly the marginal
-     * of this chain from the first reading), so enabling this does mildly
-     * double-count the accumulated component. The absolute factor is kept
-     * regardless because it is what observes `T_map_to_odom_i`, the variable
-     * `publish_map_to_odom_tf` reports; with the accumulation above it is the
-     * weakest possible statement of the motion, so what this adds is
-     * essentially the missing short-baseline precision.
+     * When enabled, exactly ONE absolute pose-in-{odom_i} factor is ever added,
+     * on the first kept reading, because one is all it takes: `T_map_to_odom_i`
+     * is a single rigid variable, so given that anchor plus the relative chain,
+     * every later "keyframe k is at odom pose p_k" is already implied. Extra
+     * absolute factors do not observe the frame any better; they re-inject the
+     * accumulated dead-reckoning error into the map poses.
+     *
+     * It also needs no renewal when its keyframe ages out: keyframes leave
+     * through the fixed-lag smoother's marginalization, which folds their
+     * factors into a linear marginal on the surviving variables, so the anchor
+     * keeps constraining `T_map_to_odom_i` after its own keyframe is gone.
      *
      * A relative factor is skipped, rather than forced, when the previous
-     * odometry keyframe has already been marginalized out of the sliding
-     * window: the chain simply re-anchors at the next reading.
+     * odometry keyframe has already been marginalized out: a factor on a
+     * variable the smoother no longer holds would resurrect it as a free state.
      */
     bool odometry_relative_factors = false;
 

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
@@ -191,6 +191,33 @@ class Parameters
     double odom_motion_model_min_std_phi_deg = 0.1;  // [deg] -- see effective-floor note above
     /** @} */
 
+    /** Fuse each wheel-odometry increment as a RELATIVE constraint between the
+     * two keyframes it spans, `BetweenFactor(T(kf_prev), T(kf_now), increment,
+     * incrementCov)`, in addition to the absolute pose-in-{odom_i} factor that
+     * is always added.
+     *
+     * Why it exists: the absolute factor asserts a dead-reckoned pose, so the
+     * covariance that must go with it is the whole accumulated dead-reckoning
+     * uncertainty -- which is honest, but by the time it is honest it is also
+     * nearly uninformative, and it throws away the one thing wheel odometry is
+     * genuinely good at: short-baseline relative motion. The relative factor
+     * states exactly that, with exactly the covariance the motion model
+     * computes for it, and nothing accumulates.
+     *
+     * The two are not independent (the absolute factor is roughly the marginal
+     * of this chain from the first reading), so enabling this does mildly
+     * double-count the accumulated component. The absolute factor is kept
+     * regardless because it is what observes `T_map_to_odom_i`, the variable
+     * `publish_map_to_odom_tf` reports; with the accumulation above it is the
+     * weakest possible statement of the motion, so what this adds is
+     * essentially the missing short-baseline precision.
+     *
+     * A relative factor is skipped, rather than forced, when the previous
+     * odometry keyframe has already been marginalized out of the sliding
+     * window: the chain simply re-anchors at the next reading.
+     */
+    bool odometry_relative_factors = false;
+
     /** High-rate same-sensor decimation for IMU. If > 0, IMU readings arriving
      * less than this many seconds after the last *processed* one are skipped.
      * Unlike wheel odometry, IMU attitude/gravity are absolute observations, so

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -358,6 +358,13 @@ class StateEstimationSmoother : public mola::NavStateFilter,
         /// `odometry_relative_factors` is enabled. Reset with the estimator.
         std::optional<frame_index_t> last_wheels_odometry_kf;
 
+        /// Keyframe carrying the single absolute pose-in-{odom_i} factor that
+        /// resolves T_map_to_odom_i under `odometry_relative_factors`. Set once
+        /// and never renewed: the fixed-lag smoother marginalizes keyframes
+        /// rather than dropping their factors, so that information survives its
+        /// own keyframe. See fuse_odometry_relative_locked().
+        std::optional<frame_index_t> wheels_odometry_anchor_kf;
+
         /// Stamp of the last IMU reading that was actually processed. Used by
         /// imu_min_sample_period to skip higher-rate readings.
         std::optional<mrpt::Clock::time_point> last_processed_imu_stamp;
@@ -439,10 +446,13 @@ class StateEstimationSmoother : public mola::NavStateFilter,
         const mrpt::Clock::time_point& timestamp, const mrpt::poses::CPose3DPDFGaussian& pose,
         const std::string& frame_id);
 
-    /// Adds the BetweenFactor tying this odometry reading's keyframe to the
-    /// previous one. See Parameters::odometry_relative_factors.
-    void add_odometry_relative_factor(
-        const mrpt::Clock::time_point& timestamp, const mrpt::poses::CPose3DPDFGaussian& increment);
+    /// Relative formulation of wheel-odometry fusion: BetweenFactors between
+    /// consecutive odometry keyframes, plus one absolute factor, added once, to
+    /// resolve T_map_to_odom_i. See Parameters::odometry_relative_factors.
+    void fuse_odometry_relative_locked(
+        const mrpt::obs::CObservationOdometry& odom, const std::string& odomName,
+        const mrpt::poses::CPose3DPDFGaussian& increment,
+        const mrpt::poses::CPose3DPDFGaussian& absolutePoseInOdom);
     void fuse_odometry_locked(
         const mrpt::obs::CObservationOdometry& odom, const std::string& odomName);
     void fuse_imu_locked(const mrpt::obs::CObservationIMU& imu);

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -353,6 +353,11 @@ class StateEstimationSmoother : public mola::NavStateFilter,
         /// Reset with the estimator.
         std::optional<mrpt::poses::CPose3DPDFGaussian> wheels_odometry_accumulated;
 
+        /// Keyframe the last KEPT wheel-odometry reading was fused into, i.e.
+        /// the tail of the relative-factor chain built when
+        /// `odometry_relative_factors` is enabled. Reset with the estimator.
+        std::optional<frame_index_t> last_wheels_odometry_kf;
+
         /// Stamp of the last IMU reading that was actually processed. Used by
         /// imu_min_sample_period to skip higher-rate readings.
         std::optional<mrpt::Clock::time_point> last_processed_imu_stamp;
@@ -433,6 +438,11 @@ class StateEstimationSmoother : public mola::NavStateFilter,
     void fuse_pose_locked(
         const mrpt::Clock::time_point& timestamp, const mrpt::poses::CPose3DPDFGaussian& pose,
         const std::string& frame_id);
+
+    /// Adds the BetweenFactor tying this odometry reading's keyframe to the
+    /// previous one. See Parameters::odometry_relative_factors.
+    void add_odometry_relative_factor(
+        const mrpt::Clock::time_point& timestamp, const mrpt::poses::CPose3DPDFGaussian& increment);
     void fuse_odometry_locked(
         const mrpt::obs::CObservationOdometry& odom, const std::string& odomName);
     void fuse_imu_locked(const mrpt::obs::CObservationIMU& imu);

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -344,6 +344,15 @@ class StateEstimationSmoother : public mola::NavStateFilter,
         /// accumulated increment.
         std::optional<mrpt::Clock::time_point> last_wheels_odometry_stamp;
 
+        /// Wheel odometry is fused as an ABSOLUTE pose in its own {odom_i}
+        /// frame, so the covariance that goes with it must be the uncertainty
+        /// accumulated over the whole dead-reckoning history, not that of the
+        /// single latest increment. This carries that accumulation: the pose is
+        /// the same one the source reports, and the covariance is the composed
+        /// motion-model covariance of every increment since the first reading.
+        /// Reset with the estimator.
+        std::optional<mrpt::poses::CPose3DPDFGaussian> wheels_odometry_accumulated;
+
         /// Stamp of the last IMU reading that was actually processed. Used by
         /// imu_min_sample_period to skip higher-rate readings.
         std::optional<mrpt::Clock::time_point> last_processed_imu_stamp;

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -126,7 +126,21 @@ params:
   # dead-reckoning covariance to be honest, which makes it nearly uninformative;
   # the relative one states what the reading actually measured, with the
   # covariance the motion model computes for it, and nothing accumulates.
-  # Default off until measured on more than one platform.
+  # OFF by default, and the reason is a measured trade rather than caution.
+  #
+  # On BotanicGarden -- the only dataset family in our evaluation corpus that
+  # feeds wheel odometry, a skid-steer platform in dense vegetation -- this is
+  # the better of the two ways to fuse: better APE on 5 of 7 sequences than the
+  # absolute-only formulation. But test-navstate-odom-gnss-fusion shows it costs
+  # geo-referencing: the ENU->map rotation error grows past its 5 deg gate
+  # (5.69 deg), where the absolute-only formulation stays inside it. Asserting
+  # the dead-reckoned pose absolutely, however weakly, is apparently what makes
+  # that yaw well observed.
+  #
+  # And on that same platform, fusing wheel odometry AT ALL is worse than
+  # ignoring it on 6 of 7 sequences, so the APE side of the trade is being paid
+  # for on a configuration that is not recommended anyway. Enable this if you
+  # fuse wheel odometry and do not estimate geo-referencing.
   odometry_relative_factors: ${MOLA_ODOM_RELATIVE_FACTORS|false}
 
   # High-rate same-sensor decimation for IMU [seconds]. If > 0, readings

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -120,6 +120,15 @@ params:
   odom_motion_model_min_std_xy: ${MOLA_ODOM_MOTION_MODEL_MIN_STD_XY|1e-3} # [m], see effective-floor note above
   odom_motion_model_min_std_phi_deg: ${MOLA_ODOM_MOTION_MODEL_MIN_STD_PHI_DEG|0.1} # [deg], see effective-floor note above
 
+  # Also fuse each wheel-odometry increment as a RELATIVE constraint between the
+  # two keyframes it spans, on top of the absolute pose-in-{odom} factor that is
+  # always added. The absolute factor has to carry the whole accumulated
+  # dead-reckoning covariance to be honest, which makes it nearly uninformative;
+  # the relative one states what the reading actually measured, with the
+  # covariance the motion model computes for it, and nothing accumulates.
+  # Default off until measured on more than one platform.
+  odometry_relative_factors: ${MOLA_ODOM_RELATIVE_FACTORS|false}
+
   # High-rate same-sensor decimation for IMU [seconds]. If > 0, readings
   # arriving less than this after the last processed one are skipped (attitude/
   # gravity are absolute, so nothing is accumulated). 0 = disabled. Default 0.1.

--- a/mola_state_estimation_smoother/src/Parameters.cpp
+++ b/mola_state_estimation_smoother/src/Parameters.cpp
@@ -47,6 +47,7 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
     MCP_LOAD_OPT(cfg, sigma_random_walk_acceleration_angular);
     MCP_LOAD_OPT(cfg, predict_twist_filter_enabled);
     MCP_LOAD_OPT(cfg, predict_twist_filter_time_const);
+    MCP_LOAD_OPT(cfg, odometry_relative_factors);
     MCP_LOAD_OPT(cfg, sigma_integrator_position);
     MCP_LOAD_OPT(cfg, sigma_integrator_orientation);
     MCP_LOAD_OPT(cfg, sigma_twist_from_consecutive_poses_linear);

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -728,9 +728,17 @@ void StateEstimationSmoother::fuse_odometry_locked(
         // This is the first time we have wheels odometry.
         // Store the pose but skip factor creation: the increment is zero,
         // which would produce a stiff near-zero BetweenFactor.
+        //
+        // This reading also defines the origin of the accumulation below: at
+        // the very first sample no dead reckoning has happened yet, so the
+        // accumulated uncertainty is zero (T_map_to_odom absorbs wherever the
+        // source happens to start).
         state_.last_wheels_odometry_name  = odomName;
         state_.last_wheels_odometry       = odom.odometry;
         state_.last_wheels_odometry_stamp = odom.timestamp;
+        state_.wheels_odometry_accumulated.emplace();
+        state_.wheels_odometry_accumulated->mean = mrpt::poses::CPose3D(odom.odometry);
+        state_.wheels_odometry_accumulated->cov.setZero();
         return;
     }
     // Use a probabilistic motion model:
@@ -748,18 +756,46 @@ void StateEstimationSmoother::fuse_odometry_locked(
 
     odoAct.computeFromOdometry(odometryIncrement, odoAct.motionModelConfiguration);
 
-    mrpt::poses::CPose3DPDFGaussian newOdomPosePdf;
-    newOdomPosePdf.copyFrom(*odoAct.poseChange);
+    mrpt::poses::CPose3DPDFGaussian incrementPdf;
+    incrementPdf.copyFrom(*odoAct.poseChange);
     // Ensure as minimal uncertainty in all 3D DOFs to prevent numerical issues:
-    newOdomPosePdf.cov.asEigen().diagonal().array() += 1e-4;
+    incrementPdf.cov.asEigen().diagonal().array() += 1e-4;
 
-    // Convert probabilistic pose back to global "odom" frame for data fusion the in "odom" frame:
-    newOdomPosePdf.changeCoordinatesReference(mrpt::poses::CPose3D(lastOdom));
+    // Compose this increment onto the accumulated dead-reckoning pose, so the
+    // covariance handed to fuse_pose_locked() is the uncertainty of the
+    // ABSOLUTE pose in {odom_i} -- which is what that factor asserts -- rather
+    // than the uncertainty of this one increment.
+    //
+    // This matters because the resulting factor is
+    // BetweenFactor(T_map_to_odom_i, T(kf), pose_in_odom, cov). T_map_to_odom_i
+    // is a single rigid variable, so with a per-increment covariance every
+    // keyframe in the window is told it lies within ~1 cm of one common frame,
+    // no matter how far the wheels have dead-reckoned since. On a platform with
+    // any slip those constraints are mutually inconsistent and the only way the
+    // optimizer can satisfy them is to distort the poses.
+    //
+    // Growing with distance travelled is the point: the factor is informative
+    // while the dead reckoning is fresh and fades as it stales, which is what it
+    // actually knows. The composition is conservative for nearby keyframe pairs
+    // (it ignores the correlation between two accumulations sharing a history),
+    // and conservative is the safe direction here.
+    ASSERT_(state_.wheels_odometry_accumulated.has_value());
+    *state_.wheels_odometry_accumulated = *state_.wheels_odometry_accumulated + incrementPdf;
+
+    // Take the mean from the source directly rather than from the composition:
+    // they agree analytically, and this keeps a long run free of accumulated
+    // round-off in a quantity the source reports exactly.
+    state_.wheels_odometry_accumulated->mean = mrpt::poses::CPose3D(odom.odometry);
+
+    const mrpt::poses::CPose3DPDFGaussian& newOdomPosePdf = *state_.wheels_odometry_accumulated;
 
     MRPT_LOG_DEBUG_FMT(
-        "[fuse_odometry]: t=%f name=%s pose=%s poseChange=%s",
+        "[fuse_odometry]: t=%f name=%s pose=%s poseChange=%s accum_sigma_xy=%.03f m "
+        "accum_sigma_yaw=%.03f deg",
         mrpt::Clock::toDouble(odom.timestamp), odomName.c_str(), odom.odometry.asString().c_str(),
-        odoAct.poseChange->getMeanVal().asString().c_str());
+        odoAct.poseChange->getMeanVal().asString().c_str(),
+        std::sqrt(newOdomPosePdf.cov(0, 0) + newOdomPosePdf.cov(1, 1)),
+        mrpt::RAD2DEG(std::sqrt(newOdomPosePdf.cov(5, 5))));
 
     // Save for next iteration (advance the anchor: this reading was kept):
     state_.last_wheels_odometry_name  = odomName;

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -802,23 +802,65 @@ void StateEstimationSmoother::fuse_odometry_locked(
     state_.last_wheels_odometry       = odom.odometry;
     state_.last_wheels_odometry_stamp = odom.timestamp;
 
-    // Fuse this new probabilistic pose observation:
-    fuse_pose_locked(odom.timestamp, newOdomPosePdf, odomName);
-
-    // Optionally, also state what this reading actually measured: the motion
-    // between the two keyframes it spans. See Parameters::odometry_relative_factors.
-    if (params_.odometry_relative_factors)
+    if (!params_.odometry_relative_factors)
     {
-        add_odometry_relative_factor(odom.timestamp, incrementPdf);
+        // Fuse this new probabilistic pose observation:
+        fuse_pose_locked(odom.timestamp, newOdomPosePdf, odomName);
+        return;
     }
+
+    fuse_odometry_relative_locked(odom, odomName, incrementPdf, newOdomPosePdf);
 }
 
-void StateEstimationSmoother::add_odometry_relative_factor(
-    const mrpt::Clock::time_point& timestamp, const mrpt::poses::CPose3DPDFGaussian& increment)
+// Relative formulation: the motion goes into BetweenFactors between consecutive
+// odometry keyframes, and exactly ONE absolute pose-in-{odom_i} factor is ever
+// added, on the first kept reading of each source, to resolve T_map_to_odom_i.
+//
+// One is all it takes, and it stays that way for the whole run. T_map_to_odom_i
+// is a single rigid variable: given that anchor plus the relative chain, every
+// later "keyframe k is at odom pose p_k" is already implied, up to the odometry
+// drift in between. A second absolute factor observes the frame no better -- it
+// re-injects the accumulated dead-reckoning error into the map poses, which is
+// the defect the covariance accumulation mitigates rather than removes.
+//
+// Nor does the anchor need renewing when its keyframe ages out. Keyframes leave
+// through IncrementalFixedLagSmoother's MARGINALIZATION, not through
+// factorsToRemove (which this class uses only for kinematic-link splicing), so
+// the anchor's information survives as a linear marginal on T_map_to_odom_i
+// after its keyframe is gone. Re-anchoring per window would therefore add
+// information the graph has already kept: the same double count, only slower.
+// T_map_to_odom_i itself is never marginalized -- its key timestamp is bumped to
+// the newest observation on every update, so it stays inside the lag forever.
+void StateEstimationSmoother::fuse_odometry_relative_locked(
+    const mrpt::obs::CObservationOdometry& odom, const std::string& odomName,
+    const mrpt::poses::CPose3DPDFGaussian& increment,
+    const mrpt::poses::CPose3DPDFGaussian& absolutePoseInOdom)
 {
-    // fuse_pose_locked() has just created (or reused) the keyframe for this
-    // stamp; asking for it again returns that same one.
-    const auto this_kf_id = create_or_get_keyframe_by_timestamp_locked(timestamp);
+    const auto frame_id_idx = add_or_get_odom_frame_id(odomName);
+    const auto this_kf_id   = create_or_get_keyframe_by_timestamp_locked(odom.timestamp);
+
+    // Unconditional, and independent of which factor is added below: this is the
+    // anchor estimated_navstate() extrapolates from when a front end asks for a
+    // pose in the source's OWN frame, so it has to track every kept reading.
+    state_.last_raw_pose_by_source[frame_id_idx] =
+        State::RawSourcePose{odom.timestamp, absolutePoseInOdom};
+
+    if (!state_.wheels_odometry_anchor_kf.has_value())
+    {
+        gtsam::Pose3   pose_out;
+        gtsam::Matrix6 cov_out;
+        mrpt::gtsam_wrappers::to_gtsam_se3_cov6(absolutePoseInOdom, pose_out, cov_out);
+
+        state_.gtsam->newFactors.emplace_shared<gtsam::BetweenFactor<gtsam::Pose3>>(
+            symbol_T_map_to_odom_i_base + frame_id_idx, T(this_kf_id), pose_out,
+            gtsam::noiseModel::Gaussian::Covariance(cov_out));
+
+        state_.wheels_odometry_anchor_kf = this_kf_id;
+
+        MRPT_LOG_DEBUG_FMT(
+            "[fuse_odometry] odom frame '%s' anchored at KF %u", odomName.c_str(),
+            static_cast<unsigned>(this_kf_id));
+    }
 
     const auto prev                = state_.last_wheels_odometry_kf;
     state_.last_wheels_odometry_kf = this_kf_id;
@@ -828,16 +870,17 @@ void StateEstimationSmoother::add_odometry_relative_factor(
         return;  // first reading of the chain, or both readings landed on one keyframe
     }
 
-    // The previous keyframe may have been marginalized out of the sliding
-    // window (a long gap in the odometry stream, or a reset in between). Adding
-    // a factor on a variable the smoother no longer holds would resurrect it as
-    // a free, unconstrained state, so skip and let the chain re-anchor here.
+    // The previous keyframe may have been marginalized out of the sliding window
+    // (a long gap in the stream, or a reset in between). Unlike the anchor above,
+    // whose information the marginalization keeps, a NEW factor naming a
+    // marginalized variable would resurrect it as a free, unconstrained state --
+    // so skip it and let the chain continue from here.
     if (state_.last_estimated_states.count(*prev) == 0)
     {
         MRPT_LOG_THROTTLE_DEBUG_FMT(
             5.0,
             "[fuse_odometry] relative factor skipped: KF %u is no longer in the window; "
-            "re-anchoring the odometry chain at KF %u",
+            "the odometry chain continues from KF %u",
             static_cast<unsigned>(*prev), static_cast<unsigned>(this_kf_id));
         return;
     }

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -804,6 +804,54 @@ void StateEstimationSmoother::fuse_odometry_locked(
 
     // Fuse this new probabilistic pose observation:
     fuse_pose_locked(odom.timestamp, newOdomPosePdf, odomName);
+
+    // Optionally, also state what this reading actually measured: the motion
+    // between the two keyframes it spans. See Parameters::odometry_relative_factors.
+    if (params_.odometry_relative_factors)
+    {
+        add_odometry_relative_factor(odom.timestamp, incrementPdf);
+    }
+}
+
+void StateEstimationSmoother::add_odometry_relative_factor(
+    const mrpt::Clock::time_point& timestamp, const mrpt::poses::CPose3DPDFGaussian& increment)
+{
+    // fuse_pose_locked() has just created (or reused) the keyframe for this
+    // stamp; asking for it again returns that same one.
+    const auto this_kf_id = create_or_get_keyframe_by_timestamp_locked(timestamp);
+
+    const auto prev                = state_.last_wheels_odometry_kf;
+    state_.last_wheels_odometry_kf = this_kf_id;
+
+    if (!prev.has_value() || *prev == this_kf_id)
+    {
+        return;  // first reading of the chain, or both readings landed on one keyframe
+    }
+
+    // The previous keyframe may have been marginalized out of the sliding
+    // window (a long gap in the odometry stream, or a reset in between). Adding
+    // a factor on a variable the smoother no longer holds would resurrect it as
+    // a free, unconstrained state, so skip and let the chain re-anchor here.
+    if (state_.last_estimated_states.count(*prev) == 0)
+    {
+        MRPT_LOG_THROTTLE_DEBUG_FMT(
+            5.0,
+            "[fuse_odometry] relative factor skipped: KF %u is no longer in the window; "
+            "re-anchoring the odometry chain at KF %u",
+            static_cast<unsigned>(*prev), static_cast<unsigned>(this_kf_id));
+        return;
+    }
+
+    // A relative transform is the same quantity in {map} and in {odom_i}: the
+    // two chains differ by one constant rigid T_map_to_odom_i, which cancels in
+    // T_prev^-1 * T_now. So the motion model's increment is directly the
+    // measurement this factor needs, with directly the covariance it computed.
+    gtsam::Pose3   incr_out;
+    gtsam::Matrix6 incrCov_out;
+    mrpt::gtsam_wrappers::to_gtsam_se3_cov6(increment, incr_out, incrCov_out);
+
+    state_.gtsam->newFactors.emplace_shared<gtsam::BetweenFactor<gtsam::Pose3>>(
+        T(*prev), T(this_kf_id), incr_out, gtsam::noiseModel::Gaussian::Covariance(incrCov_out));
 }
 
 void StateEstimationSmoother::fuse_imu(const mrpt::obs::CObservationIMU& imu)

--- a/mola_state_estimation_smoother/tests/CMakeLists.txt
+++ b/mola_state_estimation_smoother/tests/CMakeLists.txt
@@ -14,6 +14,13 @@ mola_add_test(
 )
 
 mola_add_test(
+  TARGET  test-odometry-long-drift
+  SOURCES test-odometry-long-drift.cpp
+  LINK_LIBRARIES
+    mola::mola_state_estimation_smoother
+)
+
+mola_add_test(
   TARGET  test-static-gnss-imu-orientation
   SOURCES test-static-gnss-imu-orientation.cpp
   LINK_LIBRARIES

--- a/mola_state_estimation_smoother/tests/test-navstate-odom-gnss-fusion.cpp
+++ b/mola_state_estimation_smoother/tests/test-navstate-odom-gnss-fusion.cpp
@@ -41,7 +41,27 @@ constexpr double MOTION_ANG_WZ      = 0.5;  // rad/s
 constexpr double ODOMETRY_NOISE_XY  = 0.01;
 constexpr double ODOMETRY_NOISE_PHI = 0.1_deg;
 
-constexpr double MAXIMUM_SE3_FINAL_ERROR        = 0.40;
+// Raised from 0.40 on 2026-08-21, deliberately and with the measurements in
+// hand, because the old value gated the wrong thing.
+//
+// The odometry simulated below is noise-only: a zero-mean per-increment
+// perturbation, no slip and no systematic error. On such a source, trusting
+// wheel odometry MORE than the motion model says is free accuracy, so this test
+// scores an over-confident implementation better than a correct one. Worst-case
+// final_se3_error over the same seven cases:
+//
+//   0.365  before: an absolute pose fused with the LATEST INCREMENT's covariance
+//   0.419  after:  that covariance corrected to the accumulated dead-reckoning one
+//
+// The second is the honest one. On real data the ranking inverts: the first
+// formulation DIVERGES on all seven BotanicGarden sequences, estimating 4.5-6.8x
+// the true path length, while the corrected one holds every one of them.
+//
+// So this fixture cannot discriminate a correct odometry weight from an
+// over-confident one, and must not be used as the gate on that axis. It still
+// earns its place as a regression guard on the fusion working at all, and the
+// threshold is sized for that.
+constexpr double MAXIMUM_SE3_FINAL_ERROR        = 0.45;
 constexpr double MAXIMUM_ENU2MAP_ROTATION_ERROR = 5.0_deg;
 
 constexpr const char* ODOMETRY_NAME = "odom";

--- a/mola_state_estimation_smoother/tests/test-navstate-odom-gnss-fusion.cpp
+++ b/mola_state_estimation_smoother/tests/test-navstate-odom-gnss-fusion.cpp
@@ -47,20 +47,21 @@ constexpr double ODOMETRY_NOISE_PHI = 0.1_deg;
 // The odometry simulated below is noise-only: a zero-mean per-increment
 // perturbation, no slip and no systematic error. On such a source, trusting
 // wheel odometry MORE than the motion model says is free accuracy, so this test
-// scores an over-confident implementation better than a correct one. Worst-case
-// final_se3_error over the same seven cases:
+// scores an over-confident implementation better than a correct one. Same seven
+// cases, worst-case final_se3_error:
 //
-//   0.365  before: an absolute pose fused with the LATEST INCREMENT's covariance
-//   0.419  after:  that covariance corrected to the accumulated dead-reckoning one
+//   0.365  original: absolute pose fused with the LATEST INCREMENT's covariance
+//   0.419  that covariance corrected to the accumulated dead-reckoning one
+//   0.368  ...plus a relative factor per reading (restores part of the over-trust)
+//   0.405  ...with the single anchor that formulation actually implies
 //
-// The second is the honest one. On real data the ranking inverts: the first
-// formulation DIVERGES on all seven BotanicGarden sequences, estimating 4.5-6.8x
-// the true path length, while the corrected one holds every one of them.
-//
-// So this fixture cannot discriminate a correct odometry weight from an
-// over-confident one, and must not be used as the gate on that axis. It still
-// earns its place as a regression guard on the fusion working at all, and the
-// threshold is sized for that.
+// On real data the ranking inverts: on the seven BotanicGarden sequences, which
+// have genuine wheel slip, the last of those is the best arm (0.87x the
+// lightweight estimator) and the first DIVERGES on 7 of 7, estimating 4.5-6.8x
+// the true path length. So this fixture cannot discriminate a correct odometry
+// weight from an over-confident one, and must not be used as the gate on that
+// axis. It still earns its place as a regression guard on the fusion working at
+// all; the threshold is sized for that.
 constexpr double MAXIMUM_SE3_FINAL_ERROR        = 0.45;
 constexpr double MAXIMUM_ENU2MAP_ROTATION_ERROR = 5.0_deg;
 

--- a/mola_state_estimation_smoother/tests/test-odometry-long-drift.cpp
+++ b/mola_state_estimation_smoother/tests/test-odometry-long-drift.cpp
@@ -1,0 +1,267 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   test-odometry-long-drift.cpp
+ * @brief  Wheel odometry that dead-reckons hundreds of metres away must not drag
+ *         the fused trajectory with it.
+ * @author Jose Luis Blanco Claraco
+ * @date   Aug 21, 2026
+ *
+ * Measured when this was written, and worth knowing before reading a result
+ * from it: **both odometry formulations pass this, and by two orders of
+ * magnitude.** With 600 m of true travel, a 4% scale error and periodic 4x slip
+ * bursts -- 209 m of accumulated odometry error in total -- the fused
+ * trajectory ends 0.02 m from the truth whether the increments enter as
+ * absolute poses in {odom_i} or as relative constraints between keyframes.
+ *
+ * That is not the fixture being weak; it is the graph being right, and the
+ * reason is `T_map_to_odom_i`. It is a free variable with only a weak prior,
+ * it is re-optimized on every update, and it is never marginalized (its key
+ * timestamp is bumped to the newest observation each time). So it SLIDES to
+ * absorb accumulated odometry drift -- which is exactly what a REP-105
+ * map->odom correction is for. The absolute factor's mean is therefore not
+ * "wrong by 200 m" in the graph's own terms: the frame it is measured against
+ * moved with it. The inference is forced by the numbers above -- had that frame
+ * stayed put, factors asserting a pose 200 m away with ~0.2 m sigma could not
+ * have left the estimate at 0.02 m.
+ *
+ * So this file does NOT discriminate between the two formulations, and must not
+ * be cited as evidence for either. What it does guard is real and was worth
+ * pinning down: that unbounded dead-reckoning drift, smooth or bursty, does not
+ * leak into the fused trajectory when an accurate pose source is present.
+ *
+ * The case that DOES separate them is not reachable from here: on
+ * BotanicGarden the relative formulation is better on 5 of 7 sequences, and
+ * that is a closed loop -- the estimator's output becomes the front end's ICP
+ * prior, which shapes the next pose it is fed. A standalone estimator test
+ * feeds poses that do not depend on what the estimator said, so it cannot
+ * reproduce that at all.
+ */
+
+#include <mola_state_estimation_smoother/StateEstimationSmoother.h>
+#include <mrpt/core/get_env.h>
+#include <mrpt/poses/CPose3D.h>
+#include <mrpt/random/RandomGenerators.h>
+
+#include <cmath>
+#include <iostream>
+#include <optional>
+
+using namespace std::string_literals;
+using namespace mrpt::literals;
+
+namespace
+{
+// A long drive: 1200 steps of 0.1 s at 5 m/s is 600 m of travel. Long enough
+// that a few per cent of scale error becomes tens of metres, which is the
+// regime this test exists for and the one a short fixture cannot reach.
+const size_t NUM_POSES = 1200;
+const double T         = 0.1;  // [s] sensor period
+const double GT_VX     = 5.0;  // [m/s]
+const double GT_WZ     = 0.05;  // [rad/s], a gentle curve: a straight line
+                            // leaves yaw unobservable and is a weaker test
+
+// The wheel odometry is 4% long. Nothing about that is unusual -- it is what an
+// uncalibrated wheel radius, a tyre pressure change or soft ground produce --
+// and it is SYSTEMATIC, not zero-mean noise, which is the whole point.
+const double WHEEL_SCALE_ERROR = 1.04;
+const double WHEEL_NOISE_XY    = 0.005;  // [m] per step, on top of the bias
+const double WHEEL_NOISE_PHI   = 0.0005;  // [rad] per step
+
+// Slip: every SLIP_PERIOD steps the wheels spin for SLIP_LENGTH steps and
+// report SLIP_FACTOR times the real motion. This is the part a slow scale error
+// does not reproduce -- error that arrives FAST relative to the sliding window,
+// which is what a skid-steer platform on loose ground actually does.
+const size_t SLIP_PERIOD = 50;
+const size_t SLIP_LENGTH = 5;
+const double SLIP_FACTOR = 4.0;
+
+// The other source: an accurate pose in the reference frame, i.e. what a lidar
+// front end feeds in through fuse_pose(). This is the arrangement every MOLA-LO
+// run with wheel odometry actually has.
+const double LIDAR_NOISE_XYZ = 0.02;  // [m]
+const double LIDAR_NOISE_ANG = 0.002;  // [rad]
+
+// With an accurate pose source available, the fused trajectory should stay with
+// it. Sized well clear of the lidar noise floor, and roughly two orders of
+// magnitude below the odometry's own final error, so the test says something
+// about whether the bias leaks in rather than about tuning.
+const double MAXIMUM_FINAL_ERROR = 1.0;  // [m]
+
+// Sanity bound on the fixture itself: if the simulated odometry does not
+// actually run away, the test is not testing what it claims to.
+const double MINIMUM_ODOMETRY_DRIFT = 15.0;  // [m]
+
+const bool VERBOSE = mrpt::get_env<bool>("VERBOSE", false);
+
+auto& rng = mrpt::random::getRandomGenerator();
+
+const char* navStateParams =
+    R"###(# Config for Parameters
+params:
+    vehicle_frame_name: "base_link"
+    reference_frame_name: "map"
+
+    # No GNSS here, so the map frame is defined by where the robot starts.
+    link_first_pose_to_reference_origin_sigma: 1e-6
+
+    kinematic_model: KinematicModel::ConstantVelocity
+    sliding_window_length: 5.0
+    max_time_to_use_velocity_model: 2.0
+
+    sigma_random_walk_acceleration_linear: 2.0
+    sigma_random_walk_acceleration_angular: 1.0
+    sigma_integrator_position: 0.10
+    sigma_integrator_orientation: 0.10
+
+    # Keep every reading: the decimation is orthogonal to what is under test.
+    odometry_min_sample_period: 0.0
+
+    estimate_geo_reference: false
+)###";
+
+void run_test()
+{
+    mola::state_estimation_smoother::StateEstimationSmoother stateEst;
+    if (VERBOSE)
+    {
+        stateEst.setMinLoggingLevel(mrpt::system::LVL_DEBUG);
+    }
+    stateEst.initialize(mrpt::containers::yaml::FromText(navStateParams));
+
+    mrpt::poses::CPose3D gtPose = mrpt::poses::CPose3D::Identity();
+
+    std::optional<mrpt::poses::CPose3D> lastEst;
+    mrpt::poses::CPose3D                lastEstGt;
+    size_t                              lastEstIndex = 0;
+    size_t                              numEstimates = 0;
+
+    // The odometry frame starts somewhere arbitrary, as a real one does: what
+    // ties it to {map} is the estimator, not a shared origin.
+    mrpt::poses::CPose2D odomWheels(15.0, -8.0, 30.0_deg);
+
+    const auto gtDelta = mrpt::poses::CPose3D(GT_VX * T, 0, 0, GT_WZ * T, 0, 0);
+
+    double gtTravelled   = 0;
+    double odomTravelled = 0;
+
+    for (size_t i = 0; i < NUM_POSES; i++)
+    {
+        const auto stamp = mrpt::Clock::fromDouble(T * static_cast<double>(i));
+
+        if (i > 0)
+        {
+            gtPose = gtPose + gtDelta;
+            gtTravelled += GT_VX * T;
+
+            // Wheel odometry: the same motion, over-reported by a fixed scale
+            // factor, plus a little white noise.
+            const bool   slipping = (i % SLIP_PERIOD) < SLIP_LENGTH;
+            const double slip     = slipping ? SLIP_FACTOR : 1.0;
+
+            mrpt::poses::CPose2D deltaWheels(
+                gtDelta.x() * WHEEL_SCALE_ERROR * slip + rng.drawGaussian1D(0, WHEEL_NOISE_XY),
+                rng.drawGaussian1D(0, WHEEL_NOISE_XY),
+                gtDelta.yaw() + rng.drawGaussian1D(0, WHEEL_NOISE_PHI));
+            odomWheels = odomWheels + deltaWheels;
+            odomTravelled += deltaWheels.norm();
+        }
+
+        // Accurate pose in {map}, as a lidar front end would provide.
+        mrpt::poses::CPose3DPDFGaussian lidarPdf;
+        lidarPdf.mean =
+            gtPose +
+            mrpt::poses::CPose3D(
+                rng.drawGaussian1D(0, LIDAR_NOISE_XYZ), rng.drawGaussian1D(0, LIDAR_NOISE_XYZ),
+                rng.drawGaussian1D(0, LIDAR_NOISE_XYZ), rng.drawGaussian1D(0, LIDAR_NOISE_ANG),
+                rng.drawGaussian1D(0, LIDAR_NOISE_ANG), rng.drawGaussian1D(0, LIDAR_NOISE_ANG));
+        lidarPdf.cov.setDiagonal(mrpt::square(LIDAR_NOISE_XYZ));
+        for (int k = 3; k < 6; k++)
+        {
+            lidarPdf.cov(k, k) = mrpt::square(LIDAR_NOISE_ANG);
+        }
+
+        mrpt::obs::CObservationOdometry obsOdo;
+        obsOdo.timestamp   = stamp;
+        obsOdo.sensorLabel = "wheels";
+        obsOdo.odometry    = odomWheels;
+
+        stateEst.fuse_odometry(obsOdo, "wheels");
+        stateEst.fuse_pose(stamp, lidarPdf, "map");
+
+        // Track the newest usable estimate as we go. Queried here rather than
+        // once at the end because a query can legitimately return nothing (an
+        // under-constrained window), and "the estimator went quiet" is itself a
+        // failure mode worth counting rather than crashing on.
+        if (const auto ns = stateEst.estimated_navstate(stamp, "map"); ns.has_value())
+        {
+            lastEst      = ns->pose.mean;
+            lastEstGt    = gtPose;
+            lastEstIndex = i;
+            numEstimates++;
+        }
+    }
+
+    // How far the raw odometry ended up from the truth. Its own frame offset is
+    // a rigid transform the estimator can and does absorb, so the quantity that
+    // matters is the DISTANCE TRAVELLED, which a scale error corrupts and no
+    // rigid transform can repair.
+    const double odomDrift = std::abs(odomTravelled - gtTravelled);
+
+    std::cout << "ground truth travelled: " << gtTravelled << " m\n"
+              << "wheel odometry travelled: " << odomTravelled << " m\n"
+              << "odometry drift: " << odomDrift << " m\n";
+
+    // The fixture has to actually exercise the regime it claims to.
+    ASSERT_GT_(odomDrift, MINIMUM_ODOMETRY_DRIFT);
+
+    std::cout << "usable estimates: " << numEstimates << " of " << NUM_POSES << ", newest at step "
+              << lastEstIndex << "\n";
+
+    // An estimator that simply stops answering has not passed this test.
+    ASSERT_(lastEst.has_value());
+    ASSERT_GT_(numEstimates, NUM_POSES / 2);
+    ASSERT_GT_(lastEstIndex, (NUM_POSES * 9) / 10);
+
+    const double finalError = (lastEst->translation() - lastEstGt.translation()).norm();
+
+    std::cout << "final fused error: " << finalError << " m (limit " << MAXIMUM_FINAL_ERROR
+              << " m)\n";
+
+    // The point of the whole exercise: an odometry source that has dead-reckoned
+    // tens of metres away must not drag the fused trajectory with it. It cannot,
+    // if its increments enter as RELATIVE constraints -- each one states a
+    // short-baseline motion whose error is small and zero-mean. It necessarily
+    // does if they enter as an absolute pose in the odometry frame, because that
+    // pose carries the whole accumulated bias in its MEAN, and a mean that is
+    // wrong by tens of metres is not made harmless by widening its covariance.
+    ASSERT_LT_(finalError, MAXIMUM_FINAL_ERROR);
+}
+}  // namespace
+
+int main()
+{
+    try
+    {
+        run_test();
+        std::cout << "Test successful." << std::endl;
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Test failed:\n" << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/mola_state_estimation_smoother/tests/test-odometry-long-drift.cpp
+++ b/mola_state_estimation_smoother/tests/test-odometry-long-drift.cpp
@@ -132,14 +132,19 @@ params:
     estimate_geo_reference: false
 )###";
 
-void run_test()
+void run_test(bool relativeFactors)
 {
+    std::cout << "\n--- odometry_relative_factors: " << (relativeFactors ? "true" : "false")
+              << " ---\n";
+
     mola::state_estimation_smoother::StateEstimationSmoother stateEst;
     if (VERBOSE)
     {
         stateEst.setMinLoggingLevel(mrpt::system::LVL_DEBUG);
     }
-    stateEst.initialize(mrpt::containers::yaml::FromText(navStateParams));
+    auto params = mrpt::containers::yaml::FromText(navStateParams);
+    params["params"]["odometry_relative_factors"] = relativeFactors;
+    stateEst.initialize(params);
 
     mrpt::poses::CPose3D gtPose = mrpt::poses::CPose3D::Identity();
 
@@ -255,7 +260,12 @@ int main()
 {
     try
     {
-        run_test();
+        // Both formulations, because the point of the fixture is that neither
+        // lets unbounded dead-reckoning drift into the fused trajectory -- and
+        // because a formulation nothing exercises is a formulation nothing
+        // guards.
+        run_test(false);
+        run_test(true);
         std::cout << "Test successful." << std::endl;
         return 0;
     }


### PR DESCRIPTION
**Stacked on #61** — review that one first; this branch contains it.

## What it adds

The absolute pose-in-`{odom_i}` factor has to carry the whole accumulated
dead-reckoning covariance to be honest about what it asserts (#61), and by the
time it is honest it is also nearly uninformative — it discards the one thing
wheel odometry is genuinely good at, short-baseline relative motion.

This adds the constraint that states what a reading actually measured:

```cpp
BetweenFactor(T(kf_prev), T(kf_now), increment, incrementCov)
```

with exactly the covariance the motion model computes and nothing accumulating.
The simplification that makes it clean: a relative transform is the **same
quantity** in `{map}` and `{odom_i}` — the two chains differ by one constant
rigid `T_map_to_odom_i`, which cancels in `T_prev⁻¹T_now` — so the motion
model's increment is directly the measurement, with no frame conversion.

**Exactly one absolute factor is ever added**, on the first kept reading, to
resolve `T_map_to_odom_i`. One is all it takes: given that anchor plus the
relative chain, every later "keyframe *k* is at odom pose *p_k*" is already
implied, so a second is the same information counted twice — and what it
re-injects into the map poses is the accumulated dead-reckoning error.

It also needs no renewal when its keyframe ages out. Keyframes leave through
`IncrementalFixedLagSmoother`'s **marginalization**, which folds their factors
into a linear marginal on the surviving variables — this class uses
`factorsToRemove` only for kinematic-link splicing — so the anchor keeps
constraining `T_map_to_odom_i` after its own keyframe is gone. The window still
matters in the *other* direction, and the asymmetry is stated where the guard
lives: a **new** factor naming a marginalized key would resurrect it as a free
unconstrained state, so the relative chain skips rather than forces one.

## Why it is OFF by default

Both reasons are measured, and together they say this is a trade, not a win.

**1. It costs geo-referencing.** `test-navstate-odom-gnss-fusion`'s ENU→map
rotation error grows to **5.69°** against that test's 5.0° gate; the
absolute-only formulation stays inside it. Asserting the dead-reckoned pose
absolutely, however weakly, is apparently what makes that yaw well observed.

**2. The APE gain is paid for on a configuration that is not recommended.** On
the seven BotanicGarden sequences — the only wheel-odometry family in our
evaluation corpus — this beats the absolute-only formulation on 5 of 7. But with
everything else held fixed (same commit, same harness, same pin, only
`MOLA_ODOMETRY_TOPIC` differing), **fusing that platform's wheel odometry at all
is worse than ignoring it on 6 of 7**:

| sequence | odom OFF | odom ON (relative) |
|---|---|---|
| 1005_00 | 0.758 | 0.808 |
| 1005_01 | **0.038** | 0.351 |
| 1005_07 | 0.651 | 0.999 |
| 1006_01 | 0.690 | 1.067 |
| 1008_03 | 0.525 | 0.565 |
| 1018_00 | 0.068 | 0.063 |
| 1018_13 | 0.076 | 0.077 |

Bad odometry stays bad however correctly it is weighted. What #61's correct
weighting buys is that it no longer **diverges** — the original formulation lost
all seven, estimating 4.5–6.8x the true path length.

Worth stating plainly: nothing here shows the fusion *helping* anywhere.
BotanicGarden is a skid-steer platform in dense vegetation, so that may be a
property of the data — but citrus-farm's odometry is deliberately disabled over a
frame bug, so it is the only wheel-odometry dataset we have.

## The test threshold, and why it moves

`MAXIMUM_SE3_FINAL_ERROR` 0.40 → 0.45. **This belongs to #61, not to this
feature.** The odometry that test simulates is noise-only — no slip, no
systematic error — so trusting it more than the motion model says is free
accuracy there, and the old threshold scored an over-confident implementation
better than a correct one. Worst case across the same seven cases:

| | worst `final_se3_error` |
|---|---|
| original: absolute pose with the **latest increment's** covariance | 0.365 |
| that covariance corrected to the accumulated one (#61) | 0.419 |
| …plus a relative factor per reading (restores part of the over-trust) | 0.368 |
| …with the single anchor that formulation actually implies | 0.405 |

On real data the ranking **inverts**: the last is the best arm on BotanicGarden
and the first diverges 7/7. The fixture cannot discriminate a correct odometry
weight from an over-confident one, so it must not gate that axis. It still earns
its place as a regression guard on the fusion working at all, and the threshold
is sized for that. The reasoning is recorded at the constant rather than in this
description.

`colcon test`: 34/34.

Full write-up: `~/plans/lio/detail/216_smoother_state_estimator_parity.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to fuse wheel-odometry increments as relative constraints between keyframes.
  * Added configuration support for enabling or disabling relative odometry fusion; it is disabled by default.
  * Improved handling of odometry uncertainty and keyframe marginalization during fusion.

* **Tests**
  * Updated navigation fusion regression coverage and clarified expected benchmark behavior.
  * Added long-duration drift testing for reliable pose estimation during extended motion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->