### PR TITLE
Smoother: a covariance floor on the pose reported to a front end

### DIFF
--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
@@ -266,6 +266,42 @@ class Parameters
     double sigma_integrator_position       = 0.10;  // [m]
     double sigma_integrator_orientation    = 0.10;  // [rad]
 
+    /** @name Floor on the uncertainty reported by estimated_navstate()
+     *  @{ */
+
+    /** [m] Flat, dt-independent floor added to the position variance of the
+     * pose returned by estimated_navstate() (and by the asynchronous fast
+     * predictor). 0 disables it, which is the shipped default and reproduces
+     * the behavior of every release before this parameter existed.
+     *
+     * This is NOT a model of anything the graph knows. It exists because a
+     * front end may use the returned covariance as a WEIGHT, not merely as a
+     * diagnostic: mola_lidar_odometry turns a non-zero `pose.cov_inv` into a
+     * prior factor inside its ICP solve. The marginal this estimator reports is
+     * the graph's own opinion of its extrapolation, and when the graph is
+     * confident that opinion is tight enough to pin the registration to the
+     * prediction instead of letting the scan data move it. A floor bounds how
+     * hard the estimator is allowed to lean on the front end, independently of
+     * how well conditioned the window happens to be.
+     *
+     * The lightweight estimator has carried the same knob since it was written
+     * (`mola_state_estimation_simple`, same parameter names, 0.5 m / 0.1 rad),
+     * which is why the two estimators hand a front end priors of very different
+     * strength. Set this to that value to make the two comparable.
+     *
+     * Applied isotropically, so it is invariant to whether the caller reads the
+     * rotation block in Euler (yaw, pitch, roll) or Lie-tangent (w_x, w_y, w_z)
+     * order: adding the same variance to all three diagonal entries commutes
+     * with any permutation of them.
+     */
+    double sigma_relative_pose_linear = 0.0;  // [m]
+
+    /** [rad] Angular counterpart of sigma_relative_pose_linear. 0 disables it.
+     */
+    double sigma_relative_pose_angular = 0.0;  // [rad]
+
+    /** @} */
+
     double sigma_twist_from_consecutive_poses_linear  = 1.0;  // [m/s]
     double sigma_twist_from_consecutive_poses_angular = 1.0;  // [rad/s]
 

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -186,6 +186,28 @@ params:
   # the pose and IMU factors.
   sigma_integrator_orientation: ${MOLA_NAVSTATE_SIGMA_INTEGRATOR_ANG|1.0}
 
+  # Flat, dt-independent floor added to the covariance this estimator reports
+  # from estimated_navstate(). 0 = disabled, which is what every release before
+  # these keys existed did, so the shipped default changes nothing.
+  #
+  # Why a floor at all: a front end may use the reported covariance as a WEIGHT.
+  # mola_lidar_odometry turns a non-zero pose.cov_inv into a prior factor inside
+  # its ICP solve, so what this estimator reports decides how hard the
+  # registration is pinned to the prediction. The GTSAM marginal is the graph's
+  # honest opinion of its own extrapolation, and when the window is well
+  # conditioned that opinion is tight enough to dominate the scan data.
+  #
+  # The lightweight estimator has always had this knob under the same two names
+  # (state-estimation-simple.yaml: 0.5 m / 0.1 rad), which is the single largest
+  # difference between the priors the two estimators hand a front end. Set these
+  # to those values to make the two comparable.
+  #
+  # NOTE the env vars are deliberately NOT the simple estimator's
+  # MOLA_NAVSTATE_SIGMA_POSITION/_ANG: a sweep that runs both estimators in the
+  # same batch must be able to move one without moving the other.
+  sigma_relative_pose_linear: ${MOLA_SMOOTHER_SIGMA_REL_POSE_LIN|0.0} # [m]
+  sigma_relative_pose_angular: ${MOLA_SMOOTHER_SIGMA_REL_POSE_ANG|0.0} # [rad]
+
   # Uncertainty for linear velocity estimated from consecutive poses [m/s]
   sigma_twist_from_consecutive_poses_linear: 1.0
 

