### PR TITLE
CI: check this repo's docs pages against the full doc set

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,0 +1,14 @@
+# This repository contributes .rst pages that are included into the Sphinx
+# project in MOLAorg/mola, so a broken include or a dangling reference added
+# here only shows up when the whole doc set is built. Reuse mola's job to build
+# it against this pull request.
+name: Check docs
+
+on:
+  push:
+    branches: [develop, master]
+  pull_request:
+
+jobs:
+  check-docs:
+    uses: MOLAorg/mola/.github/workflows/check-docs.yml@develop

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -11,4 +11,8 @@ on:
 
 jobs:
   check-docs:
+    # Caps what the reusable workflow's token can ever be granted, regardless
+    # of what the shared workflow itself asks for.
+    permissions:
+      contents: read
     uses: MOLAorg/mola/.github/workflows/check-docs.yml@develop


### PR DESCRIPTION
The `.rst` files in this repository are ``.. include::``d into the Sphinx project in [MOLAorg/mola](https://github.com/MOLAorg/mola), so a broken include, a dangling reference or an unreachable page added here does not show up until the whole doc set is built. Nothing built it per pull request, which is how docs.mola-slam.org accumulated months of silently broken pages.

This calls the reusable job added in MOLAorg/mola#205. It reconstructs the sibling checkout layout, replaces this repository with the code under test, builds with Sphinx, and fails on the warning classes that mean a reader sees something wrong: a missing include, a dead cross-reference, a page no navigation reaches.

It skips doxygen and doxyrest, so it costs about **40 seconds**, not the full API build.

Verified: the same job caught every real documentation defect fixed across these repos this week, and reports clean on the current `develop` of all five.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added automated documentation checks for changes submitted through pull requests.
  * Documentation is now validated when updates are pushed to the main development branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->