### PR TITLE
Port to mrpt 3.x

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,11 +151,26 @@ Key traits:
   left the pose covariance ungrown.
 
 Sensor inputs:
-- `fuse_pose()` - localization / LiDAR odometry poses
+- `fuse_pose()` - localization / LiDAR odometry / visual odometry poses
 - `fuse_odometry()` - wheel odometry with uncertainty
 - `fuse_imu()` - gravity alignment, angular velocity, attitude
 - `fuse_gnss()` - GPS in ENU coordinates
 - `fuse_twist()` - direct velocity measurements
+
+`fuse_pose()` with a `frame_id` other than the reference frame asserts an
+ABSOLUTE pose in that source's own frame, i.e. that the source relates to
+`{map}` by one rigid transform. For a source that drifts (visual odometry),
+list its frame_id in `relative_factors_frame_ids_re` instead: it is then fused
+as increments between consecutive keyframes plus one absolute anchor, which is
+`odometry_relative_factors` generalized from wheel odometry. In that mode the
+covariance passed is read as the uncertainty of ONE INCREMENT. It is a trade,
+not a free win - see the parameter docs and `test-relative-pose-factors`.
+
+**Never fuse a dataset's own ground truth.** MOLA's dataset sources publish
+their reference trajectory as a `CObservationRobotPose` labeled
+`ground_truth`; both estimators refuse that label unless
+`fuse_ground_truth_label: true`. Belt and braces for a benchmark sweep:
+`MOLA_PUBLISH_GROUND_TRUTH=false` stops the dataset publishing it at all.
 
 ### 3. `mola_gtsam_factors`
 

--- a/mola_georeferencing/CMakeLists.txt
+++ b/mola_georeferencing/CMakeLists.txt
@@ -33,14 +33,13 @@ endif()
 project(mola_georeferencing LANGUAGES CXX)
 
 # MOLA CMake scripts: "mola_xxx()"
-#find_package(CLI11 REQUIRED)
+find_package(CLI11 REQUIRED)
 find_package(GTSAM REQUIRED)
 find_package(mola_common REQUIRED)
 find_package(mola_gtsam_factors REQUIRED)
 find_package(mola_yaml REQUIRED)
 find_package(mp2p_icp REQUIRED)
-find_package(mrpt-maps REQUIRED)
-find_package(mrpt-tclap REQUIRED)
+find_package(mrpt_maps REQUIRED)
 
 # -----------------------
 # define lib:
@@ -53,13 +52,13 @@ mola_add_library(
   PUBLIC_LINK_LIBRARIES
     gtsam
     mola::mp2p_icp
-    mrpt::maps
+    mrpt::mrpt_maps
   PRIVATE_LINK_LIBRARIES
     mola::mola_gtsam_factors
   CMAKE_DEPENDENCIES
     GTSAM
     mp2p_icp
-    mrpt-maps
+    mrpt_maps
 
 )
 
