### PR TITLE
Apply a planar odometry increment in the yaw-only frame

### DIFF
--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -359,11 +359,29 @@ void StateEstimationSimple::fuse_odometry_locked(
 {
     fuse_pending_imu_up_to(odom.timestamp);
 
-    // Advance last_pose by the incremental 2D odometry delta:
+    // Advance last_pose by the incremental 2D odometry delta.
+    //
+    // The increment is a HORIZONTAL (x, y, yaw) displacement: CObservationOdometry
+    // carries a CPose2D, so whatever vertical motion the source saw is already
+    // gone by the time it arrives here. Right-composing it onto last_pose would
+    // apply that horizontal displacement along the body's own axes, so on a
+    // pitched platform part of it turns into vertical motion that never
+    // happened (on a 25 deg slope, ~42 % of every step becomes spurious z).
+    // Apply it in the yaw-only frame instead, and leave z, pitch and roll to
+    // the sources that actually observe them.
     if (state_.last_odom_obs && state_.last_pose)
     {
-        const auto poseIncr    = odom.odometry - state_.last_odom_obs->odometry;
-        state_.last_pose->mean = state_.last_pose->mean + mrpt::poses::CPose3D(poseIncr);
+        const auto poseIncr = odom.odometry - state_.last_odom_obs->odometry;
+
+        auto&        p   = state_.last_pose->mean;
+        const double yaw = p.yaw();
+        const double cy  = std::cos(yaw);
+        const double sy  = std::sin(yaw);
+
+        p.x(p.x() + cy * poseIncr.x() - sy * poseIncr.y());
+        p.y(p.y() + sy * poseIncr.x() + cy * poseIncr.y());
+        p.setYawPitchRoll(yaw + poseIncr.phi(), p.pitch(), p.roll());
+
         state_.pose_already_updated_with_odom = true;
     }
     state_.last_odom_obs = odom;


### PR DESCRIPTION
## The bug

`CObservationOdometry` carries a `CPose2D`, so the increment between two readings is a **horizontal** `(x, y, yaw)` displacement — whatever vertical motion the source observed is already gone by the time it reaches the estimator. `fuse_odometry()` right-composed it onto `last_pose`:

```cpp
const auto poseIncr    = odom.odometry - state_.last_odom_obs->odometry;
state_.last_pose->mean = state_.last_pose->mean + mrpt::poses::CPose3D(poseIncr);
```

Right-composition applies the displacement along the **body's own axes**. On a pitched platform that turns a fraction `sin(pitch)` of every step into vertical motion that never happened — about 42 % of it on a 25 deg slope. This affects any wheel- or leg-odometry source on non-flat terrain, not only the legged case that surfaced it.

## The fix

Apply the increment in the yaw-only frame, and leave `z`, pitch and roll to the sources that actually observe them. For a planar platform, where `last_pose` has no pitch or roll, this is bit-identical to the previous behavior.

## Evidence

GrandTour `arc-3` — a quadruped that spends several minutes on stairs — fusing its legged odometry through this path:

| `sigma_wheel_odom_linear/angular` | before | after |
|---|---|---|
| 0.03 / 0.01 | 0.3959 | 1.5084 |
| **0.1 / 0.05 (default)** | 1.5942 | **0.3417** |
| 0.3 / 0.15 | — | 0.8710 |
| 1.0 / 0.5 | — | 0.8710 |

Two things worth reading out of that table.

**The fix inverts the sigma response.** Before, the path needed a pathologically tight velocity sigma to be usable at all: tightening it was the only way to let the twist channel override a pose increment that was fabricating z. After, tight sigma is actively harmful and the stock default is the optimum — 0.3417 m, better than the broken path's best (0.3959 at 0.03) and a 78.6 % improvement at the default.

**0.3 and 1.0 give the identical 0.8710**, i.e. the velocity fusion gain has gone to ~0 and that is the pose-increment-only asymptote. So the curve has a genuine interior optimum at the shipped default rather than a monotonic preference.

For comparison, the same source read as `CObservationRobotPose` (full SE(3), no planar projection at all) reaches 0.3146 on the same mission — so after this fix the planar path lands close to the type that never had the defect, which is what you would expect if fabricated z was the whole of the difference.

Measured on top of #67; without it, repeats of one configuration vary 4.3x and none of these numbers mean anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TnbdKx4Nv8KbV4toLt7vR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected odometry updates on pitched platforms.
  * Horizontal movement now remains horizontal, preventing unintended changes to vertical position, pitch, or roll.
  * Yaw and planar position updates are applied more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->