### PR TITLE
Expose additional_isam2_update_steps as an environment knob

### DIFF
--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -310,7 +310,12 @@ params:
 
   # Each new sensor will become a call to isam2.update(), plus this number of additional
   # refining steps. In theory, more steps lead to more accurate results.
-  additional_isam2_update_steps: 3
+  # Extra iSAM2 update() iterations per keyframe, beyond the first. This is the
+  # single largest cost term in the backend: dropping it from 3 to 1 cuts total
+  # wall-clock by about a third, far more than shortening the sliding window
+  # (a 4x shorter window buys only 25%). Exposed so deployments with a
+  # real-time budget can trade relinearization effort for latency.
+  additional_isam2_update_steps: ${MOLA_SMOOTHER_ISAM2_EXTRA_STEPS|3}
 
   # --------------------------------------------------------------------------
   # Sensor Input Filtering (Regex Patterns)


### PR DESCRIPTION
### Why

`additional_isam2_update_steps` is the largest single cost term in the smoother's backend, and it was the only one not reachable through the environment — so it could not be swept without editing the shipped YAML, and nobody had.

Measured on the GrandTour corpus (offline, four missions, all arms under identical load):

| config | cost | vs shipped |
|---|---:|---:|
| window 6.0 s, isam 3 (shipped) | 1.87x | 1.00x |
| window 3.0 s, isam 3 | 1.60x | 0.85x |
| window 1.5 s, isam 3 | 1.40x | 0.75x |
| **window 6.0 s, isam 1** | **1.22x** | **0.65x** |
| **window 2.0 s, isam 1** | **0.95x** | **0.51x** |

Shortening the sliding window is the knob one reaches for, and it is weak: 4x shorter buys 25 %. This one buys 35 % on its own, and combining the two halves the cost.

On a real-time protocol — one mission, alone on an idle box, 12 threads, against 399 s of data:

| config | wall | x real time |
|---|---:|---:|
| shipped | 502.7 s | 1.26x |
| window 2.0 + isam 1 | 331.2 s | **0.83x** |

That is the difference between over budget and under it, on the same hardware, with ATE unchanged to within the corpus's own noise (0.02191 → 0.02157 on that mission).

### What

One line, plus the comment explaining the trade-off. **Default unchanged at 3**, so no existing deployment moves unless it opts in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an environment variable for configuring the number of additional estimator update steps.
  - The default remains 3 steps, while advanced users can adjust this value to balance processing latency and relinearization effort.

- **Documentation**
  - Expanded configuration guidance to explain the performance impact of this setting and its relationship to backend computational cost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->