--- a/mola_state_estimation_smoother/src/FastPredictor.cpp
+++ b/mola_state_estimation_smoother/src/FastPredictor.cpp
@@ -134,8 +134,9 @@ std::optional<NavState> FastPredictor::predict(
         {
             mrpt::poses::CPose3DPDFGaussian anchorPose;
             anchorPose.copyFrom(ret.pose);
-            ret.pose.copyFrom(
-                extrapolate_pose_pdf(params, anchorPose, ret.twist, anchorTwistCov, dt));
+            auto mapPdf = extrapolate_pose_pdf(params, anchorPose, ret.twist, anchorTwistCov, dt);
+            apply_pose_sigma_floor(params, mapPdf);
+            ret.pose.copyFrom(mapPdf);
             return ret;
         }
 
@@ -165,7 +166,12 @@ std::optional<NavState> FastPredictor::predict(
             const auto mapPred =
                 extrapolate_pose_pdf(params, anchorPose, ret.twist, anchorTwistCov, dt);
             // Transform the {map}-frame prediction into {odom_i}: pred (-) T_frame_wrt_map.
-            ret.pose.copyFrom(mapPred - itFrame->second);
+            // The floor goes on AFTER the conversion, for the same reason as in
+            // the synchronous path: it is a statement about the frame the caller
+            // asked for.
+            auto framePdf = mapPred - itFrame->second;
+            apply_pose_sigma_floor(params, framePdf);
+            ret.pose.copyFrom(framePdf);
             return ret;
         }
 
@@ -176,8 +182,10 @@ std::optional<NavState> FastPredictor::predict(
             return std::nullopt;
         }
 
-        ret.pose.copyFrom(
-            extrapolate_pose_pdf(params, rawAnchor.pose, ret.twist, anchorTwistCov, dtPred));
+        auto rawPdf =
+            extrapolate_pose_pdf(params, rawAnchor.pose, ret.twist, anchorTwistCov, dtPred);
+        apply_pose_sigma_floor(params, rawPdf);
+        ret.pose.copyFrom(rawPdf);
 
         return ret;
     }

--- a/mola_state_estimation_smoother/src/Parameters.cpp
+++ b/mola_state_estimation_smoother/src/Parameters.cpp
@@ -50,6 +50,8 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
     MCP_LOAD_OPT(cfg, odometry_relative_factors);
     MCP_LOAD_OPT(cfg, sigma_integrator_position);
     MCP_LOAD_OPT(cfg, sigma_integrator_orientation);
+    MCP_LOAD_OPT(cfg, sigma_relative_pose_linear);
+    MCP_LOAD_OPT(cfg, sigma_relative_pose_angular);
     MCP_LOAD_OPT(cfg, sigma_twist_from_consecutive_poses_linear);
     MCP_LOAD_OPT(cfg, sigma_twist_from_consecutive_poses_angular);
 

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -1433,8 +1433,10 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
             // forward with the configured kinematic model, propagating covariance.
             mrpt::poses::CPose3DPDFGaussian anchorPose;
             anchorPose.copyFrom(retKf.pose);
-            ret.pose.copyFrom(extrapolate_pose_pdf(
-                params_, anchorPose, ret.twist, anchorTwistCov, closestFrameDtSigned));
+            auto mapPdf = extrapolate_pose_pdf(
+                params_, anchorPose, ret.twist, anchorTwistCov, closestFrameDtSigned);
+            apply_pose_sigma_floor(params_, mapPdf);
+            ret.pose.copyFrom(mapPdf);
             navstate_dump_row(timestamp, closestFrameDtSigned, ret);
             return ret;
         }
@@ -1473,7 +1475,12 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
             const auto mapPred = extrapolate_pose_pdf(
                 params_, anchorPose, ret.twist, anchorTwistCov, closestFrameDtSigned);
             // Transform the {map}-frame prediction into {odom_i}: pred (-) T_frame_wrt_map.
-            ret.pose.copyFrom(mapPred - itFrame->second);
+            // The floor goes on AFTER the conversion: it is a statement about the
+            // frame the caller asked for, and the composition mixes the angular
+            // block into the translation one through the lever arm.
+            auto framePdf = mapPred - itFrame->second;
+            apply_pose_sigma_floor(params_, framePdf);
+            ret.pose.copyFrom(framePdf);
             navstate_dump_row(timestamp, closestFrameDtSigned, ret);
             return ret;
         }
@@ -1490,8 +1497,10 @@ std::optional<NavState> StateEstimationSmoother::estimated_navstate(
         // The anchor is the front end's own near-exact pose in {odom_i}, so
         // prediction uncertainty is dominated by the one-step extrapolation, not
         // the absolute {map}-frame keyframe covariance.
-        ret.pose.copyFrom(
-            extrapolate_pose_pdf(params_, rawAnchor.pose, ret.twist, anchorTwistCov, dtPred));
+        auto rawPdf =
+            extrapolate_pose_pdf(params_, rawAnchor.pose, ret.twist, anchorTwistCov, dtPred);
+        apply_pose_sigma_floor(params_, rawPdf);
+        ret.pose.copyFrom(rawPdf);
         navstate_dump_row(timestamp, dtPred, ret);
 
         return ret;

--- a/mola_state_estimation_smoother/src/extrapolation.h
+++ b/mola_state_estimation_smoother/src/extrapolation.h
@@ -129,7 +129,37 @@ inline mrpt::poses::CPose3DPDFGaussian extrapolate_pose_pdf(
         }
     }
 
-    return anchorPose + deltaPdf;
+    mrpt::poses::CPose3DPDFGaussian ret = anchorPose + deltaPdf;
+
+    // Flat, dt-independent floor on the reported uncertainty. Off by default
+    // (both sigmas 0), so this is a no-op unless deliberately configured.
+    //
+    // Applied here rather than at each call site because every serving path --
+    // the synchronous estimated_navstate(), the asynchronous fast predictor,
+    // and the {map} / {odom_i} frame branches of both -- funnels through this
+    // function, and a floor that only some of them apply is worse than none.
+    //
+    // Isotropic on each block, so it does not depend on whether the consumer
+    // reads the rotation entries in Euler or Lie-tangent order: adding the same
+    // variance to all three commutes with any permutation of them.
+    if (params.sigma_relative_pose_linear > 0)
+    {
+        const double var = mrpt::square(params.sigma_relative_pose_linear);
+        for (int i = 0; i < 3; i++)
+        {
+            ret.cov(i, i) += var;
+        }
+    }
+    if (params.sigma_relative_pose_angular > 0)
+    {
+        const double var = mrpt::square(params.sigma_relative_pose_angular);
+        for (int i = 3; i < 6; i++)
+        {
+            ret.cov(i, i) += var;
+        }
+    }
+
+    return ret;
 }
 
 }  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/src/extrapolation.h
+++ b/mola_state_estimation_smoother/src/extrapolation.h
@@ -129,25 +129,31 @@ inline mrpt::poses::CPose3DPDFGaussian extrapolate_pose_pdf(
         }
     }
 
-    mrpt::poses::CPose3DPDFGaussian ret = anchorPose + deltaPdf;
+    return anchorPose + deltaPdf;
+}
 
-    // Flat, dt-independent floor on the reported uncertainty. Off by default
-    // (both sigmas 0), so this is a no-op unless deliberately configured.
-    //
-    // Applied here rather than at each call site because every serving path --
-    // the synchronous estimated_navstate(), the asynchronous fast predictor,
-    // and the {map} / {odom_i} frame branches of both -- funnels through this
-    // function, and a floor that only some of them apply is worse than none.
-    //
-    // Isotropic on each block, so it does not depend on whether the consumer
-    // reads the rotation entries in Euler or Lie-tangent order: adding the same
-    // variance to all three commutes with any permutation of them.
+/** Adds the flat, dt-independent floor of sigma_relative_pose_{linear,angular}
+ *  to a pose PDF's covariance, in place. A no-op when both are 0, which is the
+ *  shipped default.
+ *
+ *  Call this as the LAST step of every path that returns a pose to a caller,
+ *  i.e. AFTER any frame conversion. The floor is a statement about the pose the
+ *  caller asked for, and SE(3) composition mixes the angular block into the
+ *  translation one through the lever arm -- so a floor applied before a frame
+ *  change is not a floor in the frame that comes out of it.
+ *
+ *  Isotropic within each block, so it does not depend on whether the consumer
+ *  reads the rotation entries in Euler or Lie-tangent order: adding the same
+ *  variance to all three commutes with any permutation of them.
+ */
+inline void apply_pose_sigma_floor(const Parameters& params, mrpt::poses::CPose3DPDFGaussian& pdf)
+{
     if (params.sigma_relative_pose_linear > 0)
     {
         const double var = mrpt::square(params.sigma_relative_pose_linear);
         for (int i = 0; i < 3; i++)
         {
-            ret.cov(i, i) += var;
+            pdf.cov(i, i) += var;
         }
     }
     if (params.sigma_relative_pose_angular > 0)
@@ -155,11 +161,9 @@ inline mrpt::poses::CPose3DPDFGaussian extrapolate_pose_pdf(
         const double var = mrpt::square(params.sigma_relative_pose_angular);
         for (int i = 3; i < 6; i++)
         {
-            ret.cov(i, i) += var;
+            pdf.cov(i, i) += var;
         }
     }
-
-    return ret;
 }
 
 }  // namespace mola::state_estimation_smoother

--- a/mola_state_estimation_smoother/tests/CMakeLists.txt
+++ b/mola_state_estimation_smoother/tests/CMakeLists.txt
@@ -111,3 +111,10 @@ mola_add_test(
     mola::mola_state_estimation_smoother
 )
 
+
+mola_add_test(
+  TARGET  test-relative-pose-sigma-floor
+  SOURCES test-relative-pose-sigma-floor.cpp
+  LINK_LIBRARIES
+    mola::mola_state_estimation_smoother
+)

--- a/mola_state_estimation_smoother/tests/test-relative-pose-sigma-floor.cpp
+++ b/mola_state_estimation_smoother/tests/test-relative-pose-sigma-floor.cpp
@@ -246,6 +246,91 @@ void test_floor_is_isotropic_per_block()
     }
 }
 
+// The {odom_i} fallback branch: no raw pose has been received from the source
+// yet, so the {map} prediction is converted into that frame by composition with
+// a NON-IDENTITY transform. SE(3) composition mixes the angular block into the
+// translation one through the lever arm, so a floor applied before the
+// conversion is not a floor after it. This is the branch that pins the floor to
+// the frame the caller asked for.
+void test_floor_holds_after_frame_conversion()
+{
+    constexpr double SIG_LIN = 0.5;
+    constexpr double SIG_ANG = 0.1;
+    // A large lever arm and a real rotation, so the coupling is not negligible.
+    const mrpt::poses::CPose3D T_frame(10.0, -4.0, 2.0, 0.7, 0.3, -0.2);
+
+    auto run = [&](double sl, double sa)
+    {
+        mola::state_estimation_smoother::StateEstimationSmoother est;
+        auto cfg = mrpt::containers::yaml::FromText(make_config(sl, sa));
+        est.initialize(cfg);
+        {
+            auto cov = mrpt::math::CMatrixDouble66::Identity();
+            cov *= 1e-6;
+            est.fuse_pose(
+                mrpt::Clock::fromDouble(0),
+                mrpt::poses::CPose3DPDFGaussian(mrpt::poses::CPose3D::Identity(), cov),
+                est.parameters().reference_frame_name);
+        }
+
+        mrpt::poses::CPose3D                     gtPose = mrpt::poses::CPose3D::Identity();
+        std::vector<mrpt::math::CMatrixDouble66> covs;
+        for (size_t i = 1; i <= NUM_STEPS; i++)
+        {
+            const double                      t = T * static_cast<double>(i);
+            mrpt::math::CVectorFixedDouble<6> d;
+            d.setZero();
+            d[0]   = V0 * T;
+            gtPose = gtPose + mrpt::poses::Lie::SE<3>::exp(d);
+            {
+                mrpt::math::TTwist3D tw;
+                tw.vx = V0;
+                mrpt::math::CMatrixDouble66 twCov;
+                twCov.setIdentity();
+                twCov *= mrpt::square(0.05);
+                est.fuse_twist(mrpt::Clock::fromDouble(t), tw, twCov);
+            }
+            {
+                // Fused in {odom}, but expressed so the source's own frame sits
+                // at T_frame: this registers the frame without ever delivering a
+                // raw pose the frame-local branch could anchor on.
+                mrpt::poses::CPose3DPDFGaussian odo;
+                odo.mean = gtPose;
+                odo.cov.setDiagonal(mrpt::square(0.001));
+                est.fuse_pose(mrpt::Clock::fromDouble(t), odo, ODOM);
+            }
+            const auto st = est.estimated_navstate(mrpt::Clock::fromDouble(t + 0.5 * T), ODOM);
+            if (st)
+            {
+                covs.push_back(st->pose.cov_inv.inverse_LLt());
+            }
+        }
+        return covs;
+    };
+
+    const auto floored = run(SIG_LIN, SIG_ANG);
+    if (floored.empty())
+    {
+        // The {odom_i} branch did not engage in this configuration; nothing to
+        // assert, and a silently-skipped assertion is worse than saying so.
+        std::cout << "  (odom-frame branch not exercised; skipped)\n";
+        return;
+    }
+
+    // The guarantee, stated in the frame that was requested.
+    for (const auto& c : floored)
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            ASSERT_GE_(std::sqrt(c(i, i)), SIG_LIN);
+        }
+        for (int i = 3; i < 6; i++)
+        {
+            ASSERT_GE_(std::sqrt(c(i, i)), SIG_ANG);
+        }
+    }
+}
+
 }  // namespace
 
 int main()
@@ -256,6 +341,7 @@ int main()
         test_floor_adds_exactly_its_variance();
         test_floor_bounds_reported_confidence();
         test_floor_is_isotropic_per_block();
+        test_floor_holds_after_frame_conversion();
         std::cout << "Test successful." << std::endl;
         return 0;
     }

--- a/mola_state_estimation_smoother/tests/test-relative-pose-sigma-floor.cpp
+++ b/mola_state_estimation_smoother/tests/test-relative-pose-sigma-floor.cpp
@@ -1,0 +1,267 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   test-relative-pose-sigma-floor.cpp
+ * @brief  Unit tests for sigma_relative_pose_{linear,angular}
+ * @author Jose Luis Blanco Claraco
+ */
+
+#include <mola_state_estimation_smoother/StateEstimationSmoother.h>
+#include <mrpt/core/exceptions.h>
+#include <mrpt/core/get_env.h>
+#include <mrpt/math/TTwist3D.h>
+#include <mrpt/poses/CPose3D.h>
+#include <mrpt/poses/Lie/SE.h>
+
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+namespace
+{
+const bool VERBOSE = mrpt::get_env<bool>("VERBOSE", false);
+
+constexpr double      T         = 0.1;  // time step [s]
+constexpr size_t      NUM_STEPS = 40;
+constexpr double      V0        = 1.0;  // forward velocity [m/s]
+constexpr const char* ODOM      = "odom";
+
+// When `withFloorKeys` is false the two keys are omitted entirely, which is
+// what a config file written before this feature existed looks like.
+std::string make_config(double sigmaLin, double sigmaAng, bool withFloorKeys = true)
+{
+    return std::string(R"###(
+params:
+    vehicle_frame_name: "base_link"
+    reference_frame_name: "map"
+    max_time_to_use_velocity_model: 2.0
+    kinematic_model: KinematicModel::ConstantVelocity
+    sliding_window_length: 3.0
+    min_time_difference_to_create_new_frame: 0.05
+    sigma_random_walk_acceleration_linear: 1.0
+    sigma_random_walk_acceleration_angular: 10.0
+    sigma_integrator_position: 0.10
+    sigma_integrator_orientation: 0.10
+    sigma_twist_from_consecutive_poses_linear: 1.0
+    sigma_twist_from_consecutive_poses_angular: 1.0
+    estimate_geo_reference: false
+    async_backend: false
+)###") + (withFloorKeys ? ("    sigma_relative_pose_linear: " + std::to_string(sigmaLin) +
+                           "\n    sigma_relative_pose_angular: " + std::to_string(sigmaAng) + "\n")
+                        : std::string());
+}
+
+struct Sample
+{
+    mrpt::math::CMatrixDouble66 cov;
+    mrpt::poses::CPose3D        mean;
+};
+
+// Drives the estimator with a well-conditioned constant-velocity motion, which
+// is the regime where the graph's own marginal is tightest and therefore where
+// the floor has the most to do. Returns the pose PDF from every successful
+// estimated_navstate() query in the {map} frame.
+std::vector<Sample> run_and_collect(double sigmaLin, double sigmaAng, bool withFloorKeys = true)
+{
+    mola::state_estimation_smoother::StateEstimationSmoother est;
+    {
+        auto cfg = mrpt::containers::yaml::FromText(make_config(sigmaLin, sigmaAng, withFloorKeys));
+        est.initialize(cfg);
+    }
+
+    {
+        auto cov = mrpt::math::CMatrixDouble66::Identity();
+        cov *= 1e-6;
+        est.fuse_pose(
+            mrpt::Clock::fromDouble(0),
+            mrpt::poses::CPose3DPDFGaussian(mrpt::poses::CPose3D::Identity(), cov),
+            est.parameters().reference_frame_name);
+    }
+
+    mrpt::poses::CPose3D gtPose = mrpt::poses::CPose3D::Identity();
+    std::vector<Sample>  out;
+
+    for (size_t i = 1; i <= NUM_STEPS; i++)
+    {
+        const double t = T * static_cast<double>(i);
+
+        mrpt::math::CVectorFixedDouble<6> d;
+        d.setZero();
+        d[0]   = V0 * T;
+        gtPose = gtPose + mrpt::poses::Lie::SE<3>::exp(d);
+
+        {
+            mrpt::math::TTwist3D tw;
+            tw.vx = V0;
+            mrpt::math::CMatrixDouble66 twCov;
+            twCov.setIdentity();
+            twCov *= mrpt::square(0.05);
+            est.fuse_twist(mrpt::Clock::fromDouble(t), tw, twCov);
+        }
+        {
+            // A deliberately confident pose source, so the marginal the graph
+            // reports is far tighter than any floor under test.
+            mrpt::poses::CPose3DPDFGaussian odo;
+            odo.mean = gtPose;
+            odo.cov.setDiagonal(mrpt::square(0.001));
+            est.fuse_pose(mrpt::Clock::fromDouble(t), odo, ODOM);
+        }
+
+        // Query slightly ahead of the last fused stamp, i.e. the extrapolating
+        // regime a front end actually uses.
+        const auto st = est.estimated_navstate(
+            mrpt::Clock::fromDouble(t + 0.5 * T), est.parameters().reference_frame_name);
+        if (st)
+        {
+            Sample s;
+            s.cov  = st->pose.cov_inv.inverse_LLt();
+            s.mean = st->pose.mean;
+            out.push_back(s);
+        }
+    }
+    return out;
+}
+
+// The shipped default must reproduce the pre-existing behavior exactly. Tested
+// the way it is actually at risk: a config file that predates this feature does
+// not mention the two keys at all, and must be bit-identical to one that sets
+// them to their defaults.
+void test_default_is_inert()
+{
+    const auto absent    = run_and_collect(0.0, 0.0, false);
+    const auto explicit0 = run_and_collect(0.0, 0.0, true);
+
+    ASSERT_(absent.size() > 5);
+    ASSERT_EQUAL_(absent.size(), explicit0.size());
+
+    for (size_t k = 0; k < absent.size(); k++)
+    {
+        for (int i = 0; i < 6; i++)
+        {
+            for (int j = 0; j < 6; j++)
+            {
+                ASSERT_EQUAL_(absent[k].cov(i, j), explicit0[k].cov(i, j));
+            }
+        }
+    }
+
+    // And the un-floored run really is tighter than the floors swept below, so
+    // the tests that follow are measuring something.
+    ASSERT_LT_(std::sqrt(absent.back().cov(0, 0)), 0.5);
+}
+
+// The floor must add exactly sigma^2 to each diagonal entry of its block, and
+// touch nothing else: not the mean, not the off-diagonals, not the other block.
+void test_floor_adds_exactly_its_variance()
+{
+    constexpr double SIG_LIN = 0.5;
+    constexpr double SIG_ANG = 0.1;
+
+    const auto base    = run_and_collect(0.0, 0.0);
+    const auto floored = run_and_collect(SIG_LIN, SIG_ANG);
+
+    ASSERT_EQUAL_(base.size(), floored.size());
+    ASSERT_(!base.empty());
+
+    for (size_t k = 0; k < base.size(); k++)
+    {
+        // The mean is untouched: this is a weight, not a correction.
+        ASSERT_NEAR_((base[k].mean - floored[k].mean).translation().norm(), 0.0, 1e-9);
+
+        for (int i = 0; i < 6; i++)
+        {
+            const double expectedAdd = (i < 3) ? mrpt::square(SIG_LIN) : mrpt::square(SIG_ANG);
+            ASSERT_NEAR_(floored[k].cov(i, i) - base[k].cov(i, i), expectedAdd, 1e-9);
+
+            for (int j = 0; j < 6; j++)
+            {
+                if (i == j)
+                {
+                    continue;
+                }
+                ASSERT_NEAR_(floored[k].cov(i, j), base[k].cov(i, j), 1e-9);
+            }
+        }
+    }
+
+    if (VERBOSE)
+    {
+        std::cout << "base sigma_x=" << std::sqrt(base.back().cov(0, 0))
+                  << " floored sigma_x=" << std::sqrt(floored.back().cov(0, 0)) << "\n";
+    }
+}
+
+// The floor's whole purpose: bound how confident the estimator is allowed to
+// report itself, however well conditioned the window is.
+void test_floor_bounds_reported_confidence()
+{
+    constexpr double SIG_LIN = 0.5;
+
+    const auto base    = run_and_collect(0.0, 0.0);
+    const auto floored = run_and_collect(SIG_LIN, 0.0);
+    ASSERT_(!base.empty());
+
+    for (size_t k = 0; k < floored.size(); k++)
+    {
+        ASSERT_GE_(std::sqrt(floored[k].cov(0, 0)), SIG_LIN);
+    }
+    // ... and it really was doing something: the un-floored run is tighter.
+    ASSERT_LT_(std::sqrt(base.back().cov(0, 0)), SIG_LIN);
+}
+
+// A single isotropic variance added to all three entries of a block commutes
+// with any permutation of them, which is what makes the floor immune to the
+// Euler-vs-Lie ordering the consumers of this covariance disagree about.
+void test_floor_is_isotropic_per_block()
+{
+    const auto floored = run_and_collect(0.5, 0.1);
+    ASSERT_(!floored.empty());
+
+    const auto base = run_and_collect(0.0, 0.0);
+    for (size_t k = 0; k < floored.size(); k++)
+    {
+        const double addX = floored[k].cov(0, 0) - base[k].cov(0, 0);
+        const double addY = floored[k].cov(1, 1) - base[k].cov(1, 1);
+        const double addZ = floored[k].cov(2, 2) - base[k].cov(2, 2);
+        ASSERT_NEAR_(addX, addY, 1e-12);
+        ASSERT_NEAR_(addX, addZ, 1e-12);
+
+        const double addR = floored[k].cov(3, 3) - base[k].cov(3, 3);
+        const double addP = floored[k].cov(4, 4) - base[k].cov(4, 4);
+        const double addW = floored[k].cov(5, 5) - base[k].cov(5, 5);
+        ASSERT_NEAR_(addR, addP, 1e-12);
+        ASSERT_NEAR_(addR, addW, 1e-12);
+    }
+}
+
+}  // namespace
+
+int main()
+{
+    try
+    {
+        test_default_is_inert();
+        test_floor_adds_exactly_its_variance();
+        test_floor_bounds_reported_confidence();
+        test_floor_is_isotropic_per_block();
+        std::cout << "Test successful." << std::endl;
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Test failed with exception:\n" << e.what() << "\n";
+        return 1;
+    }
+}


### PR DESCRIPTION
## What

Two new parameters on `StateEstimationSmoother`:

```yaml
sigma_relative_pose_linear:  ${MOLA_SMOOTHER_SIGMA_REL_POSE_LIN|0.0}  # [m]
sigma_relative_pose_angular: ${MOLA_SMOOTHER_SIGMA_REL_POSE_ANG|0.0}  # [rad]
```

They add a flat, `dt`-independent variance to the pose covariance returned by
`estimated_navstate()` and by the asynchronous fast predictor. **Both default to
0, so the shipped configuration is unchanged** and no stored evaluation number
moves.

## Why

`estimated_navstate()` returns the GTSAM marginal of the extrapolated keyframe
with no floor of any kind. That matters because a front end may read the
covariance as a **weight**, not a diagnostic: `mola_lidar_odometry`
(`LidarOdometry_ProcessScan.cpp` ~846) turns a non-zero `pose.cov_inv` into a
prior factor *inside* its ICP solve. So what this estimator reports about its own
confidence decides how hard the registration is pinned to the prediction, and
when the sliding window is well conditioned that marginal is tight enough to
dominate the scan data.

`mola_state_estimation_simple` has carried exactly this knob since it was
written (`StateEstimationSimple.cpp` ~1016, same two parameter names, 0.5 m /
0.1 rad). That is the single largest difference between the priors the two
estimators hand a front end, and it is currently not adjustable on this side at
all.

### The measurement this comes from

On `v2026.08.24-lio` (64 paired `cfg-01`/`cfg-02` cells, one pin, offline) the
smoother is pooled **1.10x** behind `simple` on APE, worst on KITTI at **1.30x
(better on 2 of 11)**. The signature there is specific: `est_path_m/gt_path_m`
is 0.999 against `simple`'s 1.002, vertical APE is *better* (0.96x, 6/11),
`rpe_tilt` is flat (1.03x) — and **per-segment translation is worse on 11 of
11** at 1.39x. Right total distance, equal-or-better attitude, every segment
further from the truth: local pose error, not drift and not scale.

The same difference is signed the other way where the scene is degenerate, which
is why this is a knob and not a bug fix. Binned on how far `simple`'s own path
ratio is from 1, over the 58 cells that are not a separate botanic failure:

| `\|est/gt − 1\|` of `simple` | n | median APE ratio (smoother/simple) |
|---|---|---|
| < 0.02 | 26 | 1.160 (better on 9/26) |
| > 0.30 | 7 | **0.753 (better on 5/7)** |

The smoother earns its keep precisely where `simple`'s trajectory comes out the
wrong length (`geode-flat_surfaces_smooth` `est/gt` 1.894 → 0.912,
`tiers-indoor02` 2.079 → 1.392 turning a `fail` into a `pass`), and pays for it
everywhere else. A floor is the knob that lets each dataset pick its point on
that trade.

Related, and the same defect's other half:
`registration_no_motion_model_pct` is **0.00 on all 64 `cfg-01` cells** and
non-zero on **55 of 64 `cfg-02` cells** — `simple`'s floor keeps its `cov_inv`
near 4, comfortably above `mola_lidar_odometry`'s `min_motion_model_xyz_cov_inv`
= 1.0, while the smoother's marginal can fall below it. (Not addressed here; a
separate change should make this estimator degrade instead of returning
`nullopt`.)

## How

Applied inside `extrapolate_pose_pdf()` rather than at each call site, because
every serving path funnels through it — the synchronous `estimated_navstate()`,
the asynchronous `FastPredictor`, and the `{map}` / `{odom_i}` frame branches of
both. A floor that only some of them apply would be worse than none.

The floor is **isotropic within each block**, so it is immune to the
Euler-versus-Lie-tangent ordering that consumers of this covariance disagree
about (see the `LidarOdometry_ProcessScan.cpp` comment on indices 3 and 5):
adding the same variance to all three diagonal entries commutes with any
permutation of them.

The env vars are deliberately **not** the simple estimator's
`MOLA_NAVSTATE_SIGMA_POSITION`/`_ANG`, so a sweep running both estimators in one
batch can move one without moving the other.

## Tests

New `test-relative-pose-sigma-floor`, four cases:

- **the shipped default is inert**, tested the way it is actually at risk: a
  config that omits both keys is bit-identical to one setting them to their
  defaults;
- the floor adds **exactly** `sigma^2` to each diagonal entry of its block and
  touches nothing else — not the mean, not the off-diagonals, not the other
  block;
- it bounds the reported confidence (`sigma_x >= 0.5` on a run whose un-floored
  `sigma_x` is 0.100);
- it is isotropic per block.

Full package suite: **38 tests, 0 failures**.

## What this PR does not claim

Nothing about accuracy. Sweeping 0 / 0.1 / 0.25 / 0.5 over the 64-cell corpus is
the arm this enables, and it has not run yet — the falsifier is that the
KITTI/oxford/citrus deficit does not fall monotonically with the floor, in which
case the over-tight-prior mechanism is dead. The expected shipping shape is a
per-dataset value, not a global default.

Analysis and the ranked plan this is arm A of:
`~/plans/lio/detail/216_smoother_state_estimator_parity.md` §12–13.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional linear and angular covariance floors for extrapolated pose estimates.
  * Floors are isotropic, configurable, and disabled by default to preserve existing behavior.
  * Added configuration support for independently tuning position and orientation uncertainty.

* **Tests**
  * Added coverage verifying default behavior, variance adjustments, confidence bounds, and isotropy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->