@@ -71,9 +70,9 @@ mola_add_executable(
   SOURCES apps/mola-sm-georeferencing-cli.cpp
   LINK_LIBRARIES
     ${PROJECT_NAME}
-    mrpt::maps
-    mrpt::tclap
-    #CLI11::CLI11
+    mrpt::mrpt_maps
+    CLI11::CLI11
+    
 )
 
 mola_add_executable(
@@ -81,9 +80,9 @@ mola_add_executable(
   SOURCES apps/mola-trajectory-georef-cli.cpp
   LINK_LIBRARIES
     ${PROJECT_NAME}
-    mrpt::maps
-    mrpt::tclap
-    #CLI11::CLI11
+    mrpt::mrpt_maps
+    CLI11::CLI11
+    
 )
 
 mola_add_executable(
@@ -91,9 +90,9 @@ mola_add_executable(
   SOURCES apps/mola-mm-add-geodetic-cli.cpp
   LINK_LIBRARIES
     ${PROJECT_NAME}
-    mrpt::maps
-    mrpt::tclap
-    #CLI11::CLI11
+    mrpt::mrpt_maps
+    CLI11::CLI11
+    
 )
 
 # -----------------------

--- a/mola_georeferencing/apps/mola-mm-add-geodetic-cli.cpp
+++ b/mola_georeferencing/apps/mola-mm-add-geodetic-cli.cpp
@@ -18,7 +18,6 @@
  */
 
 #include <mp2p_icp/metricmap.h>
-#include <mrpt/3rdparty/tclap/CmdLine.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/io/CFileGZInputStream.h>
 #include <mrpt/maps/CPointsMap.h>
@@ -30,54 +29,26 @@
 #include <mrpt/topography/data_types.h>
 #include <mrpt/version.h>
 
+#include <CLI/CLI.hpp>
 #include <iostream>
 
 namespace
 {
 // CLI flags:
-struct Cli
-{
-    TCLAP::CmdLine cmd{"mola-mm-add-geodetic"};
+CLI::App cmd{"mola-mm-add-geodetic"};
 
-    TCLAP::ValueArg<std::string> argInputMap{
-        "i", "input", "Input metric map file (*.mm)", true, "input.mm", "input.mm", cmd};
+std::string argInputMap;
+std::string argOutputMap;
+std::string argGeoRefFile;
 
-    TCLAP::ValueArg<std::string> argOutputMap{
-        "o",  "output",    "Output metric map file (*.mm) with geodetic coordinates added",
-        true, "output.mm", "output.mm",
-        cmd};
+std::vector<std::string> argLayers;
 
-    TCLAP::ValueArg<std::string> argGeoRefFile{
-        "g",
-        "georef",
-        "Optional geo-referencing file (*.georef or *.yaml) to use if the input map "
-        "does not have embedded georeferencing information",
-        false,
-        "",
-        "map.georef",
-        cmd};
+std::string argPlugins;
+bool        argVerbose = false;
 
-    TCLAP::MultiArg<std::string> argLayers{
-        "l",
-        "layer",
-        "Layer(s) to process. If not provided, all CGenericPointsMap layers will be processed. "
-        "This argument can appear multiple times.",
-        false,
-        "layerName",
-        cmd};
-
-    TCLAP::ValueArg<std::string> argPlugins{
-        "p",
-        "load-plugins",
-        "One or more (comma separated) *.so files to load as plugins",
-        false,
-        "",
-        "foobar.so",
-        cmd};
-
-    TCLAP::SwitchArg argVerbose{
-        "v", "verbose", "Enable verbose output with progress information", cmd, false};
-};
+CLI::Option* optGeoRefFile;
+CLI::Option* optLayers;
+CLI::Option* optPlugins;
 
 bool is_binary_file(const std::string& fil)
 {
@@ -204,15 +175,15 @@ void add_geodetic_fields_to_layer(
     }
 }
 
-void run_add_geodetic(Cli& cli)
+void run_add_geodetic()
 {
-    const bool verbose = cli.argVerbose.getValue();
+    const bool verbose = argVerbose;
 
     // Load plugins if specified
-    if (cli.argPlugins.isSet())
+    if (optPlugins->count() > 0)
     {
         std::string errMsg;
-        const auto  plugins = cli.argPlugins.getValue();
+        const auto& plugins = argPlugins;
         std::cout << "[mola-mm-add-geodetic] Loading plugin(s): " << plugins << "\n";
         if (!mrpt::system::loadPluginModules(plugins, errMsg))
         {
@@ -221,7 +192,7 @@ void run_add_geodetic(Cli& cli)
     }
 
     // Load input map
-    const auto& filInput = cli.argInputMap.getValue();
+    const auto& filInput = argInputMap;
     std::cout << "[mola-mm-add-geodetic] Reading input map from: '" << filInput << "'..."
               << "\n";
 
@@ -242,13 +213,12 @@ void run_add_geodetic(Cli& cli)
                   << "\n";
         georef = mm.georeferencing;
     }
-    else if (cli.argGeoRefFile.isSet())
+    else if (optGeoRefFile->count() > 0)
     {
-        georef = load_georef_file(cli.argGeoRefFile.getValue());
+        georef = load_georef_file(argGeoRefFile);
         if (!georef.has_value())
         {
-            throw std::runtime_error(
-                "Failed to load georeferencing from file: " + cli.argGeoRefFile.getValue());
+            throw std::runtime_error("Failed to load georeferencing from file: " + argGeoRefFile);
         }
     }
     else
@@ -283,10 +253,10 @@ void run_add_geodetic(Cli& cli)
 
     // Determine which layers to process
     std::vector<std::string> layersToProcess;
-    if (cli.argLayers.isSet())
+    if (optLayers->count() > 0)
     {
         // Process only selected layers
-        for (const auto& layerName : cli.argLayers.getValue())
+        for (const auto& layerName : argLayers)
         {
             layersToProcess.push_back(layerName);
         }
@@ -333,7 +303,7 @@ void run_add_geodetic(Cli& cli)
               << "\n";
 
     // Save output map
-    const auto& filOutput = cli.argOutputMap.getValue();
+    const auto& filOutput = argOutputMap;
     std::cout << "[mola-mm-add-geodetic] Saving output map to: '" << filOutput << "'..."
               << "\n";
 
@@ -350,17 +320,33 @@ void run_add_geodetic(Cli& cli)
 
 int main(int argc, char** argv)
 {
+    cmd.add_option("-i,--input", argInputMap, "Input metric map file (*.mm)")->required();
+    cmd.add_option(
+           "-o,--output", argOutputMap,
+           "Output metric map file (*.mm) with geodetic coordinates added")
+        ->required();
+
+    optGeoRefFile = cmd.add_option(
+        "-g,--georef", argGeoRefFile,
+        "Optional geo-referencing file (*.georef or *.yaml) to use if the input map "
+        "does not have embedded georeferencing information");
+
+    optLayers = cmd.add_option(
+        "-l,--layer", argLayers,
+        "Layer(s) to process. If not provided, all CGenericPointsMap layers will be processed. "
+        "This argument can appear multiple times.");
+
+    optPlugins = cmd.add_option(
+        "-p,--load-plugins", argPlugins,
+        "One or more (comma separated) *.so files to load as plugins");
+
+    cmd.add_flag("-v,--verbose", argVerbose, "Enable verbose output with progress information");
+
+    CLI11_PARSE(cmd, argc, argv);
+
     try
     {
-        Cli cli;
-
-        // Parse arguments
-        if (!cli.cmd.parse(argc, argv))
-        {
-            return 1;
-        }
-
-        run_add_geodetic(cli);
+        run_add_geodetic();
     }
     catch (const std::exception& e)
     {

--- a/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
+++ b/mola_georeferencing/apps/mola-sm-georeferencing-cli.cpp
@@ -14,176 +14,72 @@
 
 #include <mola_georeferencing/simplemap_georeference.h>
 #include <mp2p_icp/metricmap.h>
-#include <mrpt/3rdparty/tclap/CmdLine.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/io/CFileGZOutputStream.h>
 #include <mrpt/math/TPoint3D.h>
 #include <mrpt/system/filesystem.h>
 #include <mrpt/system/os.h>
 
+#include <CLI/CLI.hpp>
 #include <algorithm>
 #include <fstream>
 #include <sstream>
 
-// CLI flags:
-
-struct Cli
+// ---------------------------------------------------------------------------
+// CLI flags
+// ---------------------------------------------------------------------------
+namespace
 {
-    TCLAP::CmdLine cmd{"mola-sm-georeferencing-cli"};
+CLI::App cmd{"mola-sm-georeferencing-cli"};
 
-    TCLAP::ValueArg<std::string> argInput{
-        "i", "input", "Input .simplemap file", true, "map.simplemap", "map.simplemap", cmd};
+std::string argInput = "map.simplemap";
 
-    TCLAP::ValueArg<std::string> argWriteMMInto{
-        "",    "write-into", "An existing .mm file in which to write the georeferencing metadata",
-        false, "map.mm",     "map.mm",
-        cmd};
+std::string argWriteMMInto = "map.mm";
+std::string argOutput      = "map.georef";
 
-    TCLAP::ValueArg<std::string> argOutput{
-        "o",
-        "output",
-        "Write the obtained georeferencing metadata to a file. The format is "
-        "determined by the file extension: binary gzip (`*.georef`) or YAML "
-        "(`*.yaml`, `*.yml`).",
-        false,
-        "map.georef",
-        "(map.georef|map.yaml)",
-        cmd};
+double       argHorz                        = 1.0;
+double       argIMUGravitySigmaDeg          = 3.0;
+double       argIMUAttitudeSigmaDeg         = 3.0;
+double       argIMUAttitudeYawSigmaDeg      = 15.0;
+double       argIMUAttitudeAzimuthOffsetDeg = 0.0;
+double       argMinUncertaintyXYZ           = 0.20;
+double       argGnssHuberK                  = 1.5;
+unsigned int argMinFixQuality               = 0;
+std::string  argPlugins;
+bool         argNoIMUGravity  = false;
+bool         argNoIMUAttitude = false;
+std::string  argSetEnuToMapXYZ;
+std::string  arg_verbosity_level = "INFO";
 
-    TCLAP::ValueArg<double> argHorz{
-        "",
-        "horizontality-sigma",
-        "For short trajectories (not >10x the GPS uncertainty), this helps to "
-        "avoid degeneracy.",
-        false,
-        1.0,
-        "1.0",
-        cmd};
+CLI::Option* optWriteMMInto;
+CLI::Option* optOutput;
+CLI::Option* optHorz;
+CLI::Option* optIMUGravitySigmaDeg;
+CLI::Option* optIMUAttitudeSigmaDeg;
+CLI::Option* optIMUAttitudeYawSigmaDeg;
+CLI::Option* optIMUAttitudeAzimuthOffsetDeg;
+CLI::Option* optMinUncertaintyXYZ;
+CLI::Option* optGnssHuberK;
+CLI::Option* optMinFixQuality;
+CLI::Option* optPlugins;
+CLI::Option* optSetEnuToMapXYZ;
 
-    TCLAP::ValueArg<double> argIMUGravitySigmaDeg{"",
-                                                  "imu-gravity-sigma-deg",
-                                                  "IMU gravity alignment uncertainty (degrees).",
-                                                  false,
-                                                  3.0,
-                                                  "3.0",
-                                                  cmd};
-
-    TCLAP::ValueArg<double> argIMUAttitudeSigmaDeg{
-        "",
-        "imu-attitude-sigma-deg",
-        "IMU absolute-attitude roll/pitch uncertainty (degrees).",
-        false,
-        3.0,
-        "3.0",
-        cmd};
-
-    TCLAP::ValueArg<double> argIMUAttitudeYawSigmaDeg{
-        "",
-        "imu-attitude-yaw-sigma-deg",
-        "IMU absolute-attitude yaw (azimuth) uncertainty (degrees). Defaults higher "
-        "than the roll/pitch sigma since fused yaw (often magnetometer-based) is "
-        "typically noisier.",
-        false,
-        15.0,
-        "15.0",
-        cmd};
-
-    TCLAP::ValueArg<double> argIMUAttitudeAzimuthOffsetDeg{
-        "",
-        "imu-attitude-azimuth-offset-deg",
-        "Fixed calibration offset (degrees) between the IMU's zero-yaw reading and "
-        "true azimuth, e.g. due to sensor mounting or magnetic declination.",
-        false,
-        0.0,
-        "0.0",
-        cmd};
-
-    TCLAP::ValueArg<double> argMinUncertaintyXYZ{
-        "",
-        "min-gnss-sigma",
-        "Minimum per-axis GNSS uncertainty (meters) used as a floor for the "
-        "ENU noise model. Default: 0.20",
-        false,
-        0.20,
-        "0.20",
-        cmd};
-
-    TCLAP::ValueArg<double> argGnssHuberK{
-        "",
-        "gnss-huber-k",
-        "Parameter 'k' of the Huber robust kernel applied to GNSS position "
-        "factors (whitened units). Default: 1.5",
-        false,
-        1.5,
-        "1.5",
-        cmd};
-
-    TCLAP::ValueArg<unsigned int> argMinFixQuality{
-        "",
-        "min-gnss-fix-quality",
-        "If non-zero, discard GNSS frames whose NMEA GGA fix quality is below "
-        "this value (1=GPS, 2=DGPS, 4=RTK fixed, 5=RTK float). Default: 0 "
-        "(filter disabled).",
-        false,
-        0,
-        "0",
-        cmd};
-
-    TCLAP::ValueArg<std::string> argPlugins{
-        "l",
-        "load-plugins",
-        "One or more (comma separated) *.so files to load as plugins, e.g. "
-        "defining new CMetricMap classes",
-        false,
-        "foobar.so",
-        "foobar.so",
-        cmd};
-
-    TCLAP::SwitchArg argNoIMUGravity{
-        "", "no-imu-gravity",
-        "Disable using IMU acceleration data for gravity alignment "
-        "(enabled by default).",
-        cmd, false};
-
-    TCLAP::SwitchArg argNoIMUAttitude{
-        "", "no-imu-attitude",
-        "Disable using IMU absolute-attitude (orientation) data for full attitude "
-        "alignment, including azimuth (enabled by default).",
-        cmd, false};
-
-    TCLAP::ValueArg<std::string> argSetEnuToMapXYZ{
-        "",
-        "set-t-enu-to-map-xyz",
-        "Instead of keeping the GNSS-derived translation of T_enu_to_map (which "
-        "may be several meters from the map origin), force it to the given "
-        "\"X,Y,Z\" (meters, map frame) and move the geodetic datum accordingly so "
-        "the map<->geodetic mapping is preserved. Use \"0,0,0\" to place the ENU "
-        "origin at the map origin. The estimated rotation is kept.",
-        false,
-        "0,0,0",
-        "X,Y,Z",
-        cmd};
-
-    TCLAP::ValueArg<std::string> arg_verbosity_level{
-        "v",   "verbosity", "Verbosity level: ERROR|WARN|INFO|DEBUG (Default: INFO)",
-        false, "INFO",      "INFO",
-        cmd};
-};
+}  // namespace
 
 static bool is_binary_georef(const std::string& fil)
 {
     return mrpt::system::extractFileExtension(fil) == "georef";
 }
 
-void run_sm_georef(Cli& cli)
+void run_sm_georef()
 {
-    if (cli.argPlugins.isSet())
+    if (optPlugins->count() > 0)
     {
         std::string sErrs;
-        bool        ok = mrpt::system::loadPluginModules(cli.argPlugins.getValue(), sErrs);
+        bool        ok = mrpt::system::loadPluginModules(argPlugins, sErrs);
         if (!ok)
         {
-            std::cerr << "Errors loading plugins: " << cli.argPlugins.getValue() << std::endl;
+            std::cerr << "Errors loading plugins: " << argPlugins << std::endl;
             throw std::runtime_error(sErrs.c_str());
         }
     }
@@ -191,9 +87,9 @@ void run_sm_georef(Cli& cli)
     mrpt::system::COutputLogger logger;
     logger.setLoggerName("mola-sm-georeferencing-cli");
     logger.setVerbosityLevel(
-        mrpt::typemeta::str2enum<mrpt::system::VerbosityLevel>(cli.arg_verbosity_level.getValue()));
+        mrpt::typemeta::str2enum<mrpt::system::VerbosityLevel>(arg_verbosity_level));
 
-    const auto& filSM = cli.argInput.getValue();
+    const auto& filSM = argInput;
 
     mrpt::maps::CSimpleMap sm;
 
@@ -208,49 +104,49 @@ void run_sm_georef(Cli& cli)
     mola::SMGeoReferencingParams p;
     p.logger = &logger;
 
-    if (cli.argHorz.isSet())
+    if (optHorz->count() > 0)
     {
         p.fgParams.addHorizontalityConstraints = true;
-        p.fgParams.horizontalitySigmaZ         = cli.argHorz.getValue();
+        p.fgParams.horizontalitySigmaZ         = argHorz;
     }
-    if (cli.argMinUncertaintyXYZ.isSet())
+    if (optMinUncertaintyXYZ->count() > 0)
     {
-        p.fgParams.minimumUncertaintyXYZ = cli.argMinUncertaintyXYZ.getValue();
+        p.fgParams.minimumUncertaintyXYZ = argMinUncertaintyXYZ;
     }
-    if (cli.argGnssHuberK.isSet())
+    if (optGnssHuberK->count() > 0)
     {
-        p.fgParams.robustParamHuberK = cli.argGnssHuberK.getValue();
+        p.fgParams.robustParamHuberK = argGnssHuberK;
     }
 
-    if (cli.argMinFixQuality.isSet())
+    if (optMinFixQuality->count() > 0)
     {
-        p.minimumGNSSFixQuality = cli.argMinFixQuality.getValue();
+        p.minimumGNSSFixQuality = argMinFixQuality;
     }
 
-    if (cli.argNoIMUGravity.getValue())
+    if (argNoIMUGravity)
     {
         p.useIMUGravityAlignment = false;
     }
-    if (cli.argIMUGravitySigmaDeg.isSet())
+    if (optIMUGravitySigmaDeg->count() > 0)
     {
-        p.imuGravityParams.imuGravitySigmaDeg = cli.argIMUGravitySigmaDeg.getValue();
+        p.imuGravityParams.imuGravitySigmaDeg = argIMUGravitySigmaDeg;
     }
 
-    if (cli.argNoIMUAttitude.getValue())
+    if (argNoIMUAttitude)
     {
         p.useIMUAttitudeAlignment = false;
     }
-    if (cli.argIMUAttitudeSigmaDeg.isSet())
+    if (optIMUAttitudeSigmaDeg->count() > 0)
     {
-        p.imuAttitudeParams.imuAttitudeSigmaDeg = cli.argIMUAttitudeSigmaDeg.getValue();
+        p.imuAttitudeParams.imuAttitudeSigmaDeg = argIMUAttitudeSigmaDeg;
     }
-    if (cli.argIMUAttitudeYawSigmaDeg.isSet())
+    if (optIMUAttitudeYawSigmaDeg->count() > 0)
     {
-        p.imuAttitudeParams.imuAttitudeYawSigmaDeg = cli.argIMUAttitudeYawSigmaDeg.getValue();
+        p.imuAttitudeParams.imuAttitudeYawSigmaDeg = argIMUAttitudeYawSigmaDeg;
     }
-    if (cli.argIMUAttitudeAzimuthOffsetDeg.isSet())
+    if (optIMUAttitudeAzimuthOffsetDeg->count() > 0)
     {
-        p.imuAttitudeParams.azimuthOffsetDeg = cli.argIMUAttitudeAzimuthOffsetDeg.getValue();
+        p.imuAttitudeParams.azimuthOffsetDeg = argIMUAttitudeAzimuthOffsetDeg;
     }
 
     mola::SMGeoReferencingOutput smGeo = mola::simplemap_georeference(sm, p);
@@ -263,7 +159,7 @@ void run_sm_georef(Cli& cli)
 
     // Optional re-datuming: force T_enu_to_map to a user-defined translation,
     // moving the geodetic datum accordingly (see mola::recenter_georeference).
-    if (cli.argSetEnuToMapXYZ.isSet())
+    if (optSetEnuToMapXYZ->count() > 0)
     {
         if (!smGeo.has_geodetic_datum)
         {
@@ -273,7 +169,7 @@ void run_sm_georef(Cli& cli)
                 "re-datum).");
         }
 
-        std::string s = cli.argSetEnuToMapXYZ.getValue();
+        std::string s = argSetEnuToMapXYZ;
         std::replace(s.begin(), s.end(), ',', ' ');
         std::istringstream   iss(s);
         mrpt::math::TPoint3D xyz;
@@ -281,14 +177,14 @@ void run_sm_georef(Cli& cli)
         {
             THROW_EXCEPTION_FMT(
                 "Cannot parse --set-t-enu-to-map-xyz value as \"X,Y,Z\": '%s'",
-                cli.argSetEnuToMapXYZ.getValue().c_str());
+                argSetEnuToMapXYZ.c_str());
         }
         iss >> std::ws;
         if (!iss.eof())
         {
             THROW_EXCEPTION_FMT(
                 "Cannot parse --set-t-enu-to-map-xyz value as \"X,Y,Z\": '%s'",
-                cli.argSetEnuToMapXYZ.getValue().c_str());
+                argSetEnuToMapXYZ.c_str());
         }
 
         smGeo.geo_ref = mola::recenter_georeference(*smGeo.geo_ref, xyz);
@@ -312,7 +208,7 @@ void run_sm_georef(Cli& cli)
               << "T_enu_to_map: " << geo_ref.T_enu_to_map.asString() << "\n";
 
     // Warn if the user has not requested any output at all.
-    if (!cli.argWriteMMInto.isSet() && !cli.argOutput.isSet())
+    if (optWriteMMInto->count() == 0 && optOutput->count() == 0)
     {
         std::cerr
             << "[mola-sm-georeferencing-cli] WARNING: Georeferencing was computed successfully "
@@ -322,39 +218,37 @@ void run_sm_georef(Cli& cli)
                "  The result will be discarded.\n";
     }
 
-    if (cli.argWriteMMInto.isSet())
+    if (optWriteMMInto->count() > 0)
     {
         mp2p_icp::metric_map_t mm;
 
-        std::cout << "[mola-sm-georeferencing-cli] Loading mm map: '"
-                  << cli.argWriteMMInto.getValue() << "'..." << std::endl;
+        std::cout << "[mola-sm-georeferencing-cli] Loading mm map: '" << argWriteMMInto << "'..."
+                  << std::endl;
 
-        const bool loadOk = mm.load_from_file(cli.argWriteMMInto.getValue());
+        const bool loadOk = mm.load_from_file(argWriteMMInto);
         if (!loadOk)
         {
-            THROW_EXCEPTION_FMT(
-                "Error loading input map file: '%s'", cli.argWriteMMInto.getValue().c_str());
+            THROW_EXCEPTION_FMT("Error loading input map file: '%s'", argWriteMMInto.c_str());
         }
 
         // overwrite metadata:
         mm.georeferencing = smGeo.geo_ref;
 
         // and save:
-        const auto saved_ok = mm.save_to_file(cli.argWriteMMInto.getValue());
+        const auto saved_ok = mm.save_to_file(argWriteMMInto);
         if (!saved_ok)
         {
-            std::cerr << "Error saving modified .mm file: '" << cli.argWriteMMInto.getValue()
-                      << "'\n";
+            std::cerr << "Error saving modified .mm file: '" << argWriteMMInto << "'\n";
             return;
         }
 
-        std::cout << "[mola-sm-georeferencing-cli] Writing modified mm map: '"
-                  << cli.argWriteMMInto.getValue() << "'..." << std::endl;
+        std::cout << "[mola-sm-georeferencing-cli] Writing modified mm map: '" << argWriteMMInto
+                  << "'..." << std::endl;
     }
 
-    if (cli.argOutput.isSet())
+    if (optOutput->count() > 0)
     {
-        const std::string outFil = cli.argOutput.getValue();
+        const std::string outFil = argOutput;
 
         std::cout << "[mola-sm-georeferencing-cli] Writing georef data file: '" << outFil << "'..."
                   << std::endl;
@@ -384,17 +278,90 @@ void run_sm_georef(Cli& cli)
 
 int main(int argc, char** argv)
 {
+    cmd.add_option("-i,--input", argInput, "Input .simplemap file")->required();
+
+    optWriteMMInto = cmd.add_option(
+        "--write-into", argWriteMMInto,
+        "An existing .mm file in which to write the georeferencing metadata");
+
+    optOutput = cmd.add_option(
+        "-o,--output", argOutput,
+        "Write the obtained georeferencing metadata to a file. The format is "
+        "determined by the file extension: binary gzip (`*.georef`) or YAML "
+        "(`*.yaml`, `*.yml`).");
+
+    optHorz = cmd.add_option(
+        "--horizontality-sigma", argHorz,
+        "For short trajectories (not >10x the GPS uncertainty), this helps to "
+        "avoid degeneracy.");
+
+    optIMUGravitySigmaDeg = cmd.add_option(
+        "--imu-gravity-sigma-deg", argIMUGravitySigmaDeg,
+        "IMU gravity alignment uncertainty (degrees).");
+
+    optIMUAttitudeSigmaDeg = cmd.add_option(
+        "--imu-attitude-sigma-deg", argIMUAttitudeSigmaDeg,
+        "IMU absolute-attitude roll/pitch uncertainty (degrees).");
+
+    optIMUAttitudeYawSigmaDeg = cmd.add_option(
+        "--imu-attitude-yaw-sigma-deg", argIMUAttitudeYawSigmaDeg,
+        "IMU absolute-attitude yaw (azimuth) uncertainty (degrees). Defaults higher "
+        "than the roll/pitch sigma since fused yaw (often magnetometer-based) is "
+        "typically noisier.");
+
+    optIMUAttitudeAzimuthOffsetDeg = cmd.add_option(
+        "--imu-attitude-azimuth-offset-deg", argIMUAttitudeAzimuthOffsetDeg,
+        "Fixed calibration offset (degrees) between the IMU's zero-yaw reading and "
+        "true azimuth, e.g. due to sensor mounting or magnetic declination.");
+
+    optMinUncertaintyXYZ = cmd.add_option(
+        "--min-gnss-sigma", argMinUncertaintyXYZ,
+        "Minimum per-axis GNSS uncertainty (meters) used as a floor for the "
+        "ENU noise model. Default: 0.20");
+
+    optGnssHuberK = cmd.add_option(
+        "--gnss-huber-k", argGnssHuberK,
+        "Parameter 'k' of the Huber robust kernel applied to GNSS position "
+        "factors (whitened units). Default: 1.5");
+
+    optMinFixQuality = cmd.add_option(
+        "--min-gnss-fix-quality", argMinFixQuality,
+        "If non-zero, discard GNSS frames whose NMEA GGA fix quality is below "
+        "this value (1=GPS, 2=DGPS, 4=RTK fixed, 5=RTK float). Default: 0 "
+        "(filter disabled).");
+
+    optPlugins = cmd.add_option(
+        "-l,--load-plugins", argPlugins,
+        "One or more (comma separated) *.so files to load as plugins, e.g. "
+        "defining new CMetricMap classes");
+
+    cmd.add_flag(
+        "--no-imu-gravity", argNoIMUGravity,
+        "Disable using IMU acceleration data for gravity alignment "
+        "(enabled by default).");
+
+    cmd.add_flag(
+        "--no-imu-attitude", argNoIMUAttitude,
+        "Disable using IMU absolute-attitude (orientation) data for full attitude "
+        "alignment, including azimuth (enabled by default).");
+
+    optSetEnuToMapXYZ = cmd.add_option(
+        "--set-t-enu-to-map-xyz", argSetEnuToMapXYZ,
+        "Instead of keeping the GNSS-derived translation of T_enu_to_map (which "
+        "may be several meters from the map origin), force it to the given "
+        "\"X,Y,Z\" (meters, map frame) and move the geodetic datum accordingly so "
+        "the map<->geodetic mapping is preserved. Use \"0,0,0\" to place the ENU "
+        "origin at the map origin. The estimated rotation is kept.");
+
+    cmd.add_option(
+        "-v,--verbosity", arg_verbosity_level,
+        "Verbosity level: ERROR|WARN|INFO|DEBUG (Default: INFO)");
+
+    CLI11_PARSE(cmd, argc, argv);
+
     try
     {
-        Cli cli;
-
-        // Parse arguments:
-        if (!cli.cmd.parse(argc, argv))
-        {
-            return 1;  // should exit.
-        }
-
-        run_sm_georef(cli);
+        run_sm_georef();
     }
     catch (const std::exception& e)
     {

--- a/mola_georeferencing/apps/mola-trajectory-georef-cli.cpp
+++ b/mola_georeferencing/apps/mola-trajectory-georef-cli.cpp
@@ -13,44 +13,39 @@
 */
 
 #include <mp2p_icp/metricmap.h>
-#include <mrpt/3rdparty/tclap/CmdLine.h>
 #include <mrpt/io/CFileGZInputStream.h>
 #include <mrpt/poses/CPose3DInterpolator.h>
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/system/filesystem.h>
 #include <mrpt/topography/conversions.h>
 
+#include <CLI/CLI.hpp>
 #include <fstream>
 
-// CLI flags:
-struct Cli
+// ---------------------------------------------------------------------------
+// CLI flags
+// ---------------------------------------------------------------------------
+namespace
 {
-    TCLAP::CmdLine cmd{"mola-trajectory-georef-cli"};
+CLI::App cmd{"mola-trajectory-georef-cli"};
 
-    TCLAP::ValueArg<std::string> argMM{
-        "m", "map", "Input .mm map with georef info", false, "map.mm", "map.mm", cmd};
+std::string argMM     = "map.mm";
+std::string argGeoRef = "map.georef";
+std::string argTraj;
+std::string argOutKML;
 
-    TCLAP::ValueArg<std::string> argGeoRef{
-        "g",          "geo-ref", "Input .georef file with georef info", false, "map.georef",
-        "map.georef", cmd};
+CLI::Option* optMM;
+CLI::Option* optGeoRef;
 
-    TCLAP::ValueArg<std::string> argTraj{
-        "t",  "trajectory", "Input .tum trajectory, in map local coordinates",
-        true, "traj.tum",   "traj.tum",
-        cmd};
+}  // namespace
 
-    TCLAP::ValueArg<std::string> argOutKML{
-        "o",        "output", "The name of the google earth kml file to write to", true, "path.kml",
-        "path.kml", cmd};
-};
-
-void run_traj_georef(Cli& cli)
+void run_traj_georef()
 {
     std::optional<mp2p_icp::metric_map_t::Georeferencing> geo;
 
-    if (cli.argMM.isSet())
+    if (optMM->count() > 0)
     {
-        const auto filMM = cli.argMM.getValue();
+        const auto& filMM = argMM;
 
         mp2p_icp::metric_map_t mm;
 
@@ -69,9 +64,9 @@ void run_traj_georef(Cli& cli)
         ASSERT_(mm.georeferencing.has_value());
         geo = mm.georeferencing;
     }
-    else if (cli.argGeoRef.isSet())
+    else if (optGeoRef->count() > 0)
     {
-        mrpt::io::CFileGZInputStream f(cli.argGeoRef.getValue());
+        mrpt::io::CFileGZInputStream f(argGeoRef);
 
         auto arch = mrpt::serialization::archiveFrom(f);
         arch >> geo;
@@ -87,7 +82,7 @@ void run_traj_georef(Cli& cli)
 
     // trajectory:
     mrpt::poses::CPose3DInterpolator traj;
-    bool                             trajLoadOk = traj.loadFromTextFile_TUM(cli.argTraj.getValue());
+    bool                             trajLoadOk = traj.loadFromTextFile_TUM(argTraj);
     ASSERT_(trajLoadOk);
 
     const auto WGS84 = mrpt::topography::TEllipsoid::Ellipsoid_WGS84();
@@ -108,7 +103,7 @@ void run_traj_georef(Cli& cli)
     }
 
     // Generate KML:
-    std::ofstream f(cli.argOutKML.getValue());
+    std::ofstream f(argOutKML);
     ASSERT_(f.is_open());
 
     f << mrpt::format(
@@ -120,7 +115,7 @@ void run_traj_georef(Cli& cli)
       <LineString>
         <tessellate>1</tessellate>
         <coordinates>)xml",
-        mrpt::system::extractFileName(cli.argTraj.getValue()).c_str());
+        mrpt::system::extractFileName(argTraj).c_str());
 
     for (const auto& d : geoPath)
     {
@@ -138,17 +133,18 @@ void run_traj_georef(Cli& cli)
 
 int main(int argc, char** argv)
 {
+    optMM     = cmd.add_option("-m,--map", argMM, "Input .mm map with georef info");
+    optGeoRef = cmd.add_option("-g,--geo-ref", argGeoRef, "Input .georef file with georef info");
+    cmd.add_option("-t,--trajectory", argTraj, "Input .tum trajectory, in map local coordinates")
+        ->required();
+    cmd.add_option("-o,--output", argOutKML, "The name of the google earth kml file to write to")
+        ->required();
+
+    CLI11_PARSE(cmd, argc, argv);
+
     try
     {
-        Cli cli;
-
-        // Parse arguments:
-        if (!cli.cmd.parse(argc, argv))
-        {
-            return 1;  // should exit.
-        }
-
-        run_traj_georef(cli);
+        run_traj_georef();
     }
     catch (const std::exception& e)
     {

--- a/mola_georeferencing/package.xml
+++ b/mola_georeferencing/package.xml
@@ -16,14 +16,13 @@
 
   <author email="joseluisblancoc@gmail.com">Jose-Luis Blanco-Claraco</author>
 
-  <!-- <depend>cli11</depend> -->
+  <depend>cli11</depend>
   <depend>gtsam</depend>
   <depend>mola_common</depend>
   <depend>mola_gtsam_factors</depend>
   <depend>mola_yaml</depend>
   <depend>mp2p_icp</depend>
-  <depend>mrpt_libmaps</depend>
-  <depend>mrpt_libtclap</depend>
+  <depend>mrpt_maps</depend>
 
   <doc_depend>doxygen</doc_depend>
 

--- a/mola_gtsam_factors/CMakeLists.txt
+++ b/mola_gtsam_factors/CMakeLists.txt
@@ -35,7 +35,7 @@ project(mola_gtsam_factors LANGUAGES CXX)
 # MOLA CMake scripts: "mola_xxx()"
 find_package(mola_common REQUIRED)
 find_package(GTSAM REQUIRED)
-find_package(mrpt-poses REQUIRED)
+find_package(mrpt_poses REQUIRED)
 
 # -----------------------
 # define lib:
@@ -68,10 +68,10 @@ mola_add_library(
     src/register.cpp
   PUBLIC_LINK_LIBRARIES
     gtsam
-    mrpt::poses
+    mrpt::mrpt_poses
   #PRIVATE_LINK_LIBRARIES
   CMAKE_DEPENDENCIES
-    mrpt-poses
+    mrpt_poses
 )
 
 # -----------------------

--- a/mola_gtsam_factors/package.xml
+++ b/mola_gtsam_factors/package.xml
@@ -19,7 +19,7 @@
   <!-- <depend>cli11</depend> -->
   <depend>mola_common</depend>
   <depend>gtsam</depend>
-  <depend>mrpt_libposes</depend>
+  <depend>mrpt_poses</depend>
 
   <doc_depend>doxygen</doc_depend>
 

--- a/mola_state_estimation_simple/CMakeLists.txt
+++ b/mola_state_estimation_simple/CMakeLists.txt
@@ -32,7 +32,8 @@ project(mola_state_estimation_simple LANGUAGES CXX)
 find_package(mola_common REQUIRED)
 
 # find CMake dependencies:
-find_package(mrpt-obs)
+find_package(mrpt_obs REQUIRED)
+find_package(Eigen3 REQUIRED NO_MODULE)
 
 # Find MOLA packages:
 find_package(mola_imu_preintegration REQUIRED)
@@ -48,12 +49,12 @@ mola_add_library(
   TARGET ${PROJECT_NAME}
   SOURCES ${LIB_SRCS} ${LIB_PUBLIC_HDRS}
   PUBLIC_LINK_LIBRARIES
-    mrpt::obs
+    mrpt::mrpt_obs
     mola::mola_imu_preintegration
     mola::mola_kernel
     mola::mola_yaml
-  #PRIVATE_LINK_LIBRARIES
-  #  mrpt::obs
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mola_common
     mola_kernel

--- a/mola_state_estimation_simple/include/mola_state_estimation_simple/Parameters.h
+++ b/mola_state_estimation_simple/include/mola_state_estimation_simple/Parameters.h
@@ -101,6 +101,12 @@ class Parameters
     /// regex for odometry inputs labels (ROS topics) to be accepted as inputs
     std::string do_process_odometry_labels_re = ".*";
 
+    /** Allow fusing CObservationRobotPose observations labeled "ground_truth",
+     *  which is how MOLA's dataset sources publish their reference trajectory.
+     *  Off by default: fusing it makes any accuracy number measured against
+     *  that same trajectory meaningless. */
+    bool fuse_ground_truth_label = false;
+
     /// regex for GNSS (GPS) labels (ROS topics) to be accepted as inputs
     std::string do_process_gnss_labels_re = ".*";
 

--- a/mola_state_estimation_simple/package.xml
+++ b/mola_state_estimation_simple/package.xml
@@ -18,7 +18,8 @@
   <depend>mola_kernel</depend>
   <depend>mola_imu_preintegration</depend>
   <depend>mola_yaml</depend>
-  <depend>mrpt_libobs</depend>
+  <depend>mrpt_obs</depend>
+  <build_depend>eigen</build_depend>
 
   <doc_depend>doxygen</doc_depend>
 

--- a/mola_state_estimation_simple/src/Parameters.cpp
+++ b/mola_state_estimation_simple/src/Parameters.cpp
@@ -47,6 +47,7 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
 
     MCP_LOAD_OPT(cfg, do_process_imu_labels_re);
     MCP_LOAD_OPT(cfg, do_process_odometry_labels_re);
+    MCP_LOAD_OPT(cfg, fuse_ground_truth_label);
     MCP_LOAD_OPT(cfg, do_process_gnss_labels_re);
 
     MCP_LOAD_OPT(cfg, gnss_enabled);

--- a/mola_state_estimation_simple/src/StateEstimationSimple.cpp
+++ b/mola_state_estimation_simple/src/StateEstimationSimple.cpp
@@ -1216,9 +1216,23 @@ void StateEstimationSimple::onNewObservation(const CObservation::ConstPtr& o)
     else if (auto obsPose = std::dynamic_pointer_cast<const mrpt::obs::CObservationRobotPose>(o);
              obsPose)
     {
-        if (std::regex_match(
-                o->sensorLabel, state_.do_process_odometry_labels_re.get_regex(
-                                    params.do_process_odometry_labels_re)))
+        if (o->sensorLabel == "ground_truth" && !params.fuse_ground_truth_label)
+        {
+            // MOLA's dataset sources publish their reference trajectory as a
+            // CObservationRobotPose labeled "ground_truth" (KITTI, KITTI-360,
+            // MulRan, Paris-Luco). The offline mola-lidar-odometry-cli never
+            // sees it -- datasetGetObservations() carries only real sensors --
+            // but the online mola-cli replay path does, and fusing it would
+            // silently invalidate any accuracy number measured against that
+            // same trajectory.
+            MRPT_LOG_ONCE_WARN(
+                "Ignoring observations labeled 'ground_truth': fusing a dataset's own reference "
+                "trajectory would invalidate any accuracy evaluation against it. Set "
+                "'fuse_ground_truth_label: true' if that is really what you want.");
+        }
+        else if (std::regex_match(
+                     o->sensorLabel, state_.do_process_odometry_labels_re.get_regex(
+                                         params.do_process_odometry_labels_re)))
         {
             // Route to the dedicated 3D-odometry path so it never touches
             // last_pose_obs_tim (which belongs to the LiDAR ICP source) and

--- a/mola_state_estimation_smoother/CMakeLists.txt
+++ b/mola_state_estimation_smoother/CMakeLists.txt
@@ -36,7 +36,7 @@ project(mola_state_estimation_smoother LANGUAGES CXX)
 find_package(mola_common REQUIRED)
 
 # find CMake dependencies:
-find_package(mrpt-obs)
+find_package(mrpt_obs REQUIRED)
 find_package(GTSAM REQUIRED)
 find_package(GTSAM_UNSTABLE REQUIRED)
 
@@ -62,7 +62,7 @@ mola_add_library(
     include/mola_state_estimation_smoother/StateEstimationSmoother.h
     include/mola_state_estimation_smoother/pose_pdf_to_string_with_sigmas.h
   PUBLIC_LINK_LIBRARIES
-    mrpt::obs
+    mrpt::mrpt_obs
     mola::mola_kernel
     mola::mola_imu_preintegration
     mola::mola_gtsam_factors

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/Parameters.h
@@ -232,6 +232,37 @@ class Parameters
      */
     bool odometry_relative_factors = false;
 
+    /** Regex of odometry frame_ids (see fuse_pose()) whose poses are fused as
+     *  RELATIVE increments between consecutive keyframes, plus one absolute
+     *  factor added once to resolve T_map_to_odom_i, instead of as an absolute
+     *  pose per reading. This is the odometry_relative_factors formulation
+     *  above, generalized from wheel odometry to any fuse_pose() source.
+     *
+     *  It is what a DRIFTING source needs. An absolute-pose factor asserts that
+     *  the source's whole trajectory relates to {map} by one rigid transform,
+     *  which only holds while the drift accumulated across the sliding window
+     *  stays below the covariance given; a relative factor asserts only the
+     *  increment, which is drift-free by construction. Visual odometry is the
+     *  motivating case: its per-increment accuracy can be excellent while its
+     *  absolute pose in its own frame walks away steadily.
+     *
+     *  In relative mode the covariance passed to fuse_pose() is read as the
+     *  uncertainty of ONE INCREMENT, not of the absolute pose.
+     *
+     *  It is a trade, not a free win, and which way it goes depends on how much
+     *  the source drifts across the sliding window. Measured on the synthetic
+     *  case in test-relative-pose-factors: with a source whose frame slides
+     *  0.05 m/s (0.25 m across a 5 s window, fifty times its declared
+     *  per-increment sigma) the absolute formulation degrades by 2.3x while the
+     *  relative one does not move at all -- but with no drift at all the
+     *  absolute formulation is the better of the two, because N absolute poses
+     *  carry more information than N increments. Use this for a source that
+     *  really does drift; leave it off otherwise.
+     *
+     *  Empty (the default) keeps every source on the absolute formulation.
+     */
+    std::string relative_factors_frame_ids_re;
+
     /** High-rate same-sensor decimation for IMU. If > 0, IMU readings arriving
      * less than this many seconds after the last *processed* one are skipped.
      * Unlike wheel odometry, IMU attitude/gravity are absolute observations, so
@@ -450,6 +481,12 @@ class Parameters
 
     /// regex for GNSS (GPS) labels (ROS topics) to be accepted as inputs
     std::string do_process_gnss_labels_re = ".*";
+
+    /** Allow fusing CObservationRobotPose observations labeled "ground_truth",
+     *  which is how MOLA's offline dataset sources publish their reference
+     *  trajectory. Off by default: fusing it makes any accuracy number measured
+     *  against that same trajectory meaningless. */
+    bool fuse_ground_truth_label = false;
 
     /** @} */
 

--- a/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
+++ b/mola_state_estimation_smoother/include/mola_state_estimation_smoother/StateEstimationSmoother.h
@@ -314,6 +314,18 @@ class StateEstimationSmoother : public mola::NavStateFilter,
         };
         std::map<odometry_frameid_t, RawSourcePose> last_raw_pose_by_source;
 
+        /// Per-source bookkeeping for the relative-factor formulation of
+        /// fuse_pose() (see Parameters::relative_factors_frame_ids_re): the
+        /// keyframe carrying that source's one absolute anchor factor, and the
+        /// tail of its chain of increment factors.
+        struct RelativePoseChain
+        {
+            std::optional<frame_index_t>                   anchor_kf;
+            std::optional<frame_index_t>                   last_kf;
+            std::optional<mrpt::poses::CPose3DPDFGaussian> last_pose_in_odom;
+        };
+        std::map<odometry_frameid_t, RelativePoseChain> relative_pose_chains;
+
         /** For real-time mode operation (not offline): returns the current extrapolated stamp,
          *  by adding the difference between the last observation wallclock time and now to the
          *  last observation timestamp.
@@ -388,6 +400,7 @@ class StateEstimationSmoother : public mola::NavStateFilter,
         RegexCache do_process_imu_labels_re;
         RegexCache do_process_odometry_labels_re;
         RegexCache do_process_gnss_labels_re;
+        RegexCache relative_factors_frame_ids_re;
     };
 
     State      state_;

--- a/mola_state_estimation_smoother/package.xml
+++ b/mola_state_estimation_smoother/package.xml
@@ -27,7 +27,7 @@
   <depend>mola_imu_preintegration</depend>
   <depend>mola_gtsam_factors</depend>
 
-  <depend>mrpt_libobs</depend>
+  <depend>mrpt_obs</depend>
 
   <!-- GTSAM and its Boost deps -->
   <depend>gtsam</depend>

--- a/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
+++ b/mola_state_estimation_smoother/params/state-estimation-smoother.yaml
@@ -324,6 +324,21 @@ params:
   # Default accepts all: ".*"
   do_process_odometry_labels_re: ".*"
 
+  # Odometry frame_ids (fuse_pose) fused as RELATIVE increments between
+  # consecutive keyframes plus one absolute anchor, instead of as an absolute
+  # pose per reading. This is what a DRIFTING source needs: an absolute-pose
+  # factor claims the source relates to {map} by one rigid transform, which
+  # only holds while the drift accumulated across the sliding window stays
+  # under the covariance given. Visual odometry is the motivating case.
+  # In this mode the covariance a source passes is read as the uncertainty of
+  # ONE INCREMENT. Empty = every source stays on the absolute formulation.
+  relative_factors_frame_ids_re: "${MOLA_RELATIVE_FACTORS_FRAMES|}"
+
+  # Fusing a dataset's own reference trajectory (a CObservationRobotPose
+  # labeled "ground_truth") would invalidate any accuracy number measured
+  # against it. Opt-in only.
+  fuse_ground_truth_label: ${MOLA_FUSE_GROUND_TRUTH|false}
+
   # Regular expression to filter GNSS (GPS) labels/topics for processing
   # Default accepts all: ".*"
   do_process_gnss_labels_re: ".*"

--- a/mola_state_estimation_smoother/src/Parameters.cpp
+++ b/mola_state_estimation_smoother/src/Parameters.cpp
@@ -135,6 +135,8 @@ void Parameters::loadFrom(const mrpt::containers::yaml& cfg)
     // -----------------------------------------------------
     MCP_LOAD_OPT(cfg, do_process_imu_labels_re);
     MCP_LOAD_OPT(cfg, do_process_odometry_labels_re);
+    MCP_LOAD_OPT(cfg, fuse_ground_truth_label);
+    MCP_LOAD_OPT(cfg, relative_factors_frame_ids_re);
     MCP_LOAD_OPT(cfg, do_process_gnss_labels_re);
 
     if (cfg.has("initial_twist"))

--- a/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
+++ b/mola_state_estimation_smoother/src/StateEstimationSmoother.cpp
@@ -1216,6 +1216,71 @@ void StateEstimationSmoother::fuse_pose_locked(
         state_.gtsam->newFactors.emplace_shared<gtsam::PriorFactor<gtsam::Pose3>>(
             T(this_kf_id), pose_out, gtsam::noiseModel::Gaussian::Covariance(cov_out));
     }
+    else if (
+        !params_.relative_factors_frame_ids_re.empty() &&
+        std::regex_match(
+            frame_id,
+            state_.relative_factors_frame_ids_re.get_regex(params_.relative_factors_frame_ids_re)))
+    {
+        // Relative formulation, for a source that DRIFTS: assert only the
+        // increment between consecutive readings, plus one absolute factor
+        // added once to resolve T_map_to_odom_i. Mirrors
+        // fuse_odometry_relative_locked(), generalized to any fuse_pose()
+        // source. See Parameters::relative_factors_frame_ids_re.
+        auto& chain = state_.relative_pose_chains[frame_id_idx];
+
+        if (!chain.anchor_kf.has_value())
+        {
+            state_.gtsam->newFactors.emplace_shared<gtsam::BetweenFactor<gtsam::Pose3>>(
+                symbol_T_map_to_odom_i_base + frame_id_idx, T(this_kf_id), pose_out,
+                gtsam::noiseModel::Gaussian::Covariance(cov_out));
+            chain.anchor_kf = this_kf_id;
+
+            MRPT_LOG_DEBUG_FMT(
+                "[fuse_pose] frame '%s' anchored at KF %u (relative formulation)", frame_id.c_str(),
+                static_cast<unsigned>(this_kf_id));
+        }
+
+        // A relative transform is the same quantity in {map} and in {odom_i}:
+        // the two chains differ by one constant rigid T_map_to_odom_i, which
+        // cancels in T_prev^-1 * T_now.
+        if (chain.last_kf.has_value() && chain.last_pose_in_odom.has_value() &&
+            *chain.last_kf != this_kf_id)
+        {
+            // A NEW factor naming a marginalized variable would resurrect it as
+            // a free, unconstrained state: skip it and continue the chain here.
+            if (state_.last_estimated_states.count(*chain.last_kf) == 0)
+            {
+                MRPT_LOG_THROTTLE_DEBUG_FMT(
+                    5.0,
+                    "[fuse_pose] relative factor skipped: KF %u is no longer in the window; "
+                    "the '%s' chain continues from KF %u",
+                    static_cast<unsigned>(*chain.last_kf), frame_id.c_str(),
+                    static_cast<unsigned>(this_kf_id));
+            }
+            else
+            {
+                mrpt::poses::CPose3DPDFGaussian increment;
+                increment.mean = poseSanitized.mean - chain.last_pose_in_odom->mean;
+                // In this mode the caller's covariance describes ONE increment.
+                increment.cov = poseSanitized.cov;
+
+                gtsam::Pose3   incr_out;
+                gtsam::Matrix6 incrCov_out;
+                mrpt::gtsam_wrappers::to_gtsam_se3_cov6(increment, incr_out, incrCov_out);
+
+                state_.gtsam->newFactors.emplace_shared<gtsam::BetweenFactor<gtsam::Pose3>>(
+                    T(*chain.last_kf), T(this_kf_id), incr_out,
+                    gtsam::noiseModel::Gaussian::Covariance(incrCov_out));
+            }
+        }
+
+        chain.last_kf           = this_kf_id;
+        chain.last_pose_in_odom = poseSanitized;
+
+        state_.last_raw_pose_by_source[frame_id_idx] =
+            State::RawSourcePose{timestamp, poseSanitized};
+    }
     else
     {
         // ref is an odometry frame:
@@ -1570,6 +1635,34 @@ void StateEstimationSmoother::onNewObservation(const CObservation::ConstPtr& o)
     else if (auto obsPose = std::dynamic_pointer_cast<const mrpt::obs::CObservationRobotPose>(o);
              obsPose)
     {
+        // Same label filter the CObservationOdometry branch above uses (and
+        // that StateEstimationSimple already applies to this branch): without
+        // it, EVERY robot-pose observation reaching this module is fused,
+        // whatever it is.
+        if (!std::regex_match(
+                o->sensorLabel, state_.do_process_odometry_labels_re.get_regex(
+                                    params_.do_process_odometry_labels_re)))
+        {
+            MRPT_LOG_DEBUG_FMT(
+                "Skipping robot pose reading labeled '%s' for not passing regex",
+                o->sensorLabel.c_str());
+            return;
+        }
+
+        // MOLA's offline dataset sources publish the reference trajectory as a
+        // CObservationRobotPose labeled "ground_truth" (KITTI, KITTI-360,
+        // MulRan, Paris-Luco). Fusing it would silently make every accuracy
+        // number measured against that same trajectory meaningless, so it takes
+        // an explicit opt-in.
+        if (o->sensorLabel == "ground_truth" && !params_.fuse_ground_truth_label)
+        {
+            MRPT_LOG_ONCE_WARN(
+                "Ignoring observations labeled 'ground_truth': fusing a dataset's own reference "
+                "trajectory would invalidate any accuracy evaluation against it. Set "
+                "'fuse_ground_truth_label: true' if that is really what you want.");
+            return;
+        }
+
         auto sensedSensorPose = obsPose->pose;
         if (obsPose->sensorPose != mrpt::poses::CPose3D())
         {

--- a/mola_state_estimation_smoother/tests/CMakeLists.txt
+++ b/mola_state_estimation_smoother/tests/CMakeLists.txt
@@ -35,6 +35,13 @@ mola_add_test(
 )
 
 mola_add_test(
+  TARGET  test-relative-pose-factors
+  SOURCES test-relative-pose-factors.cpp
+  LINK_LIBRARIES
+    mola::mola_state_estimation_smoother
+)
+
+mola_add_test(
   TARGET  test-two-odometries
   SOURCES test-two-odometries.cpp
   LINK_LIBRARIES

--- a/mola_state_estimation_smoother/tests/test-relative-pose-factors.cpp
+++ b/mola_state_estimation_smoother/tests/test-relative-pose-factors.cpp
@@ -1,0 +1,264 @@
+/* _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: GPL-3.0
+ See LICENSE for full license information.
+ Closed-source licenses available upon request, for this odometry package
+ alone or in combination with the complete SLAM system.
+*/
+
+/**
+ * @file   test-relative-pose-factors.cpp
+ * @brief  Fusing a DRIFTING pose source as increments instead of as absolute
+ *         poses (Parameters::relative_factors_frame_ids_re).
+ *
+ * A source that integrates its own increments -- visual odometry being the
+ * motivating case -- has an accurate increment and an absolute pose, in its own
+ * frame, that walks away from any rigid relation to {map}. Fusing it with an
+ * absolute-pose factor whose covariance is the (small) per-increment one
+ * asserts something false and drags the fused estimate with it. The relative
+ * formulation asserts only the increment, which is what the source actually
+ * knows.
+ *
+ * This test drives the very same measurements through both formulations and
+ * checks that the relative one is the better of the two.
+ */
+
+#include <mola_state_estimation_smoother/StateEstimationSmoother.h>
+#include <mrpt/core/get_env.h>
+#include <mrpt/poses/CPose3D.h>
+#include <mrpt/random/RandomGenerators.h>
+
+#include <iostream>
+
+using namespace std::string_literals;
+using namespace mrpt::literals;
+
+namespace
+{
+const bool VERBOSE = mrpt::get_env<bool>("VERBOSE", false);
+
+constexpr size_t NUM_STEPS = 400;
+constexpr double T         = 0.1;  // [s]
+
+// The reference source: accurate, and fused as an absolute pose in {map}.
+constexpr double REF_NOISE_XYZ = 0.02;  // [m] per step
+constexpr double REF_NOISE_ANG = 0.002;  // [rad] per step
+
+// The drifting source: excellent per increment, but its own frame slowly
+// rotates with respect to {map} -- which is what accumulated heading drift
+// looks like from the outside, and what visual odometry actually does. A
+// zero-mean random walk would NOT make the point: the estimator can average
+// that away across the window. Systematic drift is what an absolute-pose
+// factor cannot represent, because it asserts ONE rigid frame transform.
+constexpr double DRIFT_NOISE_XYZ = 0.005;  // [m] per step
+constexpr double DRIFT_NOISE_ANG = 0.0005;  // [rad] per step
+
+std::string navStateParams(const std::string& relativeFramesRe)
+{
+    return R"###(# Config for Parameters
+params:
+    vehicle_frame_name: "base_link"
+    reference_frame_name: "map"
+    link_first_pose_to_reference_origin_sigma: 1e-6
+
+    kinematic_model: KinematicModel::ConstantVelocity
+    sliding_window_length: 5.0
+    max_time_to_use_velocity_model: 2.0
+
+    sigma_random_walk_acceleration_linear: 2.0
+    sigma_random_walk_acceleration_angular: 1.0
+    sigma_integrator_position: 0.10
+    sigma_integrator_orientation: 0.10
+
+    estimate_geo_reference: false
+    relative_factors_frame_ids_re: ")###" +
+           relativeFramesRe + R"###("
+)###";
+}
+
+/** Runs the identical measurement stream through the estimator, with the
+ *  drifting source fused either relatively or absolutely, and returns the RMS
+ *  position error of the fused estimate against ground truth. */
+double run(bool drifterIsRelative, double driftFrameRate)
+{
+    mola::state_estimation_smoother::StateEstimationSmoother stateEst;
+    if (VERBOSE)
+    {
+        stateEst.setMinLoggingLevel(mrpt::system::LVL_DEBUG);
+    }
+    stateEst.initialize(mrpt::containers::yaml::FromText(
+        navStateParams(drifterIsRelative ? "drifting_odom"s : ""s)));
+
+    // Same seed for both runs: the two formulations must see the same data.
+    auto& rng = mrpt::random::getRandomGenerator();
+    rng.randomize(1234);
+
+    mrpt::poses::CPose3D gtPose  = mrpt::poses::CPose3D::Identity();
+    mrpt::poses::CPose3D refOdom = mrpt::poses::CPose3D::Identity();
+    // Start the drifting source somewhere else entirely: its frame transform is
+    // for the estimator to work out, in both formulations.
+    mrpt::poses::CPose3D driftOdom =
+        mrpt::poses::CPose3D::FromXYZYawPitchRoll(7.0, -3.0, 0.5, 30.0_deg, 0.0_deg, 0.0_deg);
+
+    const auto gtDelta = mrpt::poses::CPose3D(1.0 * T, 0, 0, 0.2 * T, 0, 0);
+
+    double               sumSqErr = 0;
+    double               sumSqSrc = 0;
+    size_t               nEval    = 0;
+    mrpt::poses::CPose3D lastEst;
+    mrpt::poses::CPose3D lastGt;
+    mrpt::poses::CPose3D lastDrift;
+    bool                 havePrev = false;
+
+    for (size_t i = 0; i < NUM_STEPS; i++)
+    {
+        const auto stamp = mrpt::Clock::fromDouble(T * static_cast<double>(i));
+        if (i > 0)
+        {
+            gtPose = gtPose + gtDelta;
+        }
+
+        // Reference source: noisy increments, fused as an absolute pose.
+        auto refDelta = gtDelta;
+        refDelta.x_incr(rng.drawGaussian1D(0, REF_NOISE_XYZ));
+        refDelta.y_incr(rng.drawGaussian1D(0, REF_NOISE_XYZ));
+        refDelta.setYawPitchRoll(
+            refDelta.yaw() + rng.drawGaussian1D(0, REF_NOISE_ANG), refDelta.pitch(),
+            refDelta.roll());
+        refOdom = refOdom + refDelta;
+
+        mrpt::poses::CPose3DPDFGaussian refPdf;
+        refPdf.mean = refOdom;
+        refPdf.cov.setZero();
+        for (int k = 0; k < 3; k++)
+        {
+            refPdf.cov(k, k)         = mrpt::square(REF_NOISE_XYZ);
+            refPdf.cov(k + 3, k + 3) = mrpt::square(REF_NOISE_ANG);
+        }
+
+        // Drifting source: finer increments than the reference...
+        auto driftDelta = gtDelta;
+        driftDelta.x_incr(rng.drawGaussian1D(0, DRIFT_NOISE_XYZ));
+        driftDelta.y_incr(rng.drawGaussian1D(0, DRIFT_NOISE_XYZ));
+        driftDelta.setYawPitchRoll(
+            driftDelta.yaw() + rng.drawGaussian1D(0, DRIFT_NOISE_ANG), driftDelta.pitch(),
+            driftDelta.roll());
+        driftOdom = driftOdom + driftDelta;
+
+        // ...reported in a frame that keeps sliding. Per increment this is a
+        // 5 mm perturbation, inside the sigma quoted below; across the
+        // estimator's 5 s window it is 0.25 m, fifty times that sigma, and no
+        // single rigid transform can absorb it. That gap -- small per
+        // increment, unbounded once integrated -- IS drift, and it is what an
+        // absolute-pose factor cannot represent.
+        const mrpt::poses::CPose3D driftFrame = mrpt::poses::CPose3D::FromXYZYawPitchRoll(
+            driftFrameRate * T * static_cast<double>(i), 0, 0, 0, 0, 0);
+
+        mrpt::poses::CPose3DPDFGaussian driftPdf;
+        driftPdf.mean = driftFrame + driftOdom;
+        driftPdf.cov.setZero();
+        for (int k = 0; k < 3; k++)
+        {
+            driftPdf.cov(k, k)         = mrpt::square(DRIFT_NOISE_XYZ);
+            driftPdf.cov(k + 3, k + 3) = mrpt::square(DRIFT_NOISE_ANG);
+        }
+
+        stateEst.fuse_pose(stamp, refPdf, "reference_odom");
+        stateEst.fuse_pose(stamp, driftPdf, "drifting_odom");
+
+        // Skip the transient while the frame transforms are still being solved.
+        if (i < NUM_STEPS / 4)
+        {
+            continue;
+        }
+        // Both sources' frames float freely with respect to {map}; what is
+        // observable, and what a front end consumes, is the MOTION. Score the
+        // estimate on its increment over the last 10 steps against GT's.
+        if ((i % 10) == 0)
+        {
+            const auto st = stateEst.estimated_navstate(stamp, "map");
+            if (!st.has_value())
+            {
+                continue;
+            }
+            if (havePrev)
+            {
+                const auto   dEst = st->pose.mean - lastEst;
+                const auto   dGt  = gtPose - lastGt;
+                const auto   dSrc = driftOdom - lastDrift;
+                const double e    = (dEst.translation() - dGt.translation()).norm();
+                sumSqSrc += (dSrc.translation() - dGt.translation()).sqrNorm();
+                sumSqErr += e * e;
+                ++nEval;
+                if (VERBOSE)
+                {
+                    std::cout << "i=" << i << " err=" << e << " dEst=" << dEst.asString()
+                              << " dGt=" << dGt.asString() << "\n";
+                }
+            }
+            lastEst   = st->pose.mean;
+            lastGt    = gtPose;
+            lastDrift = driftOdom;
+            havePrev  = true;
+        }
+    }
+    ASSERT_(nEval > 10);
+    std::cout << "   (drifting source's OWN motion error = "
+              << std::sqrt(sumSqSrc / static_cast<double>(nEval)) << " m)\n";
+    return std::sqrt(sumSqErr / static_cast<double>(nEval));
+}
+}  // namespace
+
+int main()
+{
+    try
+    {
+        // The same source, with and without a slowly sliding frame of its own.
+        // 0.05 m/s perturbs one increment by 5 mm -- inside the sigma the source
+        // declares -- while displacing its absolute pose by 0.25 m across the
+        // estimator's 5 s window, fifty times that sigma.
+        const double absNoDrift = run(/*relative=*/false, 0.0);
+        const double absDrift   = run(/*relative=*/false, 0.05);
+        const double relNoDrift = run(/*relative=*/true, 0.0);
+        const double relDrift   = run(/*relative=*/true, 0.05);
+
+        std::cout << "[relative-pose-factors] ABSOLUTE: no drift = " << absNoDrift
+                  << " m, with drift = " << absDrift << " m\n";
+        std::cout << "[relative-pose-factors] RELATIVE: no drift = " << relNoDrift
+                  << " m, with drift = " << relDrift << " m\n";
+
+        // What the formulation buys is INVARIANCE to the source's absolute
+        // drift, not a lower floor: it asserts only the increment, which the
+        // drift barely touches. The absolute formulation asserts one rigid
+        // frame transform, which the drift makes false, so it degrades.
+        ASSERTMSG_(
+            absDrift > 1.5 * absNoDrift,
+            mrpt::format(
+                "The absolute formulation should degrade under the source's drift "
+                "(%.4f -> %.4f m)",
+                absNoDrift, absDrift));
+
+        ASSERTMSG_(
+            std::abs(relDrift - relNoDrift) < 0.2 * relNoDrift,
+            mrpt::format(
+                "The relative formulation should be insensitive to the source's absolute "
+                "drift (%.4f -> %.4f m)",
+                relNoDrift, relDrift));
+
+        // ...and it must still track, not merely be indifferent.
+        ASSERT_LT_(relDrift, 0.15);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Test failed: " << e.what() << "\n";
+        return 1;
+    }
+    std::cout << "Test passed.\n";
+    return 0;
+}


### PR DESCRIPTION
Part of a massive mola port move.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for fusing drifting odometry sources, including visual odometry, as relative pose increments with an absolute anchor.
  - Added configuration options to select relative-fusion sources and explicitly enable fusion of observations labeled `ground_truth`.
  - Improved command-line validation and option handling across georeferencing tools.

- **Bug Fixes**
  - Prevented unintended fusion of dataset reference trajectories labeled `ground_truth`.
  - Ignored out-of-order pose updates during relative fusion.

- **Documentation**
  - Expanded guidance on pose frames, drifting odometry, relative fusion, and ground-truth safